### PR TITLE
chore(pdp): validate server responses

### DIFF
--- a/src/pdp/index.ts
+++ b/src/pdp/index.ts
@@ -7,5 +7,16 @@ export type {
   CreateProofSetResponse,
   FindPieceResponse,
   ProofSetCreationStatusResponse,
+  RootAdditionStatusResponse,
   UploadResponse
 } from './server.js'
+
+// Export validation utilities for advanced use
+export {
+  isProofSetCreationStatusResponse,
+  isRootAdditionStatusResponse,
+  isFindPieceResponse,
+  validateProofSetCreationStatusResponse,
+  validateRootAdditionStatusResponse,
+  validateFindPieceResponse
+} from './validation.js'

--- a/src/pdp/server.ts
+++ b/src/pdp/server.ts
@@ -28,7 +28,8 @@
 
 import { ethers } from 'ethers'
 import type { PDPAuthHelper } from './auth.js'
-import type { RootData, CommP } from '../types.js'
+import type { RootData } from '../types.js'
+import type { CommP } from '../commp/index.js'
 import { asCommP, calculate as calculateCommP, downloadAndValidateCommP } from '../commp/index.js'
 import { constructPieceUrl, constructFindPieceUrl } from '../utils/piece.js'
 import { MULTIHASH_CODES } from '../utils/index.js'
@@ -80,7 +81,7 @@ export interface AddRootsResponse {
  */
 export interface FindPieceResponse {
   /** The piece CID that was found */
-  pieceCid: string
+  pieceCid: CommP
   /** @deprecated Use pieceCid instead. This field is for backward compatibility and will be removed in a future version */
   piece_cid?: string
 }
@@ -90,7 +91,7 @@ export interface FindPieceResponse {
  */
 export interface UploadResponse {
   /** CommP CID of the uploaded piece */
-  commP: string
+  commP: CommP
   /** Size of the uploaded piece in bytes */
   size: number
 }
@@ -451,7 +452,7 @@ export class PDPServer {
     if (createResponse.status === 200) {
       // Piece already exists on server
       return {
-        commP: commP.toString(),
+        commP,
         size
       }
     }
@@ -493,7 +494,7 @@ export class PDPServer {
     }
 
     return {
-      commP: commP.toString(),
+      commP,
       size
     }
   }

--- a/src/pdp/server.ts
+++ b/src/pdp/server.ts
@@ -33,6 +33,7 @@ import { asCommP, calculate as calculateCommP, downloadAndValidateCommP } from '
 import { constructPieceUrl, constructFindPieceUrl } from '../utils/piece.js'
 import { MULTIHASH_CODES } from '../utils/index.js'
 import { toHex } from 'multiformats/bytes'
+import { validateProofSetCreationStatusResponse, validateRootAdditionStatusResponse, validateFindPieceResponse } from './validation.js'
 
 /**
  * Response from creating a proof set
@@ -79,7 +80,9 @@ export interface AddRootsResponse {
  */
 export interface FindPieceResponse {
   /** The piece CID that was found */
-  piece_cid: string
+  pieceCid: string
+  /** @deprecated Use pieceCid instead. This field is for backward compatibility and will be removed in a future version */
+  piece_cid?: string
 }
 
 /**
@@ -339,7 +342,8 @@ export class PDPServer {
       throw new Error(`Failed to get proof set creation status: ${response.status} ${response.statusText} - ${errorText}`)
     }
 
-    return await response.json() as ProofSetCreationStatusResponse
+    const data = await response.json()
+    return validateProofSetCreationStatusResponse(data)
   }
 
   /**
@@ -371,7 +375,8 @@ export class PDPServer {
       throw new Error(`Failed to get root addition status: ${response.status} ${response.statusText} - ${errorText}`)
     }
 
-    return await response.json() as RootAdditionStatusResponse
+    const data = await response.json()
+    return validateRootAdditionStatusResponse(data)
   }
 
   /**
@@ -401,8 +406,8 @@ export class PDPServer {
       throw new Error(`Failed to find piece: ${response.status} ${response.statusText} - ${errorText}`)
     }
 
-    const result = await response.json() as FindPieceResponse
-    return result
+    const data = await response.json()
+    return validateFindPieceResponse(data)
   }
 
   /**

--- a/src/pdp/validation.ts
+++ b/src/pdp/validation.ts
@@ -1,0 +1,169 @@
+/**
+ * Type guards and validation utilities for PDP server responses
+ *
+ * These validators ensure that responses from untrusted PDP servers
+ * match the expected format before using them in the SDK.
+ */
+
+import type {
+  ProofSetCreationStatusResponse,
+  RootAdditionStatusResponse,
+  FindPieceResponse
+} from './server.js'
+
+/**
+ * Type guard for ProofSetCreationStatusResponse
+ * Validates the response from checking proof set creation status
+ *
+ * @param value - The value to validate
+ * @returns True if the value matches ProofSetCreationStatusResponse interface
+ */
+export function isProofSetCreationStatusResponse (value: unknown): value is ProofSetCreationStatusResponse {
+  if (typeof value !== 'object' || value == null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  // Required fields
+  if (typeof obj.createMessageHash !== 'string') {
+    return false
+  }
+  if (typeof obj.proofsetCreated !== 'boolean') {
+    return false
+  }
+  if (typeof obj.service !== 'string') {
+    return false
+  }
+  if (typeof obj.txStatus !== 'string') {
+    return false
+  }
+  if (obj.ok !== null && typeof obj.ok !== 'boolean') {
+    return false
+  }
+
+  // Optional field
+  if (obj.proofSetId !== undefined && typeof obj.proofSetId !== 'number') {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Type guard for RootAdditionStatusResponse
+ * Validates the response from checking root addition status
+ *
+ * @param value - The value to validate
+ * @returns True if the value matches RootAdditionStatusResponse interface
+ */
+export function isRootAdditionStatusResponse (value: unknown): value is RootAdditionStatusResponse {
+  if (typeof value !== 'object' || value == null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  // Required fields
+  if (typeof obj.txHash !== 'string') {
+    return false
+  }
+  if (typeof obj.txStatus !== 'string') {
+    return false
+  }
+  if (typeof obj.proofSetId !== 'number') {
+    return false
+  }
+  if (typeof obj.rootCount !== 'number') {
+    return false
+  }
+  if (obj.addMessageOk !== null && typeof obj.addMessageOk !== 'boolean') {
+    return false
+  }
+
+  // Optional field - confirmedRootIds
+  if (obj.confirmedRootIds !== undefined) {
+    if (!Array.isArray(obj.confirmedRootIds)) {
+      return false
+    }
+    // Check all elements are numbers
+    for (const id of obj.confirmedRootIds) {
+      if (typeof id !== 'number') {
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+/**
+ * Type guard for FindPieceResponse
+ * Validates the response from finding a piece
+ * Supports both pieceCid (new) and piece_cid (legacy) field names for backward compatibility
+ *
+ * @param value - The value to validate
+ * @returns True if the value matches FindPieceResponse interface
+ */
+export function isFindPieceResponse (value: unknown): value is FindPieceResponse {
+  if (typeof value !== 'object' || value == null) {
+    return false
+  }
+
+  const obj = value as Record<string, unknown>
+
+  // Accept either pieceCid (new) or piece_cid (legacy)
+  const hasPieceCid = typeof obj.pieceCid === 'string'
+  const hasPieceCidLegacy = typeof obj.piece_cid === 'string'
+
+  if (!hasPieceCid && !hasPieceCidLegacy) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Validates and returns a ProofSetCreationStatusResponse
+ * @param value - The value to validate
+ * @throws Error if validation fails
+ */
+export function validateProofSetCreationStatusResponse (value: unknown): ProofSetCreationStatusResponse {
+  if (!isProofSetCreationStatusResponse(value)) {
+    throw new Error('Invalid proof set creation status response format')
+  }
+  return value
+}
+
+/**
+ * Validates and returns a RootAdditionStatusResponse
+ * @param value - The value to validate
+ * @throws Error if validation fails
+ */
+export function validateRootAdditionStatusResponse (value: unknown): RootAdditionStatusResponse {
+  if (!isRootAdditionStatusResponse(value)) {
+    throw new Error('Invalid root addition status response format')
+  }
+  return value
+}
+
+/**
+ * Validates and returns a FindPieceResponse
+ * Normalizes the response to always have pieceCid field
+ * @param value - The value to validate
+ * @throws Error if validation fails
+ */
+export function validateFindPieceResponse (value: unknown): FindPieceResponse {
+  if (!isFindPieceResponse(value)) {
+    throw new Error('Invalid find piece response format')
+  }
+
+  const obj = value as any
+
+  // Normalize to always have pieceCid field
+  if (obj.piece_cid != null && obj.pieceCid == null) {
+    obj.pieceCid = obj.piece_cid
+  }
+
+  return obj as FindPieceResponse
+}

--- a/src/storage/service.ts
+++ b/src/storage/service.ts
@@ -698,7 +698,7 @@ export class StorageService {
     StorageService.validateRawSize(sizeBytes, 'upload')
 
     // Upload Phase: Upload data to storage provider
-    let uploadResult: { commP: string, size: number }
+    let uploadResult: { commP: CommP, size: number }
     try {
       uploadResult = await this._pdpServer.uploadPiece(dataBytes)
     } catch (error) {

--- a/src/test/pdp-validation.test.ts
+++ b/src/test/pdp-validation.test.ts
@@ -1,0 +1,205 @@
+/* globals describe it */
+import { assert } from 'chai'
+import {
+  isProofSetCreationStatusResponse,
+  isRootAdditionStatusResponse,
+  isFindPieceResponse,
+  validateProofSetCreationStatusResponse,
+  validateRootAdditionStatusResponse,
+  validateFindPieceResponse
+} from '../pdp/validation.js'
+
+describe('PDP Validation', function () {
+  describe('ProofSetCreationStatusResponse validation', function () {
+    it('should validate a valid response', function () {
+      const validResponse = {
+        createMessageHash: '0x123abc',
+        proofsetCreated: true,
+        service: 'pandora',
+        txStatus: 'confirmed',
+        ok: true,
+        proofSetId: 123
+      }
+
+      assert.isTrue(isProofSetCreationStatusResponse(validResponse))
+      assert.deepEqual(
+        validateProofSetCreationStatusResponse(validResponse),
+        validResponse
+      )
+    })
+
+    it('should validate response with null ok field', function () {
+      const validResponse = {
+        createMessageHash: '0x123abc',
+        proofsetCreated: false,
+        service: 'pandora',
+        txStatus: 'pending',
+        ok: null
+      }
+
+      assert.isTrue(isProofSetCreationStatusResponse(validResponse))
+      assert.deepEqual(
+        validateProofSetCreationStatusResponse(validResponse),
+        validResponse
+      )
+    })
+
+    it('should reject invalid responses', function () {
+      const invalidResponses = [
+        null,
+        undefined,
+        'string',
+        123,
+        [],
+        {}, // Empty object
+        { createMessageHash: 123 }, // Wrong type
+        { createMessageHash: '0x123', proofsetCreated: 'yes' }, // Wrong type
+        {
+          createMessageHash: '0x123',
+          proofsetCreated: true,
+          service: 'pandora',
+          txStatus: 'pending'
+          // Missing ok field
+        },
+        {
+          createMessageHash: '0x123',
+          proofsetCreated: true,
+          service: 'pandora',
+          txStatus: 'pending',
+          ok: null,
+          proofSetId: 'abc' // Wrong type
+        }
+      ]
+
+      for (const invalid of invalidResponses) {
+        assert.isFalse(isProofSetCreationStatusResponse(invalid))
+        assert.throws(() => validateProofSetCreationStatusResponse(invalid))
+      }
+    })
+  })
+
+  describe('RootAdditionStatusResponse validation', function () {
+    it('should validate a valid response', function () {
+      const validResponse = {
+        txHash: '0x456def',
+        txStatus: 'confirmed',
+        proofSetId: 123,
+        rootCount: 5,
+        addMessageOk: true,
+        confirmedRootIds: [1, 2, 3, 4, 5]
+      }
+
+      assert.isTrue(isRootAdditionStatusResponse(validResponse))
+      assert.deepEqual(
+        validateRootAdditionStatusResponse(validResponse),
+        validResponse
+      )
+    })
+
+    it('should validate response with null addMessageOk', function () {
+      const validResponse = {
+        txHash: '0x456def',
+        txStatus: 'pending',
+        proofSetId: 123,
+        rootCount: 5,
+        addMessageOk: null
+      }
+
+      assert.isTrue(isRootAdditionStatusResponse(validResponse))
+      assert.deepEqual(
+        validateRootAdditionStatusResponse(validResponse),
+        validResponse
+      )
+    })
+
+    it('should reject invalid responses', function () {
+      const invalidResponses = [
+        null,
+        undefined,
+        {
+          txHash: '0x456def',
+          txStatus: 'pending',
+          proofSetId: '123', // Wrong type
+          rootCount: 5,
+          addMessageOk: null
+        },
+        {
+          txHash: '0x456def',
+          txStatus: 'pending',
+          proofSetId: 123,
+          rootCount: 5,
+          addMessageOk: null,
+          confirmedRootIds: 'not-array' // Wrong type
+        },
+        {
+          txHash: '0x456def',
+          txStatus: 'pending',
+          proofSetId: 123,
+          rootCount: 5,
+          addMessageOk: null,
+          confirmedRootIds: [1, 2, 'three'] // Wrong element type
+        }
+      ]
+
+      for (const invalid of invalidResponses) {
+        assert.isFalse(isRootAdditionStatusResponse(invalid))
+        assert.throws(() => validateRootAdditionStatusResponse(invalid))
+      }
+    })
+  })
+
+  describe('FindPieceResponse validation', function () {
+    it('should validate response with legacy piece_cid field', function () {
+      const validResponse = {
+        piece_cid: 'baga6ea4seaqh5lmkfwaovjuigyp4hzclc6hqnhoqcm3re3ipumhp3kfka7wdvjq'
+      }
+
+      assert.isTrue(isFindPieceResponse(validResponse))
+      const normalized = validateFindPieceResponse(validResponse)
+      assert.equal(normalized.pieceCid, validResponse.piece_cid)
+      assert.equal(normalized.piece_cid, validResponse.piece_cid)
+    })
+
+    it('should validate response with new pieceCid field', function () {
+      const validResponse = {
+        pieceCid: 'baga6ea4seaqh5lmkfwaovjuigyp4hzclc6hqnhoqcm3re3ipumhp3kfka7wdvjq'
+      }
+
+      assert.isTrue(isFindPieceResponse(validResponse))
+      const normalized = validateFindPieceResponse(validResponse)
+      assert.equal(normalized.pieceCid, validResponse.pieceCid)
+    })
+
+    it('should validate response with both fields', function () {
+      const validResponse = {
+        pieceCid: 'baga6ea4seaqh5lmkfwaovjuigyp4hzclc6hqnhoqcm3re3ipumhp3kfka7wdvjq',
+        piece_cid: 'baga6ea4seaqh5lmkfwaovjuigyp4hzclc6hqnhoqcm3re3ipumhp3kfka7wdvjq'
+      }
+
+      assert.isTrue(isFindPieceResponse(validResponse))
+      const normalized = validateFindPieceResponse(validResponse)
+      assert.equal(normalized.pieceCid, validResponse.pieceCid)
+    })
+
+    it('should reject invalid responses', function () {
+      const invalidResponses = [
+        null,
+        undefined,
+        'string',
+        123,
+        [],
+        {},
+        { piece_cid: 123 }, // Wrong type
+        { pieceCid: 123 }, // Wrong type
+        { randomField: 'baga...' }, // Wrong field name
+        { piece_cid: null }, // Null value
+        { pieceCid: null } // Null value
+      ]
+
+      for (const invalid of invalidResponses) {
+        assert.isFalse(isFindPieceResponse(invalid))
+        assert.throws(() => validateFindPieceResponse(invalid))
+      }
+    })
+  })
+})

--- a/src/test/storage.test.ts
+++ b/src/test/storage.test.ts
@@ -1127,7 +1127,7 @@ describe('StorageService', () => {
       }
 
       const result = await service.upload(minSizeData)
-      assert.equal(result.commp, testCommP)
+      assert.equal(result.commp.toString(), testCommP)
       assert.equal(result.size, 65)
     })
 
@@ -1168,7 +1168,7 @@ describe('StorageService', () => {
 
       // Should not throw
       const result = await service.upload(maxSizeData)
-      assert.equal(result.commp, testCommP)
+      assert.equal(result.commp.toString(), testCommP)
       assert.equal(result.size, 200 * 1024 * 1024)
       assert.equal(result.rootId, 0)
     })
@@ -1213,7 +1213,7 @@ describe('StorageService', () => {
 
       const result = await service.upload(testData, {
         onUploadComplete: (commp) => {
-          assert.equal(commp, testCommP)
+          assert.equal(commp.toString(), testCommP)
           uploadCompleteCallbackFired = true
         },
         onRootAdded: () => {
@@ -1223,7 +1223,7 @@ describe('StorageService', () => {
 
       assert.isTrue(uploadCompleteCallbackFired, 'onUploadComplete should have been called')
       assert.isTrue(rootAddedCallbackFired, 'onRootAdded should have been called')
-      assert.equal(result.commp, testCommP)
+      assert.equal(result.commp.toString(), testCommP)
     })
 
     it('should handle new server with transaction tracking', async () => {
@@ -1296,7 +1296,7 @@ describe('StorageService', () => {
       try {
         const result = await service.upload(testData, {
           onUploadComplete: (commp) => {
-            assert.equal(commp, testCommP)
+            assert.equal(commp.toString(), testCommP)
             uploadCompleteCallbackFired = true
           },
           onRootAdded: (transaction) => {
@@ -1582,7 +1582,7 @@ describe('StorageService', () => {
       }
 
       const result = await service.upload(buffer)
-      assert.equal(result.commp, testCommP)
+      assert.equal(result.commp.toString(), testCommP)
       assert.equal(result.size, 1024)
     })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,7 +274,7 @@ export interface PreflightInfo {
  */
 export interface UploadCallbacks {
   /** Called when upload to storage provider completes */
-  onUploadComplete?: (commp: string) => void
+  onUploadComplete?: (commp: CommP) => void
   /** Called when root is added to proof set (with optional transaction for new servers) */
   onRootAdded?: (transaction?: ethers.TransactionResponse) => void
   /** Called when root addition is confirmed on-chain (new servers only) */
@@ -286,7 +286,7 @@ export interface UploadCallbacks {
  */
 export interface UploadResult {
   /** CommP of the uploaded data */
-  commp: string
+  commp: CommP
   /** Size of the original data */
   size: number
   /** Root ID in the proof set */


### PR DESCRIPTION
Matches Curio responses in https://github.com/filecoin-project/curio/blob/main/pdp/handlers.go

Also handle the piece_cid -> pieceCid transition in https://github.com/filecoin-project/curio/pull/547 - we're not dependent on that PR landing but if it doesn't land and this does then we'll need to wind back the `pieceCid` thing in here.