### PR TITLE
feat(pdp): add transaction tracking for root additions with server verification

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -250,8 +250,10 @@ export interface PreflightInfo {
 export interface UploadCallbacks {
   /** Called when upload to storage provider completes */
   onUploadComplete?: (commp: string) => void
-  /** Called when root is added to proof set */
-  onRootAdded?: () => void
+  /** Called when root is added to proof set (with optional transaction for new servers) */
+  onRootAdded?: (transaction?: ethers.TransactionResponse) => void
+  /** Called when root addition is confirmed on-chain (new servers only) */
+  onRootConfirmed?: (rootIds: number[]) => void
 }
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -203,7 +203,18 @@ export const TIMING_CONSTANTS = {
    * Set to 0 to just get the receipt once mined without waiting for confirmations
    * Can be increased later for better finality guarantees
    */
-  TRANSACTION_CONFIRMATIONS: 0
+  TRANSACTION_CONFIRMATIONS: 0,
+
+  /**
+   * Maximum time to wait for a root addition to be confirmed and acknowledged
+   * This includes transaction confirmation and server verification
+   */
+  ROOT_ADDITION_TIMEOUT_MS: 7 * 60 * 1000, // 7 minutes
+
+  /**
+   * How often to poll for root addition status
+   */
+  ROOT_ADDITION_POLL_INTERVAL_MS: 1000 // 1 second
 } as const
 
 /**

--- a/utils/example-storage-e2e.js
+++ b/utils/example-storage-e2e.js
@@ -155,12 +155,27 @@ async function main () {
     console.log('\n--- Uploading File ---')
     console.log('Uploading to storage provider...')
 
+    // Note: With updated Curio servers, you'll get enhanced transaction tracking
+    // The callbacks below demonstrate both old and new server compatibility
+
     const uploadResult = await storageService.upload(fileData, {
       onUploadComplete: (commp) => {
         console.log(`✓ Upload complete! CommP: ${commp}`)
       },
-      onRootAdded: () => {
-        console.log('✓ Root added to proof set')
+      onRootAdded: (transaction) => {
+        if (transaction) {
+          // New enhanced callback with transaction info
+          console.log(`✓ Root addition transaction submitted: ${transaction.hash}`)
+          console.log('  Waiting for confirmation...')
+        } else {
+          // Fallback for old servers
+          console.log('✓ Root added to proof set')
+        }
+      },
+      onRootConfirmed: (rootIds) => {
+        // New callback - only called with updated servers
+        console.log('✓ Root addition confirmed on-chain!')
+        console.log(`  Assigned root IDs: ${rootIds.join(', ')}`)
       }
     })
 


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/curio/pull/530

- Read new Location header with txHash to root addition responses in Curio handlers
- Implement g endpoint for checking transaction status
- Make verification mandatory for servers that advertise tracking capability
- Add enhanced callbacks (onRootAdded with transaction, onRootConfirmed with IDs)
- Maintain backward compatibility with servers that don't provide tracking
- Add 7-minute timeout for root addition verification process