### PR TITLE
Further integrate `withCDN=true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ interface SynapseOptions {
 
   // Advanced Configuration
   disableNonceManager?: boolean // Disable automatic nonce management
+  withCDN?: boolean             // Enable CDN for retrievals
 }
 ```
 

--- a/src/synapse.ts
+++ b/src/synapse.ts
@@ -24,6 +24,7 @@ export class Synapse implements ISynapse {
   private readonly _signer: ethers.Signer
   private readonly _network: 'mainnet' | 'calibration'
   private readonly _disableNonceManager: boolean
+  private readonly _withCDN: boolean
 
   // Cached contract instances
   private _usdfcContract: ethers.Contract | null = null
@@ -131,19 +132,21 @@ export class Synapse implements ISynapse {
       )
     }
 
-    return new Synapse(provider, signer, network, options.disableNonceManager === true)
+    return new Synapse(provider, signer, network, options.disableNonceManager === true, options.withCDN === true)
   }
 
   private constructor (
     provider: ethers.Provider,
     signer: ethers.Signer,
     network: 'mainnet' | 'calibration',
-    disableNonceManager: boolean
+    disableNonceManager: boolean,
+    withCDN: boolean
   ) {
     this._provider = provider
     this._signer = signer
     this._network = network
     this._disableNonceManager = disableNonceManager
+    this._withCDN = withCDN
   }
 
   /**
@@ -396,7 +399,7 @@ export class Synapse implements ISynapse {
     )
     console.log('[MockSynapse] Storage service ready for operations')
 
-    return new MockStorageService(proofSetId, storageProvider)
+    return new MockStorageService(proofSetId, storageProvider, await this._signer.getAddress(), this._withCDN)
   }
 
   /**

--- a/src/upload-task.ts
+++ b/src/upload-task.ts
@@ -13,10 +13,12 @@ export class MockUploadTask implements UploadTask {
   private _commp?: CommP
   private _sp?: StorageProvider
   private _txHash?: string
+  private readonly _withCDN: boolean
 
-  constructor (data: Uint8Array | ArrayBuffer) {
+  constructor (data: Uint8Array | ArrayBuffer, withCDN: boolean) {
     this._data = data instanceof ArrayBuffer ? new Uint8Array(data) : data
-    console.log('[MockSynapse] UploadTask created with', this._data.length, 'bytes')
+    this._withCDN = withCDN
+    console.log('[MockSynapse] UploadTask created with', this._data.length, 'bytes (withCDN=', this._withCDN, ')')
   }
 
   async commp (): Promise<CommP> {


### PR DESCRIPTION
This integrates the CDN flag into all of the mock calls where I think the real implementation would also need it. Also uses the CDN for retrieval.