### PR TITLE
feat: add batching for parallel uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 dist/
+package-lock.json
+yarn.lock
+bun.lock
+.zed

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ interface StorageServiceOptions {
   proofSetId?: number                      // Specific proof set ID to use
   withCDN?: boolean                        // Enable CDN services
   callbacks?: StorageCreationCallbacks     // Progress callbacks
+  uploadBatchSize?: number                 // Max uploads per batch (default: 32, min: 1)
 }
 
 // Note: The withCDN option follows an inheritance pattern:
@@ -409,6 +410,26 @@ The storage service enforces the following size limits for uploads:
 - **Maximum**: 200 MiB (209,715,200 bytes)
 
 Attempting to upload data outside these limits will result in an error.
+
+##### Efficient Batch Uploads
+
+When uploading multiple files, the SDK automatically batches operations for efficiency. Due to blockchain transaction ordering requirements, uploads are processed sequentially. To maximize efficiency:
+
+```javascript
+// Efficient: Start all uploads without await - they'll be batched automatically
+const uploads = []
+for (const data of dataArray) {
+  uploads.push(storage.upload(data))  // No await here
+}
+const results = await Promise.all(uploads)
+
+// Less efficient: Awaiting each upload forces sequential processing
+for (const data of dataArray) {
+  await storage.upload(data)  // Each waits for the previous to complete
+}
+```
+
+The SDK batches up to 32 uploads by default (configurable via `uploadBatchSize`). If you have more than 32 files, they'll be processed in multiple batches automatically.
 
 ### Storage Information
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -298,6 +298,8 @@ export interface StorageServiceOptions {
   withCDN?: boolean
   /** Callbacks for creation process */
   callbacks?: StorageCreationCallbacks
+  /** Maximum number of uploads to process in a single batch (default: 32, minimum: 1) */
+  uploadBatchSize?: number
 }
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -183,7 +183,13 @@ export const SIZE_CONSTANTS = {
    * Minimum upload size (65 bytes)
    * CommP calculation requires at least 65 bytes
    */
-  MIN_UPLOAD_SIZE: 65
+  MIN_UPLOAD_SIZE: 65,
+
+  /**
+   * Default number of uploads to batch together in a single addRoots transaction
+   * This balances gas efficiency with reasonable transaction sizes
+   */
+  DEFAULT_UPLOAD_BATCH_SIZE: 32
 } as const
 
 /**


### PR DESCRIPTION
Issue : #101 

When storage.upload is called:
	1.The file uploads immediately.
	2. Its CID is added to a list (roots array) and is immediately processed
	3. During the batch process of the addRoot , if more files are uploaded , their CIDs are added to the list for the next batch upload
