### PR TITLE
feat: add ping method to check connectivity with storage provider

### DIFF
--- a/src/pdp/server.ts
+++ b/src/pdp/server.ts
@@ -566,6 +566,23 @@ export class PDPServer {
     return encoded.slice(2)
   }
 
+  /**
+   * Ping the storage provider to check connectivity
+   * @returns Promise that resolves if provider is reachable (200 response)
+   * @throws Error if provider is not reachable or returns non-200 status
+   */
+  async ping (): Promise<void> {
+    const response = await fetch(`${this._apiEndpoint}/ping`, {
+      method: 'GET',
+      headers: {}
+    })
+
+    if (response.status !== 200) {
+      const errorText = await response.text().catch(() => 'Unknown error')
+      throw new Error(`Provider ping failed: ${response.status} ${response.statusText} - ${errorText}`)
+    }
+  }
+
   getApiEndpoint (): string {
     return this._apiEndpoint
   }


### PR DESCRIPTION
## Add provider ping functionality to PDPServer

Implements basic provider connectivity validation by adding a `ping()` method to the `PDPServer` class. The method:

- Makes a GET request to the provider's `/ping` endpoint
- Validates 200 response status 
- Throws errors for non-200 responses or connection failures

This enables checking provider reachability before proceeding with storage operations. Part of #116 - provider selection improvements.

**Related:** Additional PR will follow with provider selection retry logic that uses this ping functionality.