### PR TITLE
feat: add SDK methods to fetch proofset roots and metadata

### DIFF
--- a/src/pdp/server.ts
+++ b/src/pdp/server.ts
@@ -28,7 +28,7 @@
 
 import { ethers } from 'ethers'
 import type { PDPAuthHelper } from './auth.js'
-import type { RootData, CommP } from '../types.js'
+import type { RootData, CommP, ProofsetData } from '../types.js'
 import { asCommP, calculate as calculateCommP, downloadAndValidateCommP } from '../commp/index.js'
 import { constructPieceUrl, constructFindPieceUrl } from '../utils/piece.js'
 import { MULTIHASH_CODES } from '../utils/index.js'
@@ -513,6 +513,31 @@ export class PDPServer {
 
     // Use the shared download and validation function
     return await downloadAndValidateCommP(response, parsedCommP)
+  }
+
+  /**
+   * Get proof set details from the PDP server
+   * @param proofSetId - The ID of the proof set to fetch
+   * @returns Promise that resolves with proof set data
+   */
+  async getProofSet (proofSetId: string): Promise<ProofsetData> {
+    const response = await fetch(`${this._apiEndpoint}/pdp/proof-sets/${proofSetId}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json'
+      }
+    })
+
+    if (response.status === 404) {
+      throw new Error(`Proof set not found: ${proofSetId}`)
+    }
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(`Failed to fetch proof set: ${response.status} ${response.statusText} - ${errorText}`)
+    }
+
+    return await response.json() as ProofsetData
   }
 
   /**

--- a/src/storage/service.ts
+++ b/src/storage/service.ts
@@ -19,7 +19,9 @@ import type {
   UploadCallbacks,
   UploadResult,
   RootData,
-  CommP
+  CommP,
+  ProofsetData,
+  ProofsetRoot
 } from '../types.js'
 import type { Synapse } from '../synapse.js'
 import type { PandoraService } from '../pandora/service.js'
@@ -923,5 +925,30 @@ export class StorageService {
    */
   async download (commp: string | CommP, options?: DownloadOptions): Promise<Uint8Array> {
     return await this.providerDownload(commp, options)
+  }
+
+  /**
+   * Get proofset roots for a given proofset ID
+   * @param proofsetId - The ID of the proof set to fetch roots for
+   * @returns Array of root CIDs
+   */
+  async getProofsetRoots (proofsetId: string): Promise<string[]> {
+    const proofsetData = await this._pdpServer.getProofSet(proofsetId)
+    return proofsetData.roots || []
+  }
+
+  /**
+   * Get proofset roots with metadata for a given proofset ID
+   * @param proofsetId - The ID of the proof set to fetch roots for
+   * @returns Array of roots with metadata
+   */
+  async getProofsetRootsWithMetadata (proofsetId: string): Promise<ProofsetRoot[]> {
+    const proofsetData = await this._pdpServer.getProofSet(proofsetId)
+    const roots = proofsetData.roots || []
+    
+    return roots.map((rootCid, index) => ({
+      rootCid,
+      metadata: proofsetData.metadata?.[index]
+    }))
   }
 }

--- a/src/synapse.ts
+++ b/src/synapse.ts
@@ -8,7 +8,8 @@ import {
   type StorageServiceOptions,
   type FilecoinNetworkType,
   type PieceRetriever,
-  type CommP
+  type CommP,
+  type ProofsetRoot
 } from './types.js'
 import { StorageService } from './storage/index.js'
 import { PaymentsService } from './payments/index.js'
@@ -284,6 +285,26 @@ export class Synapse {
     )
 
     return await downloadAndValidateCommP(response, parsedCommP)
+  }
+
+  /**
+   * Get proofset roots for a given proofset ID
+   * @param proofsetId - The ID of the proof set to fetch roots for
+   * @returns Array of root CIDs
+   */
+  async getProofsetRoots (proofsetId: string): Promise<string[]> {
+    const storage = await this.createStorage()
+    return await storage.getProofsetRoots(proofsetId)
+  }
+
+  /**
+   * Get proofset roots with metadata for a given proofset ID
+   * @param proofsetId - The ID of the proof set to fetch roots for
+   * @returns Array of roots with metadata
+   */
+  async getProofsetRootsWithMetadata (proofsetId: string): Promise<ProofsetRoot[]> {
+    const storage = await this.createStorage()
+    return await storage.getProofsetRootsWithMetadata(proofsetId)
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -292,3 +292,25 @@ export interface UploadResult {
   /** Root ID in the proof set */
   rootId?: number
 }
+
+/**
+ * Proofset data returned from the API
+ */
+export interface ProofsetData {
+  /** The proof set ID */
+  proofSetId: number
+  /** Array of root CIDs in the proof set */
+  roots: string[]
+  /** Additional metadata (structure may vary) */
+  metadata?: any
+}
+
+/**
+ * Individual proofset root with metadata
+ */
+export interface ProofsetRoot {
+  /** The root CID */
+  rootCid: string
+  /** Optional metadata for this root */
+  metadata?: string
+}


### PR DESCRIPTION
- Add getProofSet() method to PDPServer for API calls
- Add getProofsetRoots() and getProofsetRootsWithMetadata() to StorageService
- Expose proofset methods in main Synapse class
- Add ProofsetData and ProofsetRoot type interfaces
- Eliminates need for manual Curio API calls

Resolves feature request for proofset root SDK methods

Closes #102