### PR TITLE
feat: streaming commp, PDP piece upload & download

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ const synapse = await Synapse.create({
   privateKey: "0x...", // For signing transactions
 })
 
-// Check balances (all return bigint in smallest unit)
+// Check balances (all return bigint in base units)
 const filBalance = await synapse.walletBalance() // FIL balance
 const usdcBalance = await synapse.walletBalance(Synapse.USDFC) // USDFC token balance
 const paymentsBalance = await synapse.balance() // USDFC in payments contract
@@ -101,7 +101,7 @@ const txHash = await uploadTask.done()
 // Download content
 const content = await storage.download(commp)
 
-// Payments (amounts in smallest unit as bigint)
+// Payments (amounts in base units as bigint)
 await synapse.deposit(100n * 10n**18n) // 100 USDFC
 await synapse.withdraw(50n * 10n**18n)  // 50 USDFC
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ A JavaScript/TypeScript SDK for interacting with Filecoin Synapse - a smart-cont
 
 ## Overview
 
-The Synapse SDK provides a simple interface for storing and retrieving binary data on Filecoin using PDP (Proof of Data Possession) for verifiability. It supports optional CDN services for improved retrieval performance and works with both private keys and browser wallets like MetaMask. In the future it will support additional services offered through the Filecoin Synapse marketplace.
+The Synapse SDK is designed with flexibility in mind:
+
+- **🚀 Simple Golden Path**: Use the high-level `Synapse` class for a streamlined experience with sensible defaults
+- **🔧 Composable Components**: Import and use individual components for fine-grained control over specific functionality
+
+Whether you're building a quick prototype or a complex application with specific requirements, the SDK adapts to your needs.
 
 ## Installation
 
@@ -14,31 +19,58 @@ npm install @filoz/synapse-sdk ethers
 
 Note: `ethers` v6 is a peer dependency and must be installed separately.
 
-## Quick Start
+## Table of Contents
 
-### With Private Key
+* [Overview](#overview)
+* [Installation](#installation)
+* [Using the Golden Path API](#using-the-golden-path-api)
+  * [Quick Start](#quick-start)
+  * [With MetaMask](#with-metamask)
+  * [API Reference](#api-reference)
+* [Using Individual Components](#using-individual-components)
+  * [CommP Utilities](#commp-utilities)
+  * [PDP Upload Service](#pdp-upload-service)
+  * [PDP Download Service](#pdp-download-service)
+  * [Storage Service (Mock)](#storage-service-mock)
+* [Network Configuration](#network-configuration)
+  * [RPC Endpoints](#rpc-endpoints)
+  * [GLIF Authorization](#glif-authorization)
+  * [Network Details](#network-details)
+* [Browser Integration](#browser-integration)
+  * [MetaMask Setup](#metamask-setup)
+* [Additional Information](#additional-information)
+  * [Type Definitions](#type-definitions)
+  * [Error Handling](#error-handling)
+* [Contributing](#contributing)
+  * [Testing](#testing)
+* [License](#license)
+
+---
+
+## Using the Golden Path API
+
+The `Synapse` class provides a complete, easy-to-use interface for interacting with Filecoin storage services.
+
+### Quick Start
 
 ```javascript
 import { Synapse, RPC_URLS } from '@filoz/synapse-sdk'
 
-// Using recommended RPC endpoints
+// Initialize with private key
 const synapse = await Synapse.create({
-  privateKey: '0x...',  // Your private key
-  rpcURL: RPC_URLS.mainnet.websocket  // or .http for HTTP
+  privateKey: '0x...',
+  rpcURL: RPC_URLS.mainnet.websocket
 })
 
 // Check balances
-const filBalance = await synapse.walletBalance()                    // FIL in your wallet
-const usdcBalance = await synapse.walletBalance(Synapse.USDFC)      // USDFC in your wallet
-const paymentsBalance = await synapse.balance(Synapse.USDFC)        // USDFC in Synapse payments contract (for spending on services)
+const filBalance = await synapse.walletBalance()                    // FIL in wallet
+const usdcBalance = await synapse.walletBalance(Synapse.USDFC)      // USDFC in wallet
+const paymentsBalance = await synapse.balance(Synapse.USDFC)        // USDFC in payments contract
 
-// Deposit if needed (amounts in smallest token size - bigint)
-if (paymentsBalance < 10n * 10n**18n) {
-  const txHash = await synapse.deposit(10n * 10n**18n, Synapse.USDFC)
-  console.log(`Deposited USDFC: ${txHash}`)
-}
+// Deposit funds for storage operations
+await synapse.deposit(10n * 10n**18n, Synapse.USDFC)
 
-// Upload data
+// Create storage service and upload data
 const storage = await synapse.createStorage()
 const uploadTask = storage.upload(new TextEncoder().encode('Hello World'))
 const commp = await uploadTask.commp()
@@ -49,21 +81,6 @@ const data = await storage.download(commp)
 console.log(new TextDecoder().decode(data)) // "Hello World"
 ```
 
-### Using CommP Utilities Standalone
-
-```javascript
-import { calculate, asCommP } from '@filoz/synapse-sdk/commp'
-
-// Calculate CommP without Synapse instance
-const data = new Uint8Array([1, 2, 3, 4])
-const commp = calculate(data)
-console.log(`CommP: ${commp.toString()}`)
-
-// Validate CommP strings
-const valid = asCommP('baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq')
-console.log(`Valid: ${valid !== null}`)
-```
-
 ### With MetaMask
 
 ```javascript
@@ -72,248 +89,166 @@ import { ethers } from 'ethers'
 
 // Connect to MetaMask
 const provider = new ethers.BrowserProvider(window.ethereum)
-
-const synapse = await Synapse.create({
-  provider: provider    // Use MetaMask provider
-})
+const synapse = await Synapse.create({ provider })
 
 // Same API as above
 const balance = await synapse.walletBalance()
 ```
 
-## API Reference
+### API Reference
 
-### Constructor Options
+#### Constructor Options
 
 ```typescript
 interface SynapseOptions {
   // Wallet Configuration (exactly one required)
-  privateKey?: string           // Private key for signing transactions
-  provider?: ethers.Provider    // Browser provider (MetaMask, WalletConnect, etc.)
-  signer?: ethers.Signer        // External signer (legacy interface)
-  
-  // Network Configuration (required when using privateKey)
-  rpcURL?: string              // RPC endpoint URL (supports http://, https://, ws://, wss://)
-  authorization?: string        // Authorization header value (e.g., 'Bearer TOKEN')
-  
+  privateKey?: string           // Private key for signing
+  provider?: ethers.Provider    // Browser provider (MetaMask, etc.)
+  signer?: ethers.Signer        // External signer
+
+  // Network Configuration
+  rpcURL?: string              // RPC endpoint URL
+  authorization?: string        // Authorization header (e.g., 'Bearer TOKEN')
+
   // Advanced Configuration
-  disableNonceManager?: boolean // Disable automatic nonce management (default: false)
+  disableNonceManager?: boolean // Disable automatic nonce management
 }
 ```
 
-### Synapse Class
+#### Synapse Methods
 
-#### Real Blockchain Methods (Not Mocked)
+- `walletBalance(token?)` - Get wallet balance (FIL or USDFC)
+- `balance(token?)` - Get balance in payments contract
+- `decimals(token?)` - Get token decimals (always 18)
+- `deposit(amount, token?)` - Deposit funds to payments contract
+- `withdraw(amount, token?)` - Withdraw funds from payments contract
+- `createStorage(options?)` - Create a storage service instance
+- `signOperation(operation, data)` - Sign data for on-chain authentication
 
-##### `walletBalance(): Promise<bigint>`
-Returns the native FIL balance of the connected wallet in attoFIL (1 FIL = 10^18 attoFIL).
+---
 
-```javascript
-const filBalance = await synapse.walletBalance()
-console.log(`Balance: ${filBalance.toString()} attoFIL`)
-```
+## Using Individual Components
 
-##### `walletBalance(token: string): Promise<bigint>`
-Returns the balance of a specific ERC20 token in smallest units.
-
-```javascript
-// Check USDFC balance
-const usdcBalance = await synapse.walletBalance(Synapse.USDFC)
-const divisor = 10n ** BigInt(synapse.decimals(Synapse.USDFC))
-console.log(`USDFC Balance: ${(usdcBalance / divisor).toString()} USDFC`)
-
-// Also accepts string literal
-const balance = await synapse.walletBalance('USDFC')
-```
-
-##### `balance(token?: string): Promise<bigint>`
-Returns your balance in the Synapse payments contract - this is the USDFC you've deposited for spending on storage and other services. Different from `walletBalance()` which shows tokens in your wallet.
-
-```javascript
-// Check payments contract balance (defaults to USDFC)
-const balance = await synapse.balance()
-// Explicit token specification
-const balance = await synapse.balance(Synapse.USDFC)
-```
-
-##### `deposit(amount: number | bigint, token?: string): Promise<string>`
-Deposits USDFC from your wallet to the Synapse payments contract. This moves tokens from `walletBalance()` to `balance()` for spending on services. Returns transaction hash.
-
-```javascript
-// Deposit 100 USDFC (amounts in smallest units)
-const txHash = await synapse.deposit(100n * 10n**18n)
-// Explicit token specification
-const txHash = await synapse.deposit(100n * 10n**18n, Synapse.USDFC)
-```
-
-##### `withdraw(amount: number | bigint, token?: string): Promise<string>`
-Withdraws USDFC from the Synapse payments contract back to your wallet. This moves tokens from `balance()` to `walletBalance()`. Returns transaction hash.
-
-```javascript
-// Withdraw 50 USDFC (amounts in smallest units)
-const txHash = await synapse.withdraw(50n * 10n**18n)
-// Explicit token specification  
-const txHash = await synapse.withdraw(50n * 10n**18n, Synapse.USDFC)
-```
-
-##### `decimals(token?: string): number`
-Returns the number of decimals for a token (always 18 for FIL and USDFC).
-
-```javascript
-const decimals = synapse.decimals() // 18
-const filDecimals = synapse.decimals('FIL') // 18
-const usdcDecimals = synapse.decimals(Synapse.USDFC) // 18
-```
-
-**Supported Tokens:**
-- `Synapse.USDFC` or `'USDFC'` - USDFC stablecoin
-  - Mainnet: `0x80B98d3aa09ffff255c3ba4A241111Ff1262F045`
-  - Calibration: `0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0`
-
-**Note:** Payment methods (`balance`, `deposit`, `withdraw`) require the payments contract addresses to be configured in `constants.ts`. These are currently empty pending contract deployment.
-
-**NonceManager:** By default, the SDK uses ethers.js NonceManager to prevent nonce conflicts when sending multiple transactions. This can be disabled with `disableNonceManager: true` if you prefer manual nonce management.
-
-#### Mock Methods (For Development)
-
-##### `createStorage(options?: StorageOptions): Promise<StorageService>`
-Creates a storage service instance (mock implementation).
-
-### StorageService Class (Mock)
-
-All StorageService methods are currently mock implementations for development purposes.
-
-```typescript
-interface StorageService {
-  readonly proofSetId: string        // Unique proof set identifier
-  readonly storageProvider: string   // Storage provider address
-  
-  // Upload binary data and track progress
-  upload(data: Uint8Array | ArrayBuffer): UploadTask
-  
-  // Download data by CommP (supports both CID and string)
-  download(commp: CommP | string, options?: DownloadOptions): Promise<Uint8Array>
-  
-  // Delete data from storage
-  delete(commp: CommP | string): Promise<void>
-  
-  // Settle payments with storage provider
-  settlePayments(): Promise<SettlementResult>
-}
-```
-
-#### Example Usage
-
-```javascript
-const storage = await synapse.createStorage()
-
-// Upload data
-const data = new TextEncoder().encode('Hello, Synapse!')
-const uploadTask = storage.upload(data)
-
-const commp = await uploadTask.commp()
-const provider = await uploadTask.store()
-const txHash = await uploadTask.done()
-
-// Download data
-const downloadedData = await storage.download(commp)
-const text = new TextDecoder().decode(downloadedData)
-
-// Download with options
-const directData = await storage.download(commp, {
-  withCDN: false,    // Force direct SP retrieval
-  noVerify: true     // Skip CommP verification
-})
-
-// Cleanup
-await storage.delete(commp)
-```
-
-### UploadTask Class (Mock)
-
-Tracks multi-stage upload progress.
-
-```typescript
-interface UploadTask {
-  commp(): Promise<CommP>        // Get the piece commitment (CommP)
-  store(): Promise<string>       // Get storage provider confirmation
-  done(): Promise<string>        // Get transaction hash when complete
-}
-```
-
-### Type Definitions
-
-#### CommP (Piece Commitment)
-CommP is a special type of CID used in Filecoin's Proof of Data Possession (PDP) system. It represents a cryptographic commitment to stored data that enables efficient verification without accessing the full data.
-
-```typescript
-// Constrained CID type with Filecoin-specific codec and hasher
-type CommP = CID & {
-  readonly code: 0xf101                // fil-commitment-unsealed codec
-  readonly multihash: { code: 0x1012 } // sha2-256-trunc254-padded hasher
-}
-```
+All components can be imported and used independently for advanced use cases.
 
 ### CommP Utilities
 
-The SDK provides standalone utilities for working with CommP values that can be used without instantiating a Synapse instance:
+Calculate and validate Filecoin Piece Commitments without instantiating the full SDK.
 
 ```javascript
-import { calculate, asCommP } from '@filoz/synapse-sdk/commp'
+import { calculate, asCommP, createCommPStream } from '@filoz/synapse-sdk/commp'
 
-// Calculate CommP for binary data
-const data = new Uint8Array([1, 2, 3, 4, 5])
+// Calculate CommP from data
+const data = new Uint8Array([1, 2, 3, 4])
 const commp = calculate(data)
 console.log(commp.toString()) // baga6ea4seaq...
 
-// Validate and parse CommP strings
-const parsed = asCommP('baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq')
-if (parsed) {
-  console.log('Valid CommP:', parsed.toString())
-} else {
-  console.log('Invalid CommP string')
+// Validate and convert CommP strings and CIDs
+const commp = asCommP('baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq')
+if (commp !== null) {
+  console.log('Valid CommP:', commp.toString())
 }
 
-// Also works with CID objects
-const cid = CID.parse('baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq')
-const validated = asCommP(cid) // Returns CommP type or null if invalid
+// Stream-based CommP calculation; compatible with Web Streams API
+const { stream, getCommP } = createCommPStream()
+// Pipe data through stream, then call getCommP() for result
 ```
 
-#### Network Detection
-The SDK automatically detects the network based on chain ID:
-- **314** - Filecoin Mainnet
-- **314159** - Filecoin Calibration Testnet
+### PDP Upload Service
+
+Upload data directly to a PDP (Proof of Data Possession) server.
+
+```javascript
+import { PDPUploadService } from '@filoz/synapse-sdk/pdp'
+import { calculate } from '@filoz/synapse-sdk/commp'
+
+// Create upload service
+const uploadService = new PDPUploadService('https://pdp.example.com')
+
+// Upload data
+const data = new Uint8Array([1, 2, 3, 4, 5])
+const commp = calculate(data)
+await uploadService.upload(data, commp)
+```
+
+#### PDPUploadService API
+
+- **Constructor**: `new PDPUploadService(apiEndpoint, serviceName?)`
+  - `apiEndpoint`: Base URL of the PDP API
+  - `serviceName`: Optional service name (defaults to 'public')
+- **Methods**:
+  - `upload(data, commp)`: Upload data with its CommP
+  - `getApiEndpoint()`: Get the API endpoint
+  - `getServiceName()`: Get the service name
+
+### PDP Download Service
+
+Download and verify data from storage providers.
+
+```javascript
+import { PDPDownloadService } from '@filoz/synapse-sdk/pdp'
+
+// Create download service
+const downloadService = new PDPDownloadService('https://sp.example.com/retrieve')
+
+// Download and verify data
+const commp = 'baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq'
+const data = await downloadService.downloadPiece(commp)
+// Data is automatically verified against CommP
+```
+
+#### PDPDownloadService API
+
+- **Constructor**: `new PDPDownloadService(retrievalUrl)`
+  - `retrievalUrl`: Base URL for the storage provider's retrieval endpoint
+- **Methods**:
+  - `downloadPiece(commp)`: Download and verify a piece by CommP
+  - `getRetrievalUrl()`: Get the retrieval URL
+
+### Storage Service (Mock)
+
+The storage service interface for future implementations.
+
+```javascript
+import { MockStorageService } from '@filoz/synapse-sdk'
+
+// Create storage service directly (usually created via Synapse.createStorage())
+const storage = new MockStorageService('proofSetId', 'f01234')
+
+// Upload data
+const uploadTask = storage.upload(data)
+const commp = await uploadTask.commp()
+await uploadTask.done()
+
+// Download data
+const retrieved = await storage.download(commp)
+
+// Other operations
+await storage.delete(commp)
+await storage.settlePayments()
+```
+
+---
 
 ## Network Configuration
 
 ### RPC Endpoints
-The SDK supports both HTTP/HTTPS and WebSocket connections:
 
 ```javascript
-import { Synapse, RPC_URLS } from '@filoz/synapse-sdk'
+import { RPC_URLS } from '@filoz/synapse-sdk'
 
-// WebSocket endpoints (recommended for better performance)
-const wsSynapse = await Synapse.create({
-  privateKey: '0x...',
-  rpcURL: RPC_URLS.mainnet.websocket  // 'wss://wss.node.glif.io/apigw/lotus/rpc/v1'
-})
+// Mainnet
+RPC_URLS.mainnet.websocket  // wss://wss.node.glif.io/apigw/lotus/rpc/v1
+RPC_URLS.mainnet.http       // https://api.node.glif.io/rpc/v1
 
-// HTTP/HTTPS endpoints
-const httpSynapse = await Synapse.create({
-  privateKey: '0x...',
-  rpcURL: RPC_URLS.mainnet.http  // 'https://api.node.glif.io/rpc/v1'
-})
-
-// Calibration testnet
-const calibrationSynapse = await Synapse.create({
-  privateKey: '0x...',
-  rpcURL: RPC_URLS.calibration.websocket
-})
+// Calibration Testnet
+RPC_URLS.calibration.websocket  // wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1
+RPC_URLS.calibration.http       // https://api.calibration.node.glif.io/rpc/v1
 ```
 
 ### GLIF Authorization
 
-The GLIF free tier is limited to 100 requests per minute, which may not be sufficient for applications making frequent SDK calls. You can use GLIF authorization tokens to increase your rate limits:
+For higher rate limits with GLIF endpoints:
 
 ```javascript
 import { Synapse } from '@filoz/synapse-sdk'
@@ -324,163 +259,82 @@ const synapse = await Synapse.create({
   rpcURL: 'https://api.node.glif.io/rpc/v1',
   authorization: 'Bearer YOUR_GLIF_TOKEN'
 })
-
-// The authorization header will be automatically added to all RPC requests
 ```
 
-Note: Authorization headers are only supported for HTTP/HTTPS endpoints. WebSocket connections do not support authorization headers.
+### Network Details
 
-### Filecoin Mainnet
+**Filecoin Mainnet**
 - Chain ID: 314
-- WebSocket RPC: wss://wss.node.glif.io/apigw/lotus/rpc/v1
-- HTTP RPC: https://api.node.glif.io/rpc/v1
 - USDFC Contract: `0x80B98d3aa09ffff255c3ba4A241111Ff1262F045`
 
-### Filecoin Calibration Testnet
+**Filecoin Calibration Testnet**
 - Chain ID: 314159
-- WebSocket RPC: wss://wss.calibration.node.glif.io/apigw/lotus/rpc/v1
-- HTTP RPC: https://api.calibration.node.glif.io/rpc/v1
 - USDFC Contract: `0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0`
+
+---
 
 ## Browser Integration
 
-The SDK works seamlessly with browser wallets. See `examples/EXAMPLES.md` for complete browser integration examples.
+The SDK works seamlessly in browsers.
 
 ### MetaMask Setup
 
-Add Filecoin networks to MetaMask:
+Official documentation for configuring MetaMask with Filecoin (both Mainnet and the Calibration Test network) can be found at: https://docs.filecoin.io/basics/assets/metamask-setup
+
+If you want to add the Filecoin network programmatically, you can use the following code snippet, for Mainnet (change accordingly for Calibration Testnet):
 
 ```javascript
-// Calibration Testnet
+// Add Filecoin network to MetaMask
 await window.ethereum.request({
   method: 'wallet_addEthereumChain',
   params: [{
-    chainId: '0x4CB2F',  // 314159 in hex
-    chainName: 'Filecoin Calibration',
-    rpcUrls: ['https://api.calibration.node.glif.io/rpc/v1'],
-    nativeCurrency: { name: 'FIL', symbol: 'tFIL', decimals: 18 }
-  }]
-})
-
-// Mainnet
-await window.ethereum.request({
-  method: 'wallet_addEthereumChain',
-  params: [{
-    chainId: '0x13A',    // 314 in hex
+    chainId: '0x13A',  // 314 for mainnet
     chainName: 'Filecoin',
+    nativeCurrency: { name: 'FIL', symbol: 'FIL', decimals: 18 },
     rpcUrls: ['https://api.node.glif.io/rpc/v1'],
-    nativeCurrency: { name: 'FIL', symbol: 'FIL', decimals: 18 }
+    blockExplorerUrls: ['https://filfox.info/en']
   }]
 })
 ```
 
-## Error Handling
+---
+
+## Additional Information
+
+### Type Definitions
+
+The SDK is fully typed with TypeScript. Key types include:
+
+- `CommP` - Filecoin Piece Commitment CID
+- `TokenAmount` - `number | bigint` for token amounts
+- `StorageOptions` - Options for storage service creation
+- `AuthSignature` - Signature data for authenticated operations
+
+### Error Handling
+
+All SDK methods use descriptive error messages with proper error chaining:
 
 ```javascript
 try {
-  const synapse = await Synapse.create({
-    privateKey: '0x...',
-    rpcURL: 'https://api.node.glif.io/rpc/v1'
-  })
-  
-  const balance = await synapse.walletBalance()
+  await synapse.deposit(amount)
 } catch (error) {
-  if (error.message.includes('Unsupported network')) {
-    // Handle unsupported network (only mainnet/calibration supported)
-  } else if (error.message.includes('network detection failed')) {
-    // Handle RPC connection issues
-  } else if (error.cause) {
-    // Access original error via Error.cause property
-    console.log('Original error:', error.cause)
-  }
+  console.error(error.message)  // Clear error description
+  console.error(error.cause)     // Underlying error if any
 }
 ```
 
-## Common Patterns
+## Contributing
 
-### Checking Multiple Balances
-
-```javascript
-const [filBalance, usdcBalance, synapseBalance] = await Promise.all([
-  synapse.walletBalance(),                    // FIL in wallet
-  synapse.walletBalance(Synapse.USDFC),       // USDFC in wallet
-  synapse.balance()                           // USDFC in Synapse payments contract (for services)
-])
-```
-
-### Upload with Progress Tracking
-
-```javascript
-const uploadTask = storage.upload(data)
-
-// Track each stage
-uploadTask.commp().then(commp => console.log('CommP:', commp))
-uploadTask.store().then(sp => console.log('Stored with:', sp))
-uploadTask.done().then(tx => console.log('Transaction:', tx))
-
-// Or wait for completion
-const txHash = await uploadTask.done()
-```
-
-### Bulk Operations
-
-```javascript
-// Upload multiple files
-const uploads = files.map(data => storage.upload(data))
-const commps = await Promise.all(uploads.map(task => task.commp()))
-
-// Download multiple files
-const downloads = commps.map(commp => storage.download(commp))
-const dataArray = await Promise.all(downloads)
-```
-
-## Development Status
-
-**Production Ready:**
-- ✅ Wallet integration (private key + browser providers + external signers)
-- ✅ Network detection and strict validation (mainnet/calibration only)
-- ✅ FIL and USDFC balance checking (bigint amounts)
-- ✅ Type-safe CommP handling with proper validation
-- ✅ Automatic nonce management with NonceManager
-- ✅ TypeScript Standard Style code formatting
-- ✅ WebSocket RPC support for real-time updates
-- ✅ Error handling with Error.cause chaining
-- ✅ Factory method pattern for async initialization
-
-**Mock Implementation (Development Only):**
-- 🚧 Storage operations (upload/download/delete)
-- 🚧 Payment operations (deposit/withdraw) 
-- 🚧 Storage service management
-
-## Development
-
-### Code Style
-This project uses [ts-standard](https://github.com/standard/ts-standard) for consistent TypeScript formatting:
-
-```bash
-# Check formatting
-npm run lint
-
-# Auto-fix formatting issues
-npm run lint:fix
-```
-
-### Build
-```bash
-# Build TypeScript to dist/
-npm run build
-
-# Watch mode for development
-npm run watch
-```
+Contributions are welcome! If using an AI tool, you are welcome to load AGENTS.md into your context to teach it about the structure and conventions of this SDK.
 
 ### Testing
-```bash
-# Run all tests
-npm test
 
-# Run tests in watch mode
-npm run test:watch
+Run the test suite:
+
+```bash
+npm test              # Run all tests and linting
+npm run test:node     # Node.js tests only
+npm run test:browser  # Browser tests only
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -11,8 +11,12 @@
       "types": "./dist/index.d.ts"
     },
     "./commp": {
-      "import": "./dist/commp.js",
-      "types": "./dist/commp.d.ts"
+      "import": "./dist/commp/index.js",
+      "types": "./dist/commp/index.d.ts"
+    },
+    "./pdp": {
+      "import": "./dist/pdp/index.js",
+      "types": "./dist/pdp/index.d.ts"
     }
   },
   "scripts": {
@@ -26,8 +30,7 @@
     "test:browser": "polendina --page --worker --serviceworker --cleanup dist/test/**/*.js",
     "test:watch": "npm run build && mocha 'dist/test/**/*.js' --watch",
     "clean": "rm -rf dist",
-    "prepublishOnly": "npm run clean && npm run build",
-    "example": "npm run build && node example-usage.js"
+    "prepublishOnly": "npm run clean && npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/commp/index.ts
+++ b/src/commp/index.ts
@@ -1,0 +1,9 @@
+// Export CommP types and utility functions
+export {
+  FIL_COMMITMENT_UNSEALED,
+  SHA2_256_TRUNC254_PADDED,
+  CommP,
+  asCommP,
+  calculate,
+  createCommPStream
+} from './commp.js'

--- a/src/pdp/index.ts
+++ b/src/pdp/index.ts
@@ -1,0 +1,3 @@
+// Export PDP services
+export { PDPUploadService } from './pdp-upload-service.js'
+export { PDPDownloadService } from './pdp-download-service.js'

--- a/src/pdp/pdp-download-service.ts
+++ b/src/pdp/pdp-download-service.ts
@@ -1,0 +1,123 @@
+/**
+ * PDP Download Service for retrieving data from storage providers
+ */
+
+import type { CommP } from '../types.js'
+import { asCommP, createCommPStream } from '../commp/index.js'
+
+/**
+ * PDPDownloadService handles retrieval of data from storage providers with CommP verification
+ */
+export class PDPDownloadService {
+  private readonly retrievalUrl: string
+
+  /**
+   * Create a new PDPDownloadService instance
+   * @param retrievalUrl - The retrieval endpoint for the storage provider (e.g., 'https://sp.example.com/retrieve')
+   */
+  constructor (retrievalUrl: string) {
+    // Validate and normalize retrieval URL (remove trailing slash)
+    if (retrievalUrl === '') {
+      throw new Error('Retrieval URL is required')
+    }
+    this.retrievalUrl = retrievalUrl.endsWith('/') ? retrievalUrl.slice(0, -1) : retrievalUrl
+  }
+
+  /**
+   * Download a piece from the storage provider and verify its CommP
+   * @param commp - The CommP (piece commitment) to download
+   * @returns The downloaded data as Uint8Array
+   * @throws Error if download fails or CommP verification fails
+   */
+  async downloadPiece (commp: CommP | string): Promise<Uint8Array> {
+    // Validate and normalize the CommP
+    const normalizedCommP = asCommP(commp)
+    if (normalizedCommP == null) {
+      throw new Error('Invalid CommP provided')
+    }
+
+    // Construct the download URL
+    const downloadUrl = `${this.retrievalUrl}/piece/${normalizedCommP.toString()}`
+
+    // Download the data
+    const response = await fetch(downloadUrl, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/octet-stream'
+      }
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(`Failed to download piece: ${response.status} ${response.statusText} - ${errorText}`)
+    }
+
+    // Ensure we have a body
+    if (response.body == null) {
+      throw new Error('Response body is null')
+    }
+
+    console.log('Streaming and verifying downloaded data...')
+
+    // Create CommP calculation stream
+    const { stream: commpStream, getCommP } = createCommPStream()
+
+    // Create a stream that collects all chunks into an array
+    const chunks: Uint8Array[] = []
+    const collectStream = new TransformStream<Uint8Array, Uint8Array>({
+      transform (chunk: Uint8Array, controller: TransformStreamDefaultController<Uint8Array>) {
+        chunks.push(chunk)
+        controller.enqueue(chunk)
+      }
+    })
+
+    // Pipe the response through both streams
+    const pipelineStream = response.body
+      .pipeThrough(commpStream)
+      .pipeThrough(collectStream)
+
+    // Consume the stream to completion
+    const reader = pipelineStream.getReader()
+    try {
+      while (true) {
+        const { done } = await reader.read()
+        if (done) break
+      }
+    } finally {
+      reader.releaseLock()
+    }
+
+    // Get the calculated CommP
+    const calculatedCommP = getCommP()
+    if (calculatedCommP == null) {
+      throw new Error('Failed to calculate CommP from stream')
+    }
+
+    // Verify the CommP
+    if (calculatedCommP.toString() !== normalizedCommP.toString()) {
+      throw new Error(
+        `CommP verification failed. Expected: ${normalizedCommP.toString()}, Got: ${calculatedCommP.toString()}`
+      )
+    }
+
+    console.log('✅ CommP verification successful')
+
+    // Combine all chunks into a single Uint8Array
+    const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0)
+    const result = new Uint8Array(totalLength)
+    let offset = 0
+    for (const chunk of chunks) {
+      result.set(chunk, offset)
+      offset += chunk.length
+    }
+
+    return result
+  }
+
+  /**
+   * Get the retrieval URL
+   */
+  getRetrievalUrl (): string {
+    return this.retrievalUrl
+  }
+}

--- a/src/pdp/pdp-upload-service.ts
+++ b/src/pdp/pdp-upload-service.ts
@@ -1,0 +1,147 @@
+/**
+ * PDP Service for uploading data to a remote PDP server
+ */
+
+import { toHex } from 'multiformats/bytes'
+import type { CommP } from '../types.js'
+
+/**
+ * PDPUploadService handles communication with a remote PDP server for data uploads
+ */
+export class PDPUploadService {
+  private readonly apiEndpoint: string
+  private readonly serviceName: string
+
+  /**
+   * Create a new PDPUploadService instance
+   * @param apiEndpoint - The root URL of the PDP API endpoint (e.g., 'https://pdp.example.com')
+   * @param serviceName - The name of the PDP service (defaults to 'public')
+   */
+  constructor (apiEndpoint: string, serviceName: string = 'public') {
+    // Validate and normalize API endpoint (remove trailing slash)
+    if (apiEndpoint === '') {
+      throw new Error('PDP API endpoint is required')
+    }
+    this.apiEndpoint = apiEndpoint.endsWith('/') ? apiEndpoint.slice(0, -1) : apiEndpoint
+
+    // Store service name
+    this.serviceName = serviceName
+  }
+
+  /**
+   * Upload data to the PDP server
+   * @param data - The raw data to upload
+   * @param commp - The CommP (piece commitment) of the data
+   * @returns Promise that resolves when upload is complete
+   */
+  async upload (data: Uint8Array | ArrayBuffer, commp: CommP): Promise<void> {
+    // Convert ArrayBuffer to Uint8Array if needed
+    const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data
+    const byteLength = bytes.length
+
+    // Step 1: POST to create the upload
+    const uploadId = await this._createUpload(commp, byteLength)
+
+    // Step 2: PUT the actual data
+    await this._uploadData(uploadId, bytes)
+  }
+
+  /**
+   * Create an upload by posting CommP and size
+   * @returns The upload ID extracted from the Location header
+   */
+  private async _createUpload (commp: CommP, byteLength: number): Promise<string> {
+    // Extract the raw hash from the CommP CID
+    // The multihash contains the hash algorithm code followed by the hash length and then the hash
+    const hashBytes = commp.multihash.digest
+    const hashHex = toHex(hashBytes)
+
+    const checkData = {
+      name: 'sha2-256-trunc254-padded', // This is the hash type for CommP
+      hash: hashHex,
+      size: byteLength
+    }
+
+    const requestBody = {
+      check: checkData
+      // No notify URL needed as per requirements
+    }
+
+    const response = await fetch(`${this.apiEndpoint}/pdp/piece`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+        // No Authorization header needed (null authentication)
+      },
+      body: JSON.stringify(requestBody)
+    })
+
+    if (response.status === 200) {
+      // Piece already exists on server
+      const data = await response.json() as { pieceCID: string }
+      console.log(`Piece already exists on server: ${data.pieceCID}`)
+      return '' // No upload needed
+    }
+
+    if (response.status !== 201) {
+      const errorText = await response.text()
+      throw new Error(`Failed to create upload: ${response.status} ${response.statusText} - ${errorText}`)
+    }
+
+    // Extract upload ID from Location header
+    const location = response.headers.get('Location')
+    if (location == null) {
+      throw new Error('Server did not provide Location header in response')
+    }
+
+    // Validate the location format and extract UUID
+    // Match /pdp/piece/upload/UUID or /piece/upload/UUID anywhere in the path
+    const locationMatch = location.match(/\/(?:pdp\/)?piece\/upload\/([a-fA-F0-9-]+)/)
+    if (locationMatch == null) {
+      throw new Error(`Invalid Location header format: ${location}`)
+    }
+
+    return locationMatch[1] // Return just the UUID
+  }
+
+  /**
+   * Upload the actual data bytes
+   */
+  private async _uploadData (uploadId: string, data: Uint8Array): Promise<void> {
+    // If uploadId is empty, the piece already exists
+    if (uploadId === '') {
+      return
+    }
+
+    const uploadUrl = `${this.apiEndpoint}/pdp/piece/upload/${uploadId}`
+
+    const response = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Length': data.length.toString()
+        // No Authorization header needed (null authentication)
+      },
+      body: data
+    })
+
+    if (response.status !== 204) {
+      const errorText = await response.text()
+      throw new Error(`Failed to upload data: ${response.status} ${response.statusText} - ${errorText}`)
+    }
+  }
+
+  /**
+   * Get the service name
+   */
+  getServiceName (): string {
+    return this.serviceName
+  }
+
+  /**
+   * Get the API endpoint
+   */
+  getApiEndpoint (): string {
+    return this.apiEndpoint
+  }
+}

--- a/src/storage-service.ts
+++ b/src/storage-service.ts
@@ -7,7 +7,7 @@
 
 import type { StorageService, CommP, DownloadOptions, SettlementResult, ProofSetId, StorageProvider } from './types.js'
 import { MockUploadTask } from './upload-task.js'
-import { asCommP } from './commp.js'
+import { asCommP } from './commp/index.js'
 
 export class MockStorageService implements StorageService {
   readonly proofSetId: ProofSetId

--- a/src/storage-service.ts
+++ b/src/storage-service.ts
@@ -102,7 +102,7 @@ export class MockStorageService implements StorageService {
     await new Promise(resolve => setTimeout(resolve, 1000))
 
     const result = {
-      settledAmount: 50000000000000000n, // Mock amount: 0.05 USDFC in smallest unit (18 decimals)
+      settledAmount: 50000000000000000n, // Mock amount: 0.05 USDFC in base units (1×10⁻¹⁸)
       epoch: Math.floor(Date.now() / 30000) // Mock epoch
     }
 

--- a/src/test/pdp-download-service.test.ts
+++ b/src/test/pdp-download-service.test.ts
@@ -1,0 +1,164 @@
+/* globals describe it beforeEach afterEach */
+
+/**
+ * Tests for PDPDownloadService
+ */
+
+import { assert } from 'chai'
+import { PDPDownloadService } from '../pdp/index.js'
+import { calculate } from '../commp/index.js'
+
+describe('PDPDownloadService', () => {
+  let originalFetch: typeof global.fetch
+  let testData: Uint8Array
+  let testCommP: string
+
+  beforeEach(() => {
+    // Save original fetch and console.log
+    originalFetch = global.fetch
+
+    // Create test data and calculate its CommP
+    testData = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+    testCommP = calculate(testData).toString()
+  })
+
+  afterEach(() => {
+    // Restore original fetch
+    global.fetch = originalFetch
+  })
+
+  describe('constructor', () => {
+    it('should create instance with valid retrieval URL', () => {
+      const service = new PDPDownloadService('https://sp.example.com/retrieve')
+      assert.instanceOf(service, PDPDownloadService)
+    })
+
+    it('should normalize URL by removing trailing slash', () => {
+      const service = new PDPDownloadService('https://sp.example.com/retrieve/')
+      assert.strictEqual(service.getRetrievalUrl(), 'https://sp.example.com/retrieve')
+    })
+
+    it('should throw on empty URL', () => {
+      assert.throws(() => new PDPDownloadService(''), 'Retrieval URL is required')
+    })
+  })
+
+  describe('downloadPiece', () => {
+    it('should successfully download and verify piece', async () => {
+      // Mock successful download
+      global.fetch = async (input: string | URL | Request): Promise<Response> => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+
+        // Verify correct URL format
+        assert.isTrue(url.endsWith(`/piece/${testCommP}`))
+
+        // Return test data as response
+        return new Response(testData, {
+          status: 200,
+          headers: { 'Content-Type': 'application/octet-stream' }
+        })
+      }
+
+      const service = new PDPDownloadService('https://sp.example.com/retrieve')
+      const result = await service.downloadPiece(testCommP)
+
+      // Verify we got the correct data back
+      assert.deepEqual(result, testData)
+    })
+
+    it('should reject invalid CommP', async () => {
+      const service = new PDPDownloadService('https://sp.example.com/retrieve')
+
+      try {
+        await service.downloadPiece('invalid-commp')
+        assert.fail('Should have thrown')
+      } catch (error) {
+        assert.include((error as Error).message, 'Invalid CommP provided')
+      }
+    })
+
+    it('should throw on download failure', async () => {
+      global.fetch = async (): Promise<Response> => {
+        return new Response('Not found', { status: 404, statusText: 'Not Found' })
+      }
+
+      const service = new PDPDownloadService('https://sp.example.com/retrieve')
+
+      try {
+        await service.downloadPiece(testCommP)
+        assert.fail('Should have thrown')
+      } catch (error) {
+        assert.match((error as Error).message, /Failed to download piece: 404 Not Found/)
+      }
+    })
+
+    it('should throw on CommP verification failure', async () => {
+      // Mock download that returns wrong data
+      global.fetch = async (): Promise<Response> => {
+        const wrongData = new Uint8Array([9, 9, 9, 9]) // Different data
+        return new Response(wrongData, {
+          status: 200,
+          headers: { 'Content-Type': 'application/octet-stream' }
+        })
+      }
+
+      const service = new PDPDownloadService('https://sp.example.com/retrieve')
+
+      try {
+        await service.downloadPiece(testCommP)
+        assert.fail('Should have thrown')
+      } catch (error) {
+        assert.match((error as Error).message, /CommP verification failed/)
+      }
+    })
+
+    it('should handle null response body', async () => {
+      global.fetch = async (): Promise<Response> => {
+        // Create a response with null body
+        const response = new Response(null, { status: 200 })
+        Object.defineProperty(response, 'body', { value: null })
+        return response
+      }
+
+      const service = new PDPDownloadService('https://sp.example.com/retrieve')
+
+      try {
+        await service.downloadPiece(testCommP)
+        assert.fail('Should have thrown')
+      } catch (error) {
+        assert.include((error as Error).message, 'Response body is null')
+      }
+    })
+
+    it('should correctly stream and verify chunked data', async () => {
+      // Mock fetch that returns data in chunks
+      global.fetch = async (): Promise<Response> => {
+        // Split test data into chunks
+        const chunk1 = testData.slice(0, 4)
+        const chunk2 = testData.slice(4)
+
+        // Create readable stream that emits chunks
+        const stream = new ReadableStream({
+          async start (controller) {
+            controller.enqueue(chunk1)
+            // Small delay to simulate network
+            await new Promise(resolve => setTimeout(resolve, 10))
+            controller.enqueue(chunk2)
+            controller.close()
+          }
+        })
+
+        return new Response(stream, {
+          status: 200,
+          headers: { 'Content-Type': 'application/octet-stream' }
+        })
+      }
+
+      const service = new PDPDownloadService('https://sp.example.com/retrieve')
+      const result = await service.downloadPiece(testCommP)
+
+      // Verify we got all the data correctly reassembled
+      assert.deepEqual(result, testData)
+    })
+  })
+})

--- a/src/test/pdp-upload-service.test.ts
+++ b/src/test/pdp-upload-service.test.ts
@@ -1,0 +1,154 @@
+/* globals describe it beforeEach afterEach */
+
+/**
+ * Tests for PDPUploadService
+ */
+
+import { assert } from 'chai'
+import { PDPUploadService } from '../pdp/index.js'
+import { calculate } from '../commp/index.js'
+
+describe('PDPUploadService', () => {
+  let originalFetch: typeof global.fetch
+  let fetchMock: typeof global.fetch
+
+  beforeEach(() => {
+    // Save original fetch
+    originalFetch = global.fetch
+    // Create mock
+    fetchMock = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+      const method = init?.method ?? 'GET'
+
+      // Mock POST /pdp/piece endpoint
+      if (method === 'POST' && url.endsWith('/pdp/piece')) {
+        const body = JSON.parse(init?.body as string)
+
+        // Validate request structure
+        assert.exists(body.check)
+        assert.exists(body.check.name)
+        assert.exists(body.check.hash)
+        assert.exists(body.check.size)
+
+        // Return 201 with Location header
+        return new Response(null, {
+          status: 201,
+          headers: {
+            Location: '/pdp/piece/upload/12345678-1234-1234-1234-123456789012'
+          }
+        })
+      }
+
+      // Mock PUT /pdp/piece/upload/{uuid} endpoint
+      if (method === 'PUT' && url.includes('/pdp/piece/upload/')) {
+        // Verify content type
+        assert.strictEqual((init?.headers as any)?.['Content-Type'], 'application/octet-stream')
+
+        // Return 204 No Content
+        return new Response(null, { status: 204 })
+      }
+
+      throw new Error(`Unexpected fetch call: ${method} ${url}`)
+    }
+
+    // Replace global fetch
+    global.fetch = fetchMock
+  })
+
+  afterEach(() => {
+    // Restore original fetch
+    global.fetch = originalFetch
+  })
+
+  describe('constructor', () => {
+    it('should create instance with valid endpoint', () => {
+      const service = new PDPUploadService('https://pdp.example.com')
+      assert.instanceOf(service, PDPUploadService)
+    })
+
+    it('should normalize endpoint by removing trailing slash', () => {
+      const service = new PDPUploadService('https://pdp.example.com/')
+      assert.strictEqual(service.getApiEndpoint(), 'https://pdp.example.com')
+    })
+
+    it('should throw on empty endpoint', () => {
+      assert.throws(() => new PDPUploadService(''), 'PDP API endpoint is required')
+    })
+  })
+
+  describe('upload', () => {
+    it('should successfully upload data', async () => {
+      const service = new PDPUploadService('https://pdp.example.com')
+      const data = new Uint8Array([1, 2, 3, 4, 5])
+      const commp = calculate(data)
+
+      // Should not throw
+      await service.upload(data, commp)
+    })
+
+    it('should handle ArrayBuffer input', async () => {
+      const service = new PDPUploadService('https://pdp.example.com')
+      const data = new ArrayBuffer(5)
+      new Uint8Array(data).set([1, 2, 3, 4, 5])
+      const commp = calculate(new Uint8Array(data))
+
+      // Should not throw
+      await service.upload(data, commp)
+    })
+
+    it('should handle existing piece (200 response)', async () => {
+      // Override mock for this test
+      global.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url
+        const method = init?.method ?? 'GET'
+
+        if (method === 'POST' && url.endsWith('/pdp/piece')) {
+          // Return 200 indicating piece already exists
+          return new Response(JSON.stringify({ pieceCID: 'baga...' }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          })
+        }
+
+        throw new Error(`Unexpected fetch call: ${method} ${url}`)
+      }
+
+      const service = new PDPUploadService('https://pdp.example.com')
+      const data = new Uint8Array([1, 2, 3, 4, 5])
+      const commp = calculate(data)
+
+      // Should not throw
+      await service.upload(data, commp)
+    })
+
+    it('should throw on create upload error', async () => {
+      // Override mock for this test
+      global.fetch = async (): Promise<Response> => {
+        return new Response('Server error', { status: 500 })
+      }
+
+      const service = new PDPUploadService('https://pdp.example.com')
+      const data = new Uint8Array([1, 2, 3, 4, 5])
+      const commp = calculate(data)
+
+      try {
+        await service.upload(data, commp)
+        assert.fail('Should have thrown')
+      } catch (error) {
+        assert.match((error as Error).message, /Failed to create upload: 500/)
+      }
+    })
+  })
+
+  describe('getters', () => {
+    it('should return service name', () => {
+      const service = new PDPUploadService('https://pdp.example.com', 'custom')
+      assert.strictEqual(service.getServiceName(), 'custom')
+    })
+
+    it('should use default service name', () => {
+      const service = new PDPUploadService('https://pdp.example.com')
+      assert.strictEqual(service.getServiceName(), 'public')
+    })
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,10 +6,11 @@
  * and optional CDN retrieval services.
  */
 
-import { LegacyPieceLink } from '@web3-storage/data-segment'
+import { CommP } from './commp/index.js'
 import type { ethers } from 'ethers'
 
 // Type definitions for common values
+export { CommP }
 export type PrivateKey = string
 export type Address = string
 export type TokenAmount = number | bigint
@@ -20,18 +21,6 @@ export type StorageProvider = string
  * Token identifier for balance queries
  */
 export type TokenIdentifier = 'USDFC' | string
-
-/**
- * CommP - A constrained CID type for Piece Commitments
- * This is implemented as a Link type which is made concrete by a CID. A CommP
- * uses the fil-commitment-unsealed codec (0xf101) and
- * sha2-256-trunc254-padded multihash function (0x1012). This will eventually be
- * replaced by a CommPv2 which uses the raw codec (0x55) and the
- * fr32-sha256-trunc254-padbintree multihash function (0x1011), which is a
- * specialised form of sha2-256-trunc254-padded multihash that also encodes the
- * content length and the height of the merkle tree.
- */
-export type CommP = LegacyPieceLink
 
 /**
  * Options for initializing the Synapse instance

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export interface DownloadOptions {
  * Payment settlement result
  */
 export interface SettlementResult {
-  /** Amount settled in USDFC (in smallest unit, not human readable) */
+  /** Amount settled in USDFC base units */
   settledAmount: bigint
   /** Epoch at which settlement occurred */
   epoch: number


### PR DESCRIPTION
Not wired up to the core SDK for now but you can use all of these pieces independently.

e.g.

```javascript
import { calculate, asCommP, createCommPStream } from '@filoz/synapse-sdk/commp'

// Calculate CommP from data
const data = new Uint8Array([1, 2, 3, 4])
const commp = calculate(data)
console.log(commp.toString()) // baga6ea4seaq...

// Validate and convert CommP strings and CIDs
const commp = asCommP('baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq')
if (commp !== null) {
  console.log('Valid CommP:', commp.toString())
}

// Stream-based CommP calculation; compatible with Web Streams API
const { stream, getCommP } = createCommPStream()
// Pipe data through stream, then call getCommP() for result
```

```javascript
import { PDPUploadService } from '@filoz/synapse-sdk/pdp'
import { calculate } from '@filoz/synapse-sdk/commp'

// Create upload service
const uploadService = new PDPUploadService('https://pdp.example.com')

// Upload data
const data = new Uint8Array([1, 2, 3, 4, 5])
const commp = calculate(data)
await uploadService.upload(data, commp)
```

```javascript
import { PDPDownloadService } from '@filoz/synapse-sdk/pdp'

// Create download service
const downloadService = new PDPDownloadService('https://sp.example.com/retrieve')

// Download and verify data
const commp = 'baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq'
const data = await downloadService.downloadPiece(commp)
// Data is automatically verified against CommP
```

I'm also renaming "smallest unit" to "base units" for tokens in here