### PR TITLE
First draft moving to mk12

### DIFF
--- a/src/pdp/server.ts
+++ b/src/pdp/server.ts
@@ -171,7 +171,7 @@ export class PDPServer {
     }
 
     // Make the POST request to create the data set
-    const response = await fetch(`${this._serviceURL}/pdp/data-sets`, {
+    const response = await fetch(`${this._serviceURL}/market/pdp/data-sets`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -191,8 +191,8 @@ export class PDPServer {
     }
 
     // Parse the location to extract the transaction hash
-    // Expected format: /pdp/data-sets/created/{txHash}
-    const locationMatch = location.match(/\/pdp\/data-sets\/created\/(.+)$/)
+    // Expected format: /market/pdp/data-sets/created/{txHash}
+    const locationMatch = location.match(/\/market\/pdp\/data-sets\/created\/(.+)$/)
     if (locationMatch == null) {
       throw new Error(`Invalid Location header format: ${location}`)
     }
@@ -278,7 +278,7 @@ export class PDPServer {
     }
 
     // Make the POST request to add pieces to the data set
-    const response = await fetch(`${this._serviceURL}/pdp/data-sets/${dataSetId}/pieces`, {
+    const response = await fetch(`${this._serviceURL}/market/pdp/data-sets/${dataSetId}/pieces`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -297,7 +297,7 @@ export class PDPServer {
     let statusUrl: string | undefined
 
     if (location != null) {
-      // Expected format: /pdp/data-sets/{dataSetId}/pieces/added/{txHash}
+      // Expected format: /market/pdp/data-sets/{dataSetId}/pieces/added/{txHash}
       const locationMatch = location.match(/\/pieces\/added\/([0-9a-fA-Fx]+)$/)
       if (locationMatch != null) {
         txHash = locationMatch[1]
@@ -324,7 +324,7 @@ export class PDPServer {
    * @returns Promise that resolves with the creation status
    */
   async getDataSetCreationStatus (txHash: string): Promise<DataSetCreationStatusResponse> {
-    const response = await fetch(`${this._serviceURL}/pdp/data-sets/created/${txHash}`, {
+    const response = await fetch(`${this._serviceURL}/market/pdp/data-sets/created/${txHash}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json'
@@ -355,7 +355,7 @@ export class PDPServer {
     txHash: string
   ): Promise<PieceAdditionStatusResponse> {
     const response = await fetch(
-      `${this._serviceURL}/pdp/data-sets/${dataSetId}/pieces/added/${txHash}`,
+      `${this._serviceURL}/market/pdp/data-sets/${dataSetId}/pieces/added/${txHash}`,
       {
         method: 'GET',
         headers: {
@@ -441,16 +441,16 @@ export class PDPServer {
     }
 
     // Create upload session or check if piece exists
-    performance.mark('synapse:POST.pdp.piece-start')
-    const createResponse = await fetch(`${this._serviceURL}/pdp/piece`, {
+    performance.mark('synapse:POST.market.pdp.piece-start')
+    const createResponse = await fetch(`${this._serviceURL}/market/pdp/piece`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
       },
       body: JSON.stringify(requestBody)
     })
-    performance.mark('synapse:POST.pdp.piece-end')
-    performance.measure('synapse:POST.pdp.piece', 'synapse:POST.pdp.piece-start', 'synapse:POST.pdp.piece-end')
+    performance.mark('synapse:POST.market.pdp.piece-end')
+    performance.measure('synapse:POST.market.pdp.piece', 'synapse:POST.market.pdp.piece-start', 'synapse:POST.market.pdp.piece-end')
 
     if (createResponse.status === 200) {
       // Piece already exists on server
@@ -472,8 +472,8 @@ export class PDPServer {
     }
 
     // Validate the location format and extract UUID
-    // Match /pdp/piece/upload/UUID or /piece/upload/UUID anywhere in the path
-    const locationMatch = location.match(/\/(?:pdp\/)?piece\/upload\/([a-fA-F0-9-]+)/)
+    // Match /market/pdp/piece/upload/UUID or /piece/upload/UUID anywhere in the path
+    const locationMatch = location.match(/\/(?:market\/pdp\/)?piece\/upload\/([a-fA-F0-9-]+)/)
     if (locationMatch == null) {
       throw new Error(`Invalid Location header format: ${location}`)
     }
@@ -481,8 +481,8 @@ export class PDPServer {
     const uploadUuid = locationMatch[1] // Extract just the UUID
 
     // Upload the data
-    performance.mark('synapse:PUT.pdp.piece.upload-start')
-    const uploadResponse = await fetch(`${this._serviceURL}/pdp/piece/upload/${uploadUuid}`, {
+    performance.mark('synapse:PUT.market.pdp.piece.upload-start')
+    const uploadResponse = await fetch(`${this._serviceURL}/market/pdp/piece/upload/${uploadUuid}`, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/octet-stream',
@@ -491,8 +491,8 @@ export class PDPServer {
       },
       body: uint8Data
     })
-    performance.mark('synapse:PUT.pdp.piece.upload-end')
-    performance.measure('synapse:PUT.pdp.piece.upload', 'synapse:PUT.pdp.piece.upload-start', 'synapse:PUT.pdp.piece.upload-end')
+    performance.mark('synapse:PUT.market.pdp.piece.upload-end')
+    performance.measure('synapse:PUT.market.pdp.piece.upload', 'synapse:PUT.market.pdp.piece.upload-start', 'synapse:PUT.market.pdp.piece.upload-end')
 
     if (uploadResponse.status !== 204) {
       const errorText = await uploadResponse.text()
@@ -533,7 +533,7 @@ export class PDPServer {
    * @returns Promise that resolves with data set data
    */
   async getDataSet (dataSetId: number): Promise<DataSetData> {
-    const response = await fetch(`${this._serviceURL}/pdp/data-sets/${dataSetId}`, {
+    const response = await fetch(`${this._serviceURL}/market/pdp/data-sets/${dataSetId}`, {
       method: 'GET',
       headers: {
         Accept: 'application/json'
@@ -614,7 +614,7 @@ export class PDPServer {
    * @throws Error if provider is not reachable or returns non-200 status
    */
   async ping (): Promise<void> {
-    const response = await fetch(`${this._serviceURL}/pdp/ping`, {
+    const response = await fetch(`${this._serviceURL}/market/pdp/ping`, {
       method: 'GET',
       headers: {}
     })

--- a/src/test/pdp-server.test.ts
+++ b/src/test/pdp-server.test.ts
@@ -89,7 +89,7 @@ describe('PDPServer', () => {
       const originalFetch = global.fetch
       global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-        assert.include(url, '/pdp/data-sets')
+        assert.include(url, '/market/pdp/data-sets')
         assert.strictEqual(init?.method, 'POST')
 
         const body = JSON.parse(init?.body as string)
@@ -101,7 +101,7 @@ describe('PDPServer', () => {
           headers: {
             get: (header: string) => {
               if (header === 'Location') {
-                return `/pdp/data-sets/created/${mockTxHash}`
+                return `/market/pdp/data-sets/created/${mockTxHash}`
               }
               return null
             }
@@ -141,7 +141,7 @@ describe('PDPServer', () => {
       const originalFetch = global.fetch
       global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-        assert.include(url, `/pdp/data-sets/1/pieces/added/${mockTxHash}`)
+        assert.include(url, `/market/pdp/data-sets/1/pieces/added/${mockTxHash}`)
         assert.strictEqual(init?.method, 'GET')
 
         return {
@@ -286,7 +286,7 @@ describe('PDPServer', () => {
       const originalFetch = global.fetch
       global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-        assert.include(url, '/pdp/data-sets/1/pieces')
+        assert.include(url, '/market/pdp/data-sets/1/pieces')
         assert.strictEqual(init?.method, 'POST')
 
         const body = JSON.parse(init?.body as string)
@@ -408,7 +408,7 @@ describe('PDPServer', () => {
       const originalFetch = global.fetch
       global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-        assert.include(url, '/pdp/data-sets/1/pieces')
+        assert.include(url, '/market/pdp/data-sets/1/pieces')
         assert.strictEqual(init?.method, 'POST')
 
         return {
@@ -417,7 +417,7 @@ describe('PDPServer', () => {
           headers: {
             get: (name: string) => {
               if (name === 'Location') {
-                return `/pdp/data-sets/1/pieces/added/${mockTxHash}`
+                return `/market/pdp/data-sets/1/pieces/added/${mockTxHash}`
               }
               return null
             }
@@ -431,7 +431,7 @@ describe('PDPServer', () => {
         assert.isDefined(result.message)
         assert.strictEqual(result.txHash, mockTxHash)
         assert.include(result.statusUrl ?? '', mockTxHash)
-        assert.include(result.statusUrl ?? '', '/pdp/data-sets/1/pieces/added/')
+        assert.include(result.statusUrl ?? '', '/market/pdp/data-sets/1/pieces/added/')
       } finally {
         global.fetch = originalFetch
       }
@@ -456,7 +456,7 @@ describe('PDPServer', () => {
           headers: {
             get: (name: string) => {
               if (name === 'Location') {
-                return `/pdp/data-sets/1/pieces/added/${mockTxHashWithout0x}`
+                return `/market/pdp/data-sets/1/pieces/added/${mockTxHashWithout0x}`
               }
               return null
             }
@@ -526,7 +526,7 @@ describe('PDPServer', () => {
       const originalFetch = global.fetch
       global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-        assert.include(url, `/pdp/data-sets/created/${mockTxHash}`)
+        assert.include(url, `/market/pdp/data-sets/created/${mockTxHash}`)
         assert.strictEqual(init?.method, 'GET')
 
         return {
@@ -577,7 +577,7 @@ describe('PDPServer', () => {
       const originalFetch = global.fetch
       global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-        assert.include(url, '/pdp/piece?')
+        assert.include(url, '/market/pdp/piece?')
         assert.include(url, 'name=sha2-256-trunc254-padded')
         assert.include(url, 'size=1048576')
         assert.strictEqual(init?.method, 'GET')
@@ -682,7 +682,7 @@ describe('PDPServer', () => {
       global.fetch = async (url: any, options: any) => {
         const urlStr = url.toString()
 
-        if (urlStr.includes('/pdp/piece') === true && options?.method === 'POST') {
+        if (urlStr.includes('/market/pdp/piece') === true && options?.method === 'POST') {
           // Verify request body has check object
           const body = JSON.parse(options.body)
           assert.exists(body.check)
@@ -697,14 +697,14 @@ describe('PDPServer', () => {
             headers: {
               get: (name: string) => {
                 if (name === 'Location') {
-                  return `/pdp/piece/upload/${mockUuid}`
+                  return `/market/pdp/piece/upload/${mockUuid}`
                 }
                 return null
               }
             },
             text: async () => 'Created'
           } as any
-        } else if (urlStr.includes(`/pdp/piece/upload/${String(mockUuid)}`) === true) {
+        } else if (urlStr.includes(`/market/pdp/piece/upload/${String(mockUuid)}`) === true) {
           // Upload data - return 204 No Content
           return {
             ok: true,
@@ -735,7 +735,7 @@ describe('PDPServer', () => {
       global.fetch = async (url: any, options: any) => {
         const urlStr = url.toString()
 
-        if (urlStr.includes('/pdp/piece') === true && options?.method === 'POST') {
+        if (urlStr.includes('/market/pdp/piece') === true && options?.method === 'POST') {
           // Verify request body has check object
           const body = JSON.parse(options.body)
           assert.exists(body.check)
@@ -750,14 +750,14 @@ describe('PDPServer', () => {
             headers: {
               get: (name: string) => {
                 if (name === 'Location') {
-                  return `/pdp/piece/upload/${mockUuid}`
+                  return `/market/pdp/piece/upload/${mockUuid}`
                 }
                 return null
               }
             },
             text: async () => 'Created'
           } as any
-        } else if (urlStr.includes(`/pdp/piece/upload/${String(mockUuid)}`) === true) {
+        } else if (urlStr.includes(`/market/pdp/piece/upload/${String(mockUuid)}`) === true) {
           // Upload data - return 204 No Content
           return {
             ok: true,
@@ -786,7 +786,7 @@ describe('PDPServer', () => {
       global.fetch = async (url: any, options: any) => {
         const urlStr = url.toString()
 
-        if (urlStr.includes('/pdp/piece') === true && options?.method === 'POST') {
+        if (urlStr.includes('/market/pdp/piece') === true && options?.method === 'POST') {
           // Verify request body has check object
           const body = JSON.parse(options.body)
           assert.exists(body.check)
@@ -823,7 +823,7 @@ describe('PDPServer', () => {
       global.fetch = async (url: any, options: any) => {
         const urlStr = url.toString()
 
-        if (urlStr.includes('/pdp/piece') === true && options?.method === 'POST') {
+        if (urlStr.includes('/market/pdp/piece') === true && options?.method === 'POST') {
           // Verify request body has check object even for error case
           const body = JSON.parse(options.body)
           assert.exists(body.check)
@@ -1001,7 +1001,7 @@ describe('PDPServer', () => {
       const originalFetch = global.fetch
       global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-        assert.include(url, '/pdp/ping')
+        assert.include(url, '/market/pdp/ping')
         assert.strictEqual(init?.method, 'GET')
         assert.deepEqual(init?.headers, {})
 
@@ -1117,7 +1117,7 @@ describe('PDPServer', () => {
 
       try {
         await pdpServer.ping()
-        assert.strictEqual(capturedUrl, `${serverUrl}/pdp/ping`)
+        assert.strictEqual(capturedUrl, `${serverUrl}/market/pdp/ping`)
       } finally {
         global.fetch = originalFetch
       }
@@ -1149,7 +1149,7 @@ describe('PDPServer', () => {
       const originalFetch = global.fetch
       global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
-        assert.include(url, '/pdp/data-sets/292')
+        assert.include(url, '/market/pdp/data-sets/292')
         assert.strictEqual(init?.method, 'GET')
         assert.strictEqual((init?.headers as any)?.Accept, 'application/json')
 

--- a/src/test/retriever-chain.test.ts
+++ b/src/test/retriever-chain.test.ts
@@ -71,7 +71,7 @@ describe('ChainRetriever', () => {
 
       global.fetch = async (input: string | URL | Request, init?: RequestInit) => {
         const url = typeof input === 'string' ? input : (input instanceof URL ? input.toString() : input.url)
-        if (url.includes('/pdp/piece?')) {
+        if (url.includes('/market/pdp/piece?')) {
           findPieceCalled = true
           return new Response('', { status: 200 })
         }
@@ -239,7 +239,7 @@ describe('ChainRetriever', () => {
         // Provider 1 is slow but successful
         if (url.includes('provider1')) {
           await new Promise(resolve => setTimeout(resolve, 50))
-          if (url.includes('/pdp/piece?')) {
+          if (url.includes('/market/pdp/piece?')) {
             return new Response('', { status: 200 })
           }
           if (url.includes('/piece/')) {
@@ -249,7 +249,7 @@ describe('ChainRetriever', () => {
 
         // Provider 2 is fast and successful
         if (url.includes('provider2')) {
-          if (url.includes('/pdp/piece?')) {
+          if (url.includes('/market/pdp/piece?')) {
             return new Response('', { status: 200 })
           }
           if (url.includes('/piece/')) {

--- a/src/test/storage.test.ts
+++ b/src/test/storage.test.ts
@@ -1660,7 +1660,7 @@ describe('StorageService', () => {
         return {
           message: 'success',
           txHash: mockTxHash,
-          statusUrl: `https://pdp.example.com/pdp/data-sets/123/pieces/added/${mockTxHash}`
+          statusUrl: `https://pdp.example.com/market/pdp/data-sets/123/pieces/added/${mockTxHash}`
         }
       }
 
@@ -1749,7 +1749,7 @@ describe('StorageService', () => {
         return {
           message: 'success',
           txHash: mockTxHash,
-          statusUrl: `https://pdp.example.com/pdp/data-sets/123/pieces/added/${mockTxHash}`
+          statusUrl: `https://pdp.example.com/market/pdp/data-sets/123/pieces/added/${mockTxHash}`
         }
       }
 
@@ -1802,7 +1802,7 @@ describe('StorageService', () => {
         return {
           message: 'success',
           txHash: mockTxHash,
-          statusUrl: `https://pdp.example.com/pdp/data-sets/123/pieces/added/${mockTxHash}`
+          statusUrl: `https://pdp.example.com/market/pdp/data-sets/123/pieces/added/${mockTxHash}`
         }
       }
 
@@ -1866,7 +1866,7 @@ describe('StorageService', () => {
         return {
           message: 'success',
           txHash: mockTxHash,
-          statusUrl: `https://pdp.example.com/pdp/data-sets/123/pieces/added/${mockTxHash}`
+          statusUrl: `https://pdp.example.com/market/pdp/data-sets/123/pieces/added/${mockTxHash}`
         }
       }
 

--- a/src/utils/piece.ts
+++ b/src/utils/piece.ts
@@ -38,5 +38,5 @@ export function constructFindPieceUrl (apiEndpoint: string, commp: CommP, size =
     size: size.toString()
   })
 
-  return `${endpoint}/pdp/piece?${params.toString()}`
+  return `${endpoint}/market/pdp/piece?${params.toString()}`
 }


### PR DESCRIPTION
WIP for now.  After syncing with @rvagg I'll see if scope also includes moving over to mk20.

As best I can tell there is no breaking change on the retrieval apis of curio with the markets v2 PR so the only change absolutely required for synapse to work with the code in that PR running on a curio node is this minimal PR.  Of course moving to mk20 instead of the legacy mk12 would mean leveraging a different deal making protocol and would be a much more invasive change here.  