### PR TITLE
feat(download): composable download location discovery mechanism (WIP)

### DIFF
--- a/src/discovery/chain.ts
+++ b/src/discovery/chain.ts
@@ -1,0 +1,123 @@
+/**
+ * ChainDiscovery - Default implementation of PieceDiscovery using on-chain data
+ *
+ * This implementation discovers piece locations by:
+ * 1. Querying the client's proof sets from Pandora contract
+ * 2. Checking each storage provider to see if they have the piece
+ * 3. Yielding URLs as they're discovered for progressive downloads
+ * 4. Caching results for efficient repeated lookups
+ *
+ * @example
+ * ```typescript
+ * const discovery = new ChainDiscovery(provider, pandoraAddress)
+ *
+ * // Use directly
+ * for await (const url of discovery.findPiece(commp, client)) {
+ *   console.log('Found piece at:', url)
+ * }
+ *
+ * // Or with Synapse
+ * const synapse = await Synapse.create({ pieceDiscovery: discovery })
+ * ```
+ */
+
+import { ethers } from 'ethers'
+import type { PieceDiscovery } from '../types.js'
+import { PandoraService } from '../pandora/service.js'
+
+interface CachedEntry {
+  urls: Map<string, string> // providerAddress -> url
+  timestamp: number
+}
+
+export class ChainDiscovery implements PieceDiscovery {
+  private readonly cache = new Map<string, CachedEntry>()
+  private readonly cacheTTL = 30 * 60 * 1000 // 30 minutes
+
+  constructor (
+    private readonly provider: ethers.Provider,
+    private readonly pandoraAddress: string
+  ) {}
+
+  async * findPiece (
+    commp: string,
+    client: string,
+    options?: { providerAddress?: string }
+  ): AsyncIterable<string> {
+    // Simple cache key - just the piece
+    const cached = this.cache.get(commp)
+
+    // Yield cached URLs immediately if available
+    if (cached != null && Date.now() - cached.timestamp < this.cacheTTL) {
+      // If specific provider requested, try that first
+      if (options?.providerAddress != null && cached.urls.has(options.providerAddress)) {
+        const providerUrl = cached.urls.get(options.providerAddress)
+        if (providerUrl !== undefined) {
+          yield providerUrl
+        }
+      }
+
+      // Then yield all other cached URLs
+      for (const [paddr, url] of cached.urls) {
+        if (paddr !== options?.providerAddress) {
+          yield url
+        }
+      }
+      return // Cache hit, no need to query chain
+    }
+
+    // Get client's proof sets
+    const pandora = new PandoraService(this.provider, this.pandoraAddress)
+    const proofSets = await pandora.getClientProofSetsWithDetails(client)
+
+    // Filter to active proof sets, optionally by provider
+    let activeProofSets = proofSets.filter(ps =>
+      ps.isLive && ps.currentRootCount > 0
+    )
+
+    // If providerAddress specified, prioritize that provider's proof sets
+    if (options?.providerAddress != null) {
+      // Put this provider's proof sets first
+      const providerAddress = options.providerAddress
+      const providerSets = activeProofSets.filter(ps =>
+        ps.payee.toLowerCase() === providerAddress.toLowerCase()
+      )
+      const otherSets = activeProofSets.filter(ps =>
+        ps.payee.toLowerCase() !== providerAddress.toLowerCase()
+      )
+      activeProofSets = [...providerSets, ...otherSets]
+    }
+
+    // Track URLs for caching
+    const foundUrls = new Map<string, string>()
+
+    // Query providers and yield URLs as they're found
+    for (const proofSet of activeProofSets) {
+      try {
+        // Get provider info by address
+        const provider = await pandora.getApprovedProvider(proofSet.payee)
+
+        // Check if provider has the piece
+        // For discovery, we only need to call findPiece which doesn't require auth
+        // So we can use a direct HTTP call instead of PDPServer
+        const findUrl = `${provider.pdpUrl}/pdp/piece/${commp}`
+        const response = await fetch(findUrl, { method: 'GET' })
+        const hasPiece = response.ok
+
+        if (hasPiece) {
+          // Construct and yield URL immediately
+          const url = `${provider.pdpUrl}/pdp/piece/${commp}`
+          yield url
+          foundUrls.set(proofSet.payee, url)
+        }
+      } catch {
+        // Provider might be offline, continue to next
+      }
+    }
+
+    // Cache results for future queries (cache by piece only)
+    if (foundUrls.size > 0) {
+      this.cache.set(commp, { urls: foundUrls, timestamp: Date.now() })
+    }
+  }
+}

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Discovery module exports
+ *
+ * For users who want to use discovery classes separately:
+ * ```typescript
+ * import { ChainDiscovery, type PieceDiscovery } from '@filoz/synapse-sdk/discovery'
+ * ```
+ */
+
+export { ChainDiscovery } from './chain.js'
+export type { PieceDiscovery } from '../types.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,6 @@ export * from './payments/index.js'
 export * from './pandora/index.js'
 export * from './pdp/index.js'
 export * from './storage/index.js'
+
+// Discovery exports
+export { ChainDiscovery } from './discovery/chain.js'

--- a/src/test/download.test.ts
+++ b/src/test/download.test.ts
@@ -1,0 +1,296 @@
+/* globals describe it */
+import { assert } from 'chai'
+import { Synapse } from '../synapse.js'
+import { ChainDiscovery } from '../discovery/chain.js'
+import type { PieceDiscovery } from '../types.js'
+import { ethers } from 'ethers'
+
+describe('Download with Discovery', () => {
+  describe('ChainDiscovery', () => {
+    it('should yield cached URLs immediately', async () => {
+      const mockProvider: ethers.Provider = {} as any
+      const mockPandoraAddress = '0x1234567890123456789012345678901234567890'
+
+      const discovery = new ChainDiscovery(mockProvider, mockPandoraAddress)
+
+      // Manually populate cache
+      const cacheAny = discovery as any
+      cacheAny.cache.set('test-commp', {
+        urls: new Map([['0xprovider1', 'https://provider1.com/pdp/piece/test-commp']]),
+        timestamp: Date.now()
+      })
+
+      // Should yield cached URL immediately
+      const urls: string[] = []
+      for await (const url of discovery.findPiece('test-commp', '0xclient')) {
+        urls.push(url)
+      }
+
+      assert.equal(urls.length, 1)
+      assert.equal(urls[0], 'https://provider1.com/pdp/piece/test-commp')
+    })
+
+    it('should respect cache TTL', async () => {
+      const mockProvider: ethers.Provider = {} as any
+      const mockPandoraAddress = '0x1234567890123456789012345678901234567890'
+
+      const discovery = new ChainDiscovery(mockProvider, mockPandoraAddress)
+
+      // Populate cache with expired entry
+      const cacheAny = discovery as any
+      cacheAny.cache.set('expired-commp', {
+        urls: new Map([['0xprovider1', 'https://provider1.com/pdp/piece/expired-commp']]),
+        timestamp: Date.now() - (31 * 60 * 1000) // 31 minutes ago (past 30 min TTL)
+      })
+
+      // Mock provider to avoid actual calls
+      cacheAny.provider = {
+        _isProvider: true
+      }
+
+      // Should not yield expired cache entry
+      const urls: string[] = []
+      try {
+        for await (const url of discovery.findPiece('expired-commp', '0xclient')) {
+          urls.push(url)
+        }
+      } catch (e) {
+        // Expected - no URLs found
+      }
+
+      assert.equal(urls.length, 0)
+    })
+  })
+
+  describe('Custom Discovery Implementation', () => {
+    it('should allow custom discovery implementations', async () => {
+      // Create a custom discovery that always returns a specific URL
+      class StaticDiscovery implements PieceDiscovery {
+        async * findPiece (commp: string): AsyncIterable<string> {
+          yield `https://static.example.com/pieces/${commp}`
+        }
+      }
+
+      const mockSigner: ethers.Signer = {
+        getAddress: async () => '0xclient',
+        provider: {
+          getNetwork: async () => ({ chainId: 314159n })
+        }
+      } as any
+
+      const synapse = await Synapse.create({
+        signer: mockSigner,
+        pieceDiscovery: new StaticDiscovery()
+      })
+
+      // Mock fetch to succeed
+      const originalFetch = global.fetch
+      global.fetch = async (url: any) => {
+        assert.equal(url as string, 'https://static.example.com/pieces/test-commp')
+        return {
+          ok: true,
+          body: new ReadableStream({
+            start (controller) {
+              controller.enqueue(new Uint8Array([1, 2, 3]))
+              controller.close()
+            }
+          })
+        } as any
+      }
+
+      try {
+        const stream = await synapse.download('test-commp')
+        assert.exists(stream)
+        assert.instanceOf(stream, ReadableStream)
+      } finally {
+        global.fetch = originalFetch
+      }
+    })
+  })
+
+  describe('Synapse.download()', () => {
+    it('should try URLs until one succeeds', async () => {
+      // Create a discovery that yields multiple URLs
+      class MultiUrlDiscovery implements PieceDiscovery {
+        async * findPiece (): AsyncIterable<string> {
+          yield 'https://provider1.com/fail'
+          yield 'https://provider2.com/fail'
+          yield 'https://provider3.com/success'
+        }
+      }
+
+      const mockSigner: ethers.Signer = {
+        getAddress: async () => '0xclient',
+        provider: {
+          getNetwork: async () => ({ chainId: 314159n })
+        }
+      } as any
+
+      const synapse = await Synapse.create({
+        signer: mockSigner,
+        pieceDiscovery: new MultiUrlDiscovery()
+      })
+
+      // Mock fetch to fail for first two URLs, succeed for third
+      const originalFetch = global.fetch
+      let fetchCount = 0
+      global.fetch = async (url: any) => {
+        fetchCount++
+        const urlStr = url as string
+
+        if (urlStr.includes('fail')) {
+          return {
+            ok: false,
+            status: 404,
+            statusText: 'Not Found'
+          } as any
+        }
+
+        return {
+          ok: true,
+          body: new ReadableStream({
+            start (controller) {
+              controller.enqueue(new Uint8Array([1, 2, 3]))
+              controller.close()
+            }
+          })
+        } as any
+      }
+
+      try {
+        const stream = await synapse.download('test-commp')
+        assert.exists(stream)
+        assert.equal(fetchCount, 3) // Should have tried all 3 URLs
+      } finally {
+        global.fetch = originalFetch
+      }
+    })
+
+    it('should throw AggregateError when all downloads fail', async () => {
+      // Create a discovery that yields URLs that all fail
+      class FailingDiscovery implements PieceDiscovery {
+        async * findPiece (): AsyncIterable<string> {
+          yield 'https://provider1.com/fail'
+          yield 'https://provider2.com/fail'
+        }
+      }
+
+      const mockSigner: ethers.Signer = {
+        getAddress: async () => '0xclient',
+        provider: {
+          getNetwork: async () => ({ chainId: 314159n })
+        }
+      } as any
+
+      const synapse = await Synapse.create({
+        signer: mockSigner,
+        pieceDiscovery: new FailingDiscovery()
+      })
+
+      // Mock fetch to always fail
+      const originalFetch = global.fetch
+      global.fetch = async () => {
+        return {
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error'
+        } as any
+      }
+
+      try {
+        await synapse.download('test-commp')
+        assert.fail('Should have thrown error')
+      } catch (error: any) {
+        assert.include(error.message, 'All download attempts failed')
+        // The cause should be an AggregateError
+        assert.exists(error.cause)
+        assert.property(error.cause, 'errors')
+        assert.equal((error.cause as AggregateError).errors.length, 2)
+      } finally {
+        global.fetch = originalFetch
+      }
+    })
+
+    it('should throw when no URLs are found', async () => {
+      // Create a discovery that yields no URLs
+      class EmptyDiscovery implements PieceDiscovery {
+        async * findPiece (): AsyncIterable<string> {
+          // Yield nothing
+        }
+      }
+
+      const mockSigner: ethers.Signer = {
+        getAddress: async () => '0xclient',
+        provider: {
+          getNetwork: async () => ({ chainId: 314159n })
+        }
+      } as any
+
+      const synapse = await Synapse.create({
+        signer: mockSigner,
+        pieceDiscovery: new EmptyDiscovery()
+      })
+
+      try {
+        await synapse.download('test-commp')
+        assert.fail('Should have thrown error')
+      } catch (error: any) {
+        assert.include(error.message, 'Piece test-commp not found')
+      }
+    })
+
+    it('should respect providerId hint', async () => {
+      // Create a discovery that tracks providerAddress hints
+      let receivedProviderAddress: string | undefined
+
+      class TrackingDiscovery implements PieceDiscovery {
+        async * findPiece (
+          commp: string,
+          client: string,
+          options?: { providerAddress?: string }
+        ): AsyncIterable<string> {
+          receivedProviderAddress = options?.providerAddress
+          yield 'https://provider.com/piece'
+        }
+      }
+
+      const mockSigner: ethers.Signer = {
+        getAddress: async () => '0xclient',
+        provider: {
+          getNetwork: async () => ({ chainId: 314159n })
+        }
+      } as any
+
+      const discovery = new TrackingDiscovery()
+      const synapse = await Synapse.create({
+        signer: mockSigner,
+        pieceDiscovery: discovery
+      })
+
+      // Mock fetch
+      const originalFetch = global.fetch
+      global.fetch = async () => ({
+        ok: true,
+        body: new ReadableStream()
+      } as any)
+
+      try {
+        await synapse.download('test-commp', { providerAddress: '0x1234567890123456789012345678901234567890' })
+        assert.equal(receivedProviderAddress, '0x1234567890123456789012345678901234567890')
+      } finally {
+        global.fetch = originalFetch
+      }
+    })
+  })
+
+  describe('StorageService.directDownload()', () => {
+    it('should show deprecation warning for download()', async () => {
+      // This test verifies the deprecation warning exists in the code
+      // The actual warning would be shown when calling storage.download()
+      // which is tested in the storage.test.ts file
+
+      // For now, just verify the method exists and compilation succeeds
+      assert.isTrue(true)
+    })
+  })
+})

--- a/src/test/pandora-service.test.ts
+++ b/src/test/pandora-service.test.ts
@@ -598,11 +598,13 @@ describe('PandoraService', () => {
             ['tuple(address,string,string,uint256,uint256)'],
             [providerInfo]
           )
+        } else if (data?.startsWith('0x93ecb91e') === true) { // getProviderIdByAddress selector
+          return ethers.zeroPadValue('0x01', 32) // Return ID 1
         }
         return '0x' + '0'.repeat(64)
       }
 
-      const info = await pandoraService.getApprovedProvider(1)
+      const info = await pandoraService.getApprovedProviderById(1)
       assert.equal(info.owner.toLowerCase(), '0x1234567890123456789012345678901234567890')
       assert.equal(info.pdpUrl, 'https://pdp.provider.com')
       assert.equal(info.pieceRetrievalUrl, 'https://retrieval.provider.com')

--- a/src/types.ts
+++ b/src/types.ts
@@ -265,3 +265,22 @@ export interface UploadResult {
   /** Root ID in the proof set */
   rootId?: number
 }
+
+/**
+ * Interface for pluggable piece discovery
+ * Implementations yield URLs as they're found, enabling progressive discovery
+ */
+export interface PieceDiscovery {
+  /**
+   * Find URLs where a piece can be downloaded
+   * @param commp - The piece commitment (CommP) to find
+   * @param client - The client address who owns the piece
+   * @param options - Optional parameters like preferred provider
+   * @returns AsyncIterable of URLs where the piece can be downloaded
+   */
+  findPiece: (
+    commp: string,
+    client: string,
+    options?: { providerAddress?: string }
+  ) => AsyncIterable<string>
+}


### PR DESCRIPTION
Closes: https://github.com/FilOzone/synapse-sdk/issues/85

Very rough first go at this. I need to go back over this and rethink a few things. I'm considering using streams as the return type from this new API (or maybe we add `downloadStreaming()`?). Also a few things are wonky in here and smell a little bit. But the `PieceDiscovery` is the important bit here. I started off with `providerId` but I think address is more universally helpful. I just need to trace back through the code to work out how expensive that is for the common case.