### PR TITLE
feat: implement SynapseStorage#pieceStatus(commp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,12 @@ const downloaded = await storage.providerDownload(result.commp)
 // Get the list of root CIDs in the current proof set by querying the provider
 const rootCids = await storage.getProofSetRoots()
 console.log(`Root CIDs: ${rootCids.map(cid => cid.toString()).join(', ')}`)
+
+// Check the status of a piece on the storage provider
+const status = await storage.pieceStatus(result.commp)
+console.log(`Piece exists: ${status.exists}`)
+console.log(`Proof set last proven: ${status.proofSetLastProven}`)
+console.log(`Proof set next proof due: ${status.proofSetNextProofDue}`)
 ```
 
 **Storage Service Methods:**
@@ -392,6 +398,7 @@ console.log(`Root CIDs: ${rootCids.map(cid => cid.toString()).join(', ')}`)
 - `preflightUpload(dataSize)` - Check if an upload is possible before attempting it
 - `getProviderInfo()` - Get detailed information about the selected storage provider
 - `getProofSetRoots()` - Get the list of root CIDs in the proof set by querying the provider
+- `pieceStatus(commp)` - Get the status of a piece including proof set timing information
 
 ##### Size Constraints
 

--- a/src/pandora/service.ts
+++ b/src/pandora/service.ts
@@ -879,4 +879,75 @@ export class PandoraService {
       epochsPerMonth: result.epochsPerMonth
     }
   }
+
+  // ========== Proving Period Operations ==========
+
+  /**
+   * Get the maximum proving period in epochs
+   * This is the maximum time allowed between proofs before a fault is recorded
+   * @returns Maximum proving period in epochs
+   */
+  async getMaxProvingPeriod (): Promise<number> {
+    const contract = this._getPandoraContract()
+    const maxProvingPeriod = await contract.getMaxProvingPeriod()
+    return Number(maxProvingPeriod)
+  }
+
+  /**
+   * Get the challenge window size in epochs
+   * This is the window at the end of each proving period where proofs can be submitted
+   * @returns Challenge window size in epochs
+   */
+  async getChallengeWindow (): Promise<number> {
+    const contract = this._getPandoraContract()
+    const challengeWindow = await contract.challengeWindow()
+    return Number(challengeWindow)
+  }
+
+  /**
+   * Get the maximum proving period in hours
+   * Convenience method that converts epochs to hours
+   * @returns Maximum proving period in hours
+   */
+  async getProvingPeriodInHours (): Promise<number> {
+    const maxProvingPeriod = await this.getMaxProvingPeriod()
+    // Convert epochs to hours: epochs * 30 seconds / 3600 seconds per hour
+    return (maxProvingPeriod * 30) / 3600
+  }
+
+  /**
+   * Get the challenge window in minutes
+   * Convenience method that converts epochs to minutes
+   * @returns Challenge window in minutes
+   */
+  async getChallengeWindowInMinutes (): Promise<number> {
+    const challengeWindow = await this.getChallengeWindow()
+    // Convert epochs to minutes: epochs * 30 seconds / 60 seconds per minute
+    return (challengeWindow * 30) / 60
+  }
+
+  /**
+   * Get comprehensive proving period information
+   * @returns Object with all proving period timing information
+   */
+  async getProvingPeriodInfo (): Promise<{
+    maxProvingPeriodEpochs: number
+    challengeWindowEpochs: number
+    maxProvingPeriodHours: number
+    challengeWindowMinutes: number
+    epochDurationSeconds: number
+  }> {
+    const [maxProvingPeriod, challengeWindow] = await Promise.all([
+      this.getMaxProvingPeriod(),
+      this.getChallengeWindow()
+    ])
+
+    return {
+      maxProvingPeriodEpochs: maxProvingPeriod,
+      challengeWindowEpochs: challengeWindow,
+      maxProvingPeriodHours: (maxProvingPeriod * 30) / 3600,
+      challengeWindowMinutes: (challengeWindow * 30) / 60,
+      epochDurationSeconds: 30
+    }
+  }
 }

--- a/src/test/epoch.test.ts
+++ b/src/test/epoch.test.ts
@@ -1,0 +1,142 @@
+/* globals describe it */
+import { assert } from 'chai'
+import {
+  epochToDate,
+  dateToEpoch,
+  getGenesisTimestamp,
+  timeUntilEpoch,
+  calculateLastProofDate
+} from '../utils/epoch.js'
+import { GENESIS_TIMESTAMPS, TIME_CONSTANTS } from '../utils/constants.js'
+
+describe('Epoch Utilities', () => {
+  describe('epochToDate', () => {
+    it('should convert epoch 0 to genesis timestamp for mainnet', () => {
+      const date = epochToDate(0, 'mainnet')
+      assert.equal(date.getTime(), GENESIS_TIMESTAMPS.mainnet * 1000)
+    })
+
+    it('should convert epoch 0 to genesis timestamp for calibration', () => {
+      const date = epochToDate(0, 'calibration')
+      assert.equal(date.getTime(), GENESIS_TIMESTAMPS.calibration * 1000)
+    })
+
+    it('should calculate correct date for future epochs', () => {
+      const epochsPerDay = 24 * 60 * 2 // 2880 epochs per day
+      const date = epochToDate(epochsPerDay, 'mainnet')
+      const expectedTime = (GENESIS_TIMESTAMPS.mainnet + epochsPerDay * TIME_CONSTANTS.EPOCH_DURATION) * 1000
+      assert.equal(date.getTime(), expectedTime)
+    })
+
+    it('should handle large epoch numbers', () => {
+      const largeEpoch = 1000000
+      const date = epochToDate(largeEpoch, 'calibration')
+      const expectedTime = (GENESIS_TIMESTAMPS.calibration + largeEpoch * TIME_CONSTANTS.EPOCH_DURATION) * 1000
+      assert.equal(date.getTime(), expectedTime)
+    })
+  })
+
+  describe('dateToEpoch', () => {
+    it('should convert genesis date to epoch 0 for mainnet', () => {
+      const genesisDate = new Date(GENESIS_TIMESTAMPS.mainnet * 1000)
+      const epoch = dateToEpoch(genesisDate, 'mainnet')
+      assert.equal(epoch, 0)
+    })
+
+    it('should convert genesis date to epoch 0 for calibration', () => {
+      const genesisDate = new Date(GENESIS_TIMESTAMPS.calibration * 1000)
+      const epoch = dateToEpoch(genesisDate, 'calibration')
+      assert.equal(epoch, 0)
+    })
+
+    it('should calculate correct epoch for future dates', () => {
+      const futureDate = new Date((GENESIS_TIMESTAMPS.mainnet + 3600) * 1000) // 1 hour after genesis
+      const epoch = dateToEpoch(futureDate, 'mainnet')
+      assert.equal(epoch, 120) // 3600 seconds / 30 seconds per epoch
+    })
+
+    it('should round down to nearest epoch', () => {
+      const partialEpochDate = new Date((GENESIS_TIMESTAMPS.calibration + 45) * 1000) // 1.5 epochs
+      const epoch = dateToEpoch(partialEpochDate, 'calibration')
+      assert.equal(epoch, 1) // Should round down
+    })
+  })
+
+  describe('getGenesisTimestamp', () => {
+    it('should return correct timestamp for mainnet', () => {
+      const timestamp = getGenesisTimestamp('mainnet')
+      assert.equal(timestamp, GENESIS_TIMESTAMPS.mainnet)
+    })
+
+    it('should return correct timestamp for calibration', () => {
+      const timestamp = getGenesisTimestamp('calibration')
+      assert.equal(timestamp, GENESIS_TIMESTAMPS.calibration)
+    })
+  })
+
+  describe('timeUntilEpoch', () => {
+    it('should calculate correct time difference', () => {
+      const currentEpoch = 1000
+      const futureEpoch = 1120 // 120 epochs in the future = 1 hour
+      const result = timeUntilEpoch(futureEpoch, currentEpoch)
+
+      assert.equal(result.epochs, 120)
+      assert.equal(result.seconds, 3600)
+      assert.equal(result.minutes, 60)
+      assert.equal(result.hours, 1)
+      assert.equal(result.days, 1 / 24)
+    })
+
+    it('should handle same epoch', () => {
+      const result = timeUntilEpoch(1000, 1000)
+
+      assert.equal(result.epochs, 0)
+      assert.equal(result.seconds, 0)
+      assert.equal(result.minutes, 0)
+      assert.equal(result.hours, 0)
+      assert.equal(result.days, 0)
+    })
+
+    it('should handle negative differences (past epochs)', () => {
+      const result = timeUntilEpoch(1000, 1120)
+
+      assert.equal(result.epochs, -120)
+      assert.equal(result.seconds, -3600)
+      assert.equal(result.minutes, -60)
+      assert.equal(result.hours, -1)
+      assert.equal(result.days, -1 / 24)
+    })
+  })
+
+  describe('calculateLastProofDate', () => {
+    it('should return null when nextChallengeEpoch is 0', () => {
+      const result = calculateLastProofDate(0, 2880, 'mainnet')
+      assert.isNull(result)
+    })
+
+    it('should return null when in first proving period', () => {
+      const result = calculateLastProofDate(100, 2880, 'mainnet')
+      assert.isNull(result)
+    })
+
+    it('should calculate correct last proof date', () => {
+      const nextChallengeEpoch = 5760 // 2 days worth of epochs
+      const maxProvingPeriod = 2880 // 1 day
+      const result = calculateLastProofDate(nextChallengeEpoch, maxProvingPeriod, 'mainnet')
+
+      assert.isNotNull(result)
+      // Last proof should be at epoch 2880 (5760 - 2880)
+      const expectedDate = epochToDate(2880, 'mainnet')
+      assert.equal(result?.getTime(), expectedDate.getTime())
+    })
+
+    it('should handle edge case at proving period boundary', () => {
+      const nextChallengeEpoch = 2880
+      const maxProvingPeriod = 2880
+      const result = calculateLastProofDate(nextChallengeEpoch, maxProvingPeriod, 'mainnet')
+
+      // Should return null since lastProofEpoch would be 0
+      assert.isNull(result)
+    })
+  })
+})

--- a/src/test/pandora-service.test.ts
+++ b/src/test/pandora-service.test.ts
@@ -1544,4 +1544,59 @@ describe('PandoraService', () => {
       mockProvider.getTransactionReceipt = originalGetTransactionReceipt
     })
   })
+
+  describe('getMaxProvingPeriod() and getChallengeWindow()', () => {
+    it('should return max proving period from contract', async () => {
+      // Mock contract call
+      const originalCall = mockProvider.call
+      mockProvider.call = async ({ data }: any) => {
+        // Check if it's the getMaxProvingPeriod call
+        if (typeof data === 'string' && data.includes('0x')) {
+          // Return encoded uint64 value of 2880
+          return '0x0000000000000000000000000000000000000000000000000000000000000b40'
+        }
+        return '0x'
+      }
+
+      const result = await pandoraService.getMaxProvingPeriod()
+      assert.equal(result, 2880)
+
+      mockProvider.call = originalCall
+    })
+
+    it('should return challenge window from contract', async () => {
+      // Mock contract call
+      const originalCall = mockProvider.call
+      mockProvider.call = async ({ data }: any) => {
+        // Check if it's the getChallengeWindow call
+        if (typeof data === 'string' && data.includes('0x')) {
+          // Return encoded uint256 value of 60
+          return '0x000000000000000000000000000000000000000000000000000000000000003c'
+        }
+        return '0x'
+      }
+
+      const result = await pandoraService.getChallengeWindow()
+      assert.equal(result, 60)
+
+      mockProvider.call = originalCall
+    })
+
+    it('should handle contract call failures', async () => {
+      // Mock contract call to throw error
+      const originalCall = mockProvider.call
+      mockProvider.call = async () => {
+        throw new Error('Contract call failed')
+      }
+
+      try {
+        await pandoraService.getMaxProvingPeriod()
+        assert.fail('Should have thrown error')
+      } catch (error: any) {
+        assert.include(error.message, 'Contract call failed')
+      }
+
+      mockProvider.call = originalCall
+    })
+  })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -438,3 +438,27 @@ export interface ProofSetRootData {
   /** Sub-root offset */
   subrootOffset: number
 }
+
+/**
+ * Status information for a piece stored on a provider
+ * Note: Proofs are submitted for entire proof sets, not individual pieces.
+ * The timing information reflects the proof set's status.
+ */
+export interface PieceStatus {
+  /** Whether the piece exists on the storage provider */
+  exists: boolean
+  /** When the proof set containing this piece was last proven on-chain (null if never proven or not yet due) */
+  proofSetLastProven: Date | null
+  /** When the next proof is due for the proof set containing this piece (end of challenge window) */
+  proofSetNextProofDue: Date | null
+  /** URL where the piece can be retrieved (null if not available) */
+  retrievalUrl: string | null
+  /** The root ID if the piece is in the proof set */
+  rootId?: number
+  /** Whether the proof set is currently in a challenge window */
+  inChallengeWindow?: boolean
+  /** Time until the proof set enters the challenge window (in hours) */
+  hoursUntilChallengeWindow?: number
+  /** Whether the proof is overdue (past the challenge window without being submitted) */
+  isProofOverdue?: boolean
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -83,7 +83,13 @@ export const CONTRACT_ABIS = {
     'function railToProofSet(uint256 railId) external view returns (uint256 proofSetId)',
 
     // Get proof set info by ID
-    'function getProofSet(uint256 id) public view returns (tuple(uint256 railId, address payer, address payee, uint256 commissionBps, string metadata, string[] rootMetadata, uint256 clientDataSetId, bool withCDN) info)'
+    'function getProofSet(uint256 id) public view returns (tuple(uint256 railId, address payer, address payee, uint256 commissionBps, string metadata, string[] rootMetadata, uint256 clientDataSetId, bool withCDN) info)',
+
+    // Proving period and timing functions
+    'function getMaxProvingPeriod() external view returns (uint64)',
+    'function challengeWindow() external view returns (uint256)',
+    'function maxProvingPeriod() external view returns (uint64)',
+    'function challengeWindowSize() external view returns (uint256)'
   ] as const,
 
   /**
@@ -127,6 +133,20 @@ export const TIME_CONSTANTS = {
    * Default lockup period in days
    */
   DEFAULT_LOCKUP_DAYS: 10n
+} as const
+
+/**
+ * Genesis timestamps for Filecoin networks (Unix timestamp in seconds)
+ */
+export const GENESIS_TIMESTAMPS: Record<FilecoinNetworkType, number> = {
+  /**
+   * Mainnet genesis: August 24, 2020 22:00:00 UTC
+   */
+  mainnet: 1598306400,
+  /**
+   * Calibration testnet genesis: November 1, 2022 18:13:00 UTC
+   */
+  calibration: 1667326380
 } as const
 
 /**

--- a/src/utils/epoch.ts
+++ b/src/utils/epoch.ts
@@ -1,0 +1,96 @@
+/**
+ * Epoch to date conversion utilities for Filecoin networks
+ */
+
+import type { FilecoinNetworkType } from '../types.js'
+import { TIME_CONSTANTS, GENESIS_TIMESTAMPS } from './constants.js'
+
+/**
+ * Convert a Filecoin epoch to a JavaScript Date
+ * @param epoch - The epoch number to convert
+ * @param network - The Filecoin network (mainnet or calibration)
+ * @returns Date object representing the epoch time
+ */
+export function epochToDate (epoch: number, network: FilecoinNetworkType): Date {
+  const genesisTimestamp = GENESIS_TIMESTAMPS[network]
+  const epochDuration = TIME_CONSTANTS.EPOCH_DURATION
+  const timestampSeconds = genesisTimestamp + (epoch * epochDuration)
+  return new Date(timestampSeconds * 1000) // Convert to milliseconds
+}
+
+/**
+ * Convert a JavaScript Date to a Filecoin epoch
+ * @param date - The date to convert
+ * @param network - The Filecoin network (mainnet or calibration)
+ * @returns The epoch number (rounded down to nearest epoch)
+ */
+export function dateToEpoch (date: Date, network: FilecoinNetworkType): number {
+  const genesisTimestamp = GENESIS_TIMESTAMPS[network]
+  const epochDuration = TIME_CONSTANTS.EPOCH_DURATION
+  const timestampSeconds = Math.floor(date.getTime() / 1000)
+  const secondsSinceGenesis = timestampSeconds - genesisTimestamp
+  return Math.floor(secondsSinceGenesis / epochDuration)
+}
+
+/**
+ * Get the genesis timestamp for a network
+ * @param network - The Filecoin network
+ * @returns Genesis timestamp in seconds (Unix timestamp)
+ */
+export function getGenesisTimestamp (network: FilecoinNetworkType): number {
+  return GENESIS_TIMESTAMPS[network]
+}
+
+/**
+ * Calculate the time until a future epoch
+ * @param futureEpoch - The future epoch number
+ * @param currentEpoch - The current epoch number
+ * @returns Object with time until the epoch in various units
+ */
+export function timeUntilEpoch (futureEpoch: number, currentEpoch: number): {
+  epochs: number
+  seconds: number
+  minutes: number
+  hours: number
+  days: number
+} {
+  const epochDifference = futureEpoch - currentEpoch
+  const seconds = epochDifference * TIME_CONSTANTS.EPOCH_DURATION
+
+  return {
+    epochs: epochDifference,
+    seconds,
+    minutes: seconds / 60,
+    hours: seconds / 3600,
+    days: seconds / 86400
+  }
+}
+
+/**
+ * Calculate when the last proof should have been submitted based on current time
+ * @param nextChallengeEpoch - The next challenge epoch from the proof set
+ * @param maxProvingPeriod - The maximum proving period in epochs
+ * @param network - The Filecoin network
+ * @returns Date when the last proof should have been submitted, or null if no proof submitted yet
+ */
+export function calculateLastProofDate (
+  nextChallengeEpoch: number,
+  maxProvingPeriod: number,
+  network: FilecoinNetworkType
+): Date | null {
+  // If nextChallengeEpoch is 0, no proofs scheduled
+  if (nextChallengeEpoch === 0) {
+    return null
+  }
+
+  // The last proof should have been submitted before the current proving period started
+  // Current proving period starts at nextChallengeEpoch - maxProvingPeriod
+  const lastProofEpoch = nextChallengeEpoch - maxProvingPeriod
+
+  // If this is negative, we're in the first proving period
+  if (lastProofEpoch <= 0) {
+    return null
+  }
+
+  return epochToDate(lastProofEpoch, network)
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { createError } from './errors.js'
 export * from './constants.js'
 export { constructPieceUrl, constructFindPieceUrl } from './piece.js'
+export * from './epoch.js'

--- a/utils/example-piece-status.js
+++ b/utils/example-piece-status.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+/**
+ * Example: Check Piece Status
+ *
+ * This example demonstrates how to check the status of a piece stored on Filecoin,
+ * including whether it exists, when it was last proven, and when the next proof is due.
+ *
+ * Usage:
+ *   node example-piece-status.js <commp> [providerAddress[, proofSetId]]
+ *
+ * Arguments:
+ *   commp           - Required: The CommP (piece commitment) to check
+ *   providerAddress - Optional: Specific provider address to check
+ *   proofSetId      - Optional: Specific proof set ID to use
+ *
+ * Environment variables:
+ *   PRIVATE_KEY     - Your Ethereum private key (with 0x prefix)
+ *   RPC_URL         - Filecoin RPC endpoint (defaults to calibration)
+ *   PANDORA_ADDRESS - Pandora service contract address (optional)
+ *   LOCALE          - Date/time locale (optional, defaults to system locale)
+ *
+ * Examples:
+ *   # Check piece on any provider
+ *   PRIVATE_KEY=0x... node example-piece-status.js baga6ea4seaq...
+ *
+ *   # Check piece on specific provider
+ *   PRIVATE_KEY=0x... node example-piece-status.js baga6ea4seaq... 0x123...
+ *
+ *   # Check piece with specific provider and proof set
+ *   PRIVATE_KEY=0x... node example-piece-status.js baga6ea4seaq... 0x123... 456
+ */
+
+import { Synapse } from '@filoz/synapse-sdk'
+
+// Configuration from environment
+const PRIVATE_KEY = process.env.PRIVATE_KEY
+const RPC_URL = process.env.RPC_URL || 'https://api.calibration.node.glif.io/rpc/v1'
+const PANDORA_ADDRESS = process.env.PANDORA_ADDRESS // Optional
+
+// Parse command line arguments
+const args = process.argv.slice(2)
+const commp = args[0]
+const providerAddress = args[1]
+const proofSetId = args[2] ? parseInt(args[2]) : undefined
+
+// Validate inputs
+if (!PRIVATE_KEY) {
+  console.error('ERROR: PRIVATE_KEY environment variable is required')
+  console.error('Usage: PRIVATE_KEY=0x... node example-piece-status.js <commp> [providerAddress[, proofSetId]]')
+  process.exit(1)
+}
+
+if (!commp) {
+  console.error('ERROR: CommP argument is required')
+  console.error('Usage: PRIVATE_KEY=0x... node example-piece-status.js <commp> [providerAddress[, proofSetId]]')
+  process.exit(1)
+}
+
+// Get user's locale or fallback to en-US
+const userLocale = process.env.LOCALE || Intl.DateTimeFormat().resolvedOptions().locale || 'en-US'
+
+// Date formatting options
+const dateTimeOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: true
+}
+
+// Helper to format dates in user's locale
+function formatDate (date) {
+  if (!date) return 'N/A'
+  return date.toLocaleString(userLocale, dateTimeOptions)
+}
+
+// Helper to format time differences
+function formatTimeDiff (date) {
+  if (!date) return 'N/A'
+
+  const now = new Date()
+  const diff = date.getTime() - now.getTime()
+  const absDiff = Math.abs(diff)
+
+  const hours = Math.floor(absDiff / (1000 * 60 * 60))
+  const minutes = Math.floor((absDiff % (1000 * 60 * 60)) / (1000 * 60))
+
+  let timeStr = ''
+  if (hours > 0) {
+    timeStr = `${hours} hour${hours !== 1 ? 's' : ''}`
+    if (minutes > 0) {
+      timeStr += ` ${minutes} minute${minutes !== 1 ? 's' : ''}`
+    }
+  } else {
+    timeStr = `${minutes} minute${minutes !== 1 ? 's' : ''}`
+  }
+
+  return diff > 0 ? `in ${timeStr}` : `${timeStr} ago`
+}
+
+async function main () {
+  try {
+    console.log('=== Piece Status Check ===\n')
+    console.log(`Date: ${formatDate(new Date())}`)
+    console.log(`\nCommP: ${commp}`)
+    if (providerAddress) {
+      console.log(`Provider: ${providerAddress}`)
+    }
+    if (proofSetId !== undefined) {
+      console.log(`Proof Set ID: ${proofSetId}`)
+    }
+
+    // Initialize Synapse SDK
+    console.log('\nInitializing Synapse SDK...')
+    const synapseOptions = {
+      privateKey: PRIVATE_KEY,
+      rpcURL: RPC_URL
+    }
+
+    if (PANDORA_ADDRESS) {
+      synapseOptions.pandoraAddress = PANDORA_ADDRESS
+    }
+
+    const synapse = await Synapse.create(synapseOptions)
+    console.log('✓ Synapse instance created')
+
+    // Create storage service
+    console.log('\nCreating storage service...')
+    const storageOptions = {}
+
+    // Add provider address if specified
+    if (providerAddress) {
+      storageOptions.providerAddress = providerAddress
+    }
+
+    // Add proof set ID if specified
+    if (proofSetId !== undefined) {
+      storageOptions.proofSetId = proofSetId
+    }
+
+    // Add callbacks to show what's happening
+    storageOptions.callbacks = {
+      onProviderSelected: (provider) => {
+        console.log(`✓ Using provider: ${provider.owner}`)
+      },
+      onProofSetResolved: (info) => {
+        console.log(`✓ Using proof set: ${info.proofSetId}`)
+      }
+    }
+
+    const storage = await synapse.createStorage(storageOptions)
+
+    // Check piece status
+    console.log('\n--- Checking Piece Status ---')
+    const status = await storage.pieceStatus(commp)
+
+    // Display results
+    console.log('\n📊 Piece Status Report:')
+    console.log('─'.repeat(50))
+
+    // Basic status
+    console.log(`\n✅ Exists on provider: ${status.exists ? 'Yes' : 'No'}`)
+
+    if (!status.exists) {
+      console.log('\n❌ This piece does not exist on the selected storage provider.')
+      return
+    }
+
+    // Retrieval URL
+    if (status.retrievalUrl) {
+      console.log(`\n🔗 Retrieval URL: ${status.retrievalUrl}`)
+    }
+
+    // Root ID
+    if (status.rootId !== undefined) {
+      console.log(`\n🆔 Root ID: ${status.rootId}`)
+    }
+
+    // Proof timing
+    console.log('\n⏱️  Proof Set Timing (proofs cover all pieces in the set):')
+
+    if (status.proofSetLastProven) {
+      console.log(`   Proof set last proven: ${formatDate(status.proofSetLastProven)} (${formatTimeDiff(status.proofSetLastProven)})`)
+    } else {
+      console.log('   Proof set last proven: Never (proof set not yet proven)')
+    }
+
+    if (status.proofSetNextProofDue) {
+      console.log(`   Proof set next proof due: ${formatDate(status.proofSetNextProofDue)} (${formatTimeDiff(status.proofSetNextProofDue)})`)
+
+      // Challenge window status
+      if (status.isProofOverdue) {
+        console.log('\n🚨 PROOF IS OVERDUE!')
+        console.log('   The storage provider has missed the proof deadline and may face penalties.')
+      } else if (status.inChallengeWindow) {
+        // Calculate time remaining in challenge window
+        const timeRemaining = status.proofSetNextProofDue.getTime() - new Date().getTime()
+        const minutesRemaining = Math.floor(timeRemaining / (1000 * 60))
+        console.log('\n⚠️  CURRENTLY IN CHALLENGE WINDOW!')
+        console.log(`   The storage provider has ${minutesRemaining} minutes to submit a proof.`)
+      } else if (status.hoursUntilChallengeWindow !== undefined && status.hoursUntilChallengeWindow > 0) {
+        console.log(`\n⏳ Challenge window opens in: ${status.hoursUntilChallengeWindow.toFixed(1)} hours`)
+      }
+    } else {
+      console.log('   Proof set next proof due: Not scheduled')
+    }
+
+    // Additional info
+    console.log('\n📝 Storage Details:')
+    console.log(`   Provider: ${storage.storageProvider}`)
+    console.log(`   Proof Set: ${storage.proofSetId}`)
+
+    // Summary
+    console.log('\n' + '─'.repeat(50))
+    if (status.isProofOverdue) {
+      console.log('🚨 Status: PROOF OVERDUE - Penalties may apply')
+    } else if (status.inChallengeWindow) {
+      console.log('⚠️  Status: Proof urgently needed')
+    } else if (status.hoursUntilChallengeWindow && status.hoursUntilChallengeWindow < 24) {
+      console.log('⏰ Status: Proof needed soon')
+    } else if (status.proofSetNextProofDue) {
+      console.log('✅ Status: All good')
+    } else {
+      console.log('❓ Status: Unknown (no proof schedule)')
+    }
+  } catch (error) {
+    console.error('\n❌ Error:', error.message)
+    if (error.cause) {
+      console.error('Caused by:', error.cause.message)
+    }
+    process.exit(1)
+  }
+}
+
+// Run the example
+main().catch(console.error)

--- a/utils/example-storage-e2e.js
+++ b/utils/example-storage-e2e.js
@@ -216,7 +216,23 @@ async function main () {
       process.exit(1)
     }
 
-    // Step 9: Show storage info
+    // Step 9: Check piece status
+    console.log('\n--- Piece Status ---')
+    const pieceStatus = await storageService.pieceStatus(uploadResult.commp)
+    console.log(`Piece exists on provider: ${pieceStatus.exists}`)
+    if (pieceStatus.proofSetLastProven) {
+      console.log(`Proof set last proven: ${pieceStatus.proofSetLastProven.toLocaleString()}`)
+    }
+    if (pieceStatus.proofSetNextProofDue) {
+      console.log(`Proof set next proof due: ${pieceStatus.proofSetNextProofDue.toLocaleString()}`)
+    }
+    if (pieceStatus.inChallengeWindow) {
+      console.log('⚠️  Currently in challenge window - proof must be submitted soon!')
+    } else if (pieceStatus.hoursUntilChallengeWindow && pieceStatus.hoursUntilChallengeWindow > 0) {
+      console.log(`Hours until challenge window: ${pieceStatus.hoursUntilChallengeWindow.toFixed(1)}`)
+    }
+
+    // Step 10: Show storage info
     console.log('\n--- Storage Information ---')
     console.log('Your file is now stored on the Filecoin network with:')
     console.log(`- Piece CID / hash (CommP): ${uploadResult.commp}`)


### PR DESCRIPTION
Currently just on the `SynapseStorage`, so you must already have the provider and proof set that you're querying. Doesn't yet work with a generic commp unassociated with a provider. We can add that, but I think it might involve scanning providers for your piece (currently) or using a subgraph. I'm also concerned about how a call not associated with a provider will work; while we can do `Synapse#pieceStatus(commp)`, I don't think it's obvious that it would be potentially a lot more work than just against a specific provider. I need to think about how we're building out these APIs between `Synapse` and `SynapseStorage`, something needs to change for this to smell less.

But this seems to work OK. Not super quick, it has to make a few calls to various places, but gets what we need.

```
$ PRIVATE_KEY="0x123..." node ./utils/example-piece-status.js baga6ea4seaqbw2iafjrl4y2cf2xupbyl5wmf6fhxey363tnrjekpmgbfcegx4oy 0xe9bc394383B67aBcEbe86FD9843F53d8B4a2E981 292
=== Piece Status Check ===

Date: 10 July 2025, 9:37:27 pm

CommP: baga6ea4seaqbw2iafjrl4y2cf2xupbyl5wmf6fhxey363tnrjekpmgbfcegx4oy
Provider: 0xe9bc394383B67aBcEbe86FD9843F53d8B4a2E981
Proof Set ID: 292

Initializing Synapse SDK...
✓ Synapse instance created

Creating storage service...
✓ Using provider: 0xe9bc394383B67aBcEbe86FD9843F53d8B4a2E981
✓ Using proof set: 292

--- Checking Piece Status ---

📊 Piece Status Report:
──────────────────────────────────────────────────

✅ Exists on provider: Yes

🔗 Retrieval URL: https://polynomial.computer/piece/baga6ea4seaqbw2iafjrl4y2cf2xupbyl5wmf6fhxey363tnrjekpmgbfcegx4oy

🆔 Root ID: 25

⏱️  Proof Set Timing (proofs cover all pieces in the set):
   Proof set last proven: 10 July 2025, 9:29:30 pm (8 minutes ago)
   Proof set next proof due: 10 July 2025, 9:52:00 pm (in 14 minutes)

⏳ Challenge window opens in: 0.1 hours

📝 Storage Details:
   Provider: 0xe9bc394383B67aBcEbe86FD9843F53d8B4a2E981
   Proof Set: 292

──────────────────────────────────────────────────
⏰ Status: Proof needed soon
```