### PR TITLE
docs: add conventional commits guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This document serves as context for LLM agent sessions working with the Synapse 
   - **BEWARE** of common TS code, these rules will cause problems so you should either `lint:fix` regularly or avoid code that produces these: strict-boolean-expressions, no-trailing-spaces, return-await, no-unused-vars, indent
 - **Build Scripts**: `npm run build` but prefer `npm run build:browser` to to build browser bundles to `dist/browser/{synapse-sdk.esm.js,synapse-sdk.min.js}`
 - **Testing**: Mocha with `/* globals describe it */`, Chai for `{ assert }` in `src/test/`
+- **Conventional Commits**: Auto-publishing enabled with semantic versioning based on commit messages. Use `feat:` for minor, `fix:`/`chore:`/`docs:`/`test:` for patch. AVOID breaking change signifiers (`!` or `BREAKING CHANGE`) even if there are actual breaking changes. See <README.md#commit-message-guidelines> for full details. IMPORTANT: only create commits if asked to by the user, prefer to provide commit messages.
 
 ## Design Decisions
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Note: `ethers` v6 is a peer dependency and must be installed separately.
   * [Type Definitions](#type-definitions)
   * [Error Handling](#error-handling)
 * [Contributing](#contributing)
+  * [Commit Message Guidelines](#commit-message-guidelines)
   * [Testing](#testing)
 * [Migration Guide](#migration-guide)
   * [Transaction Return Types](#transaction-return-types-v070)
@@ -654,6 +655,55 @@ try {
 ## Contributing
 
 Contributions are welcome! If using an AI tool, you are welcome to load AGENTS.md into your context to teach it about the structure and conventions of this SDK.
+
+### Commit Message Guidelines
+
+This repository uses **auto-publishing** with semantic versioning based on commit messages. All commits must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+#### Commit Message Format
+
+```
+<type>(optional scope): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+#### Supported Types and Version Bumps
+
+- **patch** (0.x.Y): `chore:`, `fix:`, `test:`, `docs:`
+- **minor** (0.X.y): `feat:`
+- **major** (X.y.z): Any type with `!` suffix or `BREAKING CHANGE` in footer
+
+The `(optional scope)` is used to provide additional clarity about the target of the changes if isolated to a specific subsystem. e.g. `payments`, `storage`, `pandora`, `ci`, etc.
+
+#### Examples
+
+```bash
+# Patch releases (0.x.Y)
+git commit -m "fix(payments): resolve approval race condition"
+git commit -m "docs: update storage service examples"
+git commit -m "test: add unit tests for CommP calculation"
+git commit -m "chore: update dependencies"
+
+# Minor releases (0.X.y)
+git commit -m "feat: add CDN support for downloads"
+git commit -m "feat(storage): implement batch upload operations"
+
+# Major releases (X.y.z) - AVOID UNTIL M1
+git commit -m "feat!: remove deprecated payment methods"
+git commit -m "fix: update API signature
+
+BREAKING CHANGE: The createStorage method now requires explicit provider selection"
+```
+
+#### Important Notes
+
+- **Stay in 0.x.x range**: Avoid breaking changes (`!` or `BREAKING CHANGE`) until M1 milestone
+- **Auto-publishing**: Every merge to main triggers automatic npm publishing based on commit messages
+- **Changelog generation**: Commit messages are used to generate release notes
+- **Standard JS**: We follow [Standard JS](https://standardjs.com/) code style
 
 ### Testing
 


### PR DESCRIPTION
This PR documents the conventional commits guidelines for this repo. Since we've enabled automatic npm publishing based on commit messages, all contributors need to follow the conventional commits specification.