### PR TITLE
chore: update testing setup and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "msw": "^2.10.5",
     "p-defer": "^4.0.1",
     "playwright-test": "^14.1.12",
+    "type-fest": "^4.41.0",
     "typescript": "5.9.2",
     "webpack": "^5.99.9",
     "webpack-cli": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   "homepage": "https://github.com/FilOzone/synapse-sdk#readme",
   "dependencies": {
     "@web3-storage/data-segment": "^5.3.0",
-    "abitype": "^1.1.0",
     "ethers": "^6.14.3",
     "multiformats": "^13.3.6",
     "viem": "^2.37.2"
@@ -91,6 +90,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.0",
     "@wagmi/cli": "^2.5.1",
+    "abitype": "^1.1.0",
     "chai": "^6.0.1",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "iso-web": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,9 @@
     "@wagmi/cli": "^2.5.1",
     "chai": "^6.0.1",
     "conventional-changelog-conventionalcommits": "^9.0.0",
+    "iso-web": "^1.3.0",
     "mocha": "^11.5.0",
+    "msw": "^2.10.5",
     "playwright-test": "^14.1.12",
     "typescript": "5.9.2",
     "webpack": "^5.99.9",
@@ -188,6 +190,11 @@
           ]
         }
       ]
+    ]
+  },
+  "msw": {
+    "workerDirectory": [
+      "src/test/mocks"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "homepage": "https://github.com/FilOzone/synapse-sdk#readme",
   "dependencies": {
     "@web3-storage/data-segment": "^5.3.0",
+    "abitype": "^1.1.0",
     "ethers": "^6.14.3",
     "multiformats": "^13.3.6",
     "viem": "^2.37.2"
@@ -95,6 +96,7 @@
     "iso-web": "^1.3.0",
     "mocha": "^11.5.0",
     "msw": "^2.10.5",
+    "p-defer": "^4.0.1",
     "playwright-test": "^14.1.12",
     "typescript": "5.9.2",
     "webpack": "^5.99.9",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "test:ci": "npm run test",
     "test": "npm run lint && npm run test:node && npm run test:browser",
     "test:node": "playwright-test 'src/test/**/!(*.browser).test.{js,ts}' --mode node",
-    "test:browser": "playwright-test 'src/test/**/!(*.node).test.{js,ts}'",
-    "test:watch": "npm run test:node --watch",
+    "test:browser": "playwright-test 'src/test/**/!(*.node).test.{js,ts}' --assets ./src/test/mocks",
+    "test:watch": "npm run test:node -- --watch",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run clean && npm run build && npm run build:browser"
   },

--- a/src/pdp/server.ts
+++ b/src/pdp/server.ts
@@ -116,6 +116,19 @@ export interface PieceAdditionStatusResponse {
   confirmedPieceIds?: number[]
 }
 
+/**
+ * Input for adding pieces to a data set
+ */
+export interface PDPAddPiecesInput {
+  pieces: {
+    pieceCid: string
+    subPieces: {
+      subPieceCid: string
+    }[]
+  }[]
+  extraData: string
+}
+
 export class PDPServer {
   private readonly _serviceURL: string
   private readonly _authHelper: PDPAuthHelper | null
@@ -254,7 +267,7 @@ export class PDPServer {
 
     // Prepare request body matching the Curio handler expectation
     // Each piece has itself as its only subPiece (internal implementation detail)
-    const requestBody = {
+    const requestBody: PDPAddPiecesInput = {
       pieces: pieceDataArray.map((pieceData) => {
         // Convert to string for JSON serialization
         const cidString = typeof pieceData === 'string' ? pieceData : pieceData.toString()

--- a/src/piece/download.ts
+++ b/src/piece/download.ts
@@ -73,8 +73,13 @@ export async function downloadAndValidate(
     reader.releaseLock()
   }
 
+  if (chunks.length === 0) {
+    throw new Error('Response body is null')
+  }
+
   // Get the calculated PieceCID
   const calculatedPieceCid = getPieceCID()
+
   if (calculatedPieceCid == null) {
     throw new Error('Failed to calculate PieceCID from stream')
   }

--- a/src/test/mocks/jsonrpc/index.ts
+++ b/src/test/mocks/jsonrpc/index.ts
@@ -1,0 +1,263 @@
+import { HttpResponse, http } from 'msw'
+import { type Address, decodeFunctionData, encodeAbiParameters, type Hex, isAddressEqual, multicall3Abi } from 'viem'
+import { CONTRACT_ADDRESSES } from '../../../utils/constants.ts'
+import {
+  type dataSetLiveInput,
+  type getDataSetListenerInput,
+  type getNextPieceIdInput,
+  pdpVerifierCallHandler,
+} from './pdp.ts'
+import {
+  type getProviderInput,
+  type PDPOffering,
+  type ProviderInfo,
+  serviceProviderRegistryCallHandler,
+} from './service-registry.ts'
+import {
+  type DataSetInfo,
+  type getClientDataSetsInput,
+  type isProviderApprovedInput,
+  type railToDataSetInput,
+  warmStorageCallHandler,
+  warmStorageViewCallHandler,
+} from './warm-storage.ts'
+
+export const PRIVATE_KEYS = {
+  key1: '0x1234567890123456789012345678901234567890123456789012345678901234',
+}
+export const ADDRESSES = {
+  client1: '0x2e988A386a799F506693793c6A5AF6B54dfAaBfB' as Address,
+  zero: '0x0000000000000000000000000000000000000000' as Address,
+  serviceProvider1: '0x0000000000000000000000000000000000000001' as Address,
+  payee1: '0x1000000000000000000000000000000000000001' as Address,
+  mainnet: {
+    warmStorage: '0x1234567890123456789012345678901234567890' as Address,
+    multicall3: CONTRACT_ADDRESSES.MULTICALL3.mainnet,
+    pdpVerifier: '0x9876543210987654321098765432109876543210',
+  },
+  calibration: {
+    warmStorage: CONTRACT_ADDRESSES.WARM_STORAGE.calibration as Address,
+    multicall3: CONTRACT_ADDRESSES.MULTICALL3.calibration,
+    pdpVerifier: '0x3ce3C62C4D405d69738530A6A65E4b13E8700C48' as Address,
+    payments: '0x80Df863d84eFaa0aaC8da2E9B08D14A7236ff4D0' as Address,
+    usdfcToken: '0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0' as Address,
+    filCDN: '0x0000000000000000000000000000000000000000' as Address,
+    viewContract: '0x1996B60838871D0bc7980Bc02DD6Eb920535bE54' as Address,
+    spRegistry: '0x0000000000000000000000000000000000000001' as Address,
+  },
+}
+
+type SuccessResult<result> = {
+  method?: undefined
+  result: result
+  error?: undefined
+}
+type ErrorResult<error> = {
+  method?: undefined
+  result?: undefined
+  error: error
+}
+type Subscription<result, error> = {
+  method: 'eth_subscription'
+  error?: undefined
+  result?: undefined
+  params:
+    | {
+        subscription: string
+        result: result
+        error?: undefined
+      }
+    | {
+        subscription: string
+        result?: undefined
+        error: error
+      }
+}
+export type RpcResponse<result = any, error = any> = {
+  jsonrpc: `${number}`
+  id: number
+} & (SuccessResult<result> | ErrorResult<error> | Subscription<result, error>)
+
+export type RpcRequest = {
+  jsonrpc?: '2.0' | undefined
+  method: string
+  params?: any | undefined
+  id?: number | undefined
+}
+/**
+ * Options for the JSONRPC server
+ *
+ * TODO: some types are not exactly correct we should make all input and outputs types strict and infered from the abi. all hooks should functions to override outputs based on inputs.
+ */
+export interface JSONRPCOptions {
+  debug?: boolean
+  eth_chainId?: string
+  eth_accounts?: string[]
+  eth_call?: {
+    to: string
+    data: string
+  }
+  warmStorage?: {
+    pdpVerifierAddress?: Address
+    paymentsContractAddress?: Address
+    usdfcTokenAddress?: Address
+    filCDNBeneficiaryAddress?: Address
+    viewContractAddress?: Address
+    serviceProviderRegistry?: Address
+  }
+  pdpVerifier?: {
+    dataSetLive?: (args: dataSetLiveInput) => boolean
+    getDataSetListener?: (args: getDataSetListenerInput) => Address
+    getNextPieceId?: (args: getNextPieceIdInput) => bigint
+  }
+  warmStorageView?: {
+    isProviderApproved?: (args: isProviderApprovedInput) => boolean
+    getClientDataSets?: (args: getClientDataSetsInput) => DataSetInfo
+    railToDataSet?: (args: railToDataSetInput) => [bigint]
+  }
+  serviceRegistry?: {
+    getProviderByAddress?: ProviderInfo
+    getProviderIdByAddress?: bigint
+    getPDPService?: PDPOffering
+    getProvider?: (args: getProviderInput) => ProviderInfo
+  }
+}
+
+/**
+ * Mock JSONRPC server for testing
+ */
+export function JSONRPC(options?: JSONRPCOptions) {
+  return http.post<Record<string, any>, RpcRequest | RpcRequest[], RpcResponse | RpcResponse[]>(
+    'https://api.calibration.node.glif.io/rpc/v1',
+    async ({ request }) => {
+      try {
+        const body = await request.json()
+        if (Array.isArray(body)) {
+          const results: RpcResponse[] = []
+          for (const item of body) {
+            const { id } = item
+            const result = handler(item, options ?? {})
+            results.push({
+              jsonrpc: '2.0',
+              result: result,
+              id: id ?? 1,
+            })
+          }
+          return HttpResponse.json(results)
+        } else {
+          const { id } = body
+          return HttpResponse.json({
+            jsonrpc: '2.0',
+            result: handler(body, options ?? {}),
+            id: id ?? 1,
+          })
+        }
+      } catch (error) {
+        console.error(error)
+        return HttpResponse.json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message: error instanceof Error ? error.message : 'Unknown error',
+          },
+          id: 1,
+        })
+      }
+    }
+  )
+}
+
+/**
+ * Handle all calls
+ */
+function handler(body: RpcRequest, options: JSONRPCOptions) {
+  const { method, params } = body
+  switch (method) {
+    case 'eth_chainId':
+      return options.eth_chainId ?? '314159'
+    case 'eth_accounts':
+      return options.eth_accounts ?? ['0x1234567890123456789012345678901234567890']
+    case 'eth_call': {
+      const { to, data } = params[0]
+
+      if (
+        isAddressEqual(ADDRESSES.calibration.warmStorage, to as Address) ||
+        isAddressEqual(ADDRESSES.mainnet.warmStorage, to as Address)
+      ) {
+        return warmStorageCallHandler(data as Hex, options)
+      }
+
+      if (isAddressEqual(CONTRACT_ADDRESSES.MULTICALL3.calibration, to as Address)) {
+        return multicall3CallHandler(data as Hex, options)
+      }
+
+      if (isAddressEqual(ADDRESSES.calibration.spRegistry, to as Address)) {
+        return serviceProviderRegistryCallHandler(data as Hex, options)
+      }
+
+      if (isAddressEqual(ADDRESSES.calibration.viewContract, to as Address)) {
+        return warmStorageViewCallHandler(data as Hex, options)
+      }
+      if (isAddressEqual(ADDRESSES.calibration.pdpVerifier, to as Address)) {
+        return pdpVerifierCallHandler(data as Hex, options)
+      }
+
+      throw new Error(`Unknown eth_call to address: ${to}`)
+    }
+    default: {
+      throw new Error(`Unknown method: ${method}`)
+    }
+  }
+}
+
+function multicall3CallHandler(data: Hex, options: JSONRPCOptions): Hex {
+  const decoded = decodeFunctionData({
+    abi: multicall3Abi,
+    data: data as Hex,
+  })
+
+  const results = []
+
+  for (const arg of decoded.args[0]) {
+    results.push(
+      handler(
+        {
+          method: 'eth_call',
+          params: [
+            {
+              to: arg.target,
+              data: arg.callData,
+            },
+          ],
+        },
+        options
+      )
+    )
+  }
+
+  const result = encodeAbiParameters(
+    [
+      {
+        components: [
+          {
+            name: 'success',
+            type: 'bool',
+          },
+          {
+            name: 'returnData',
+            type: 'bytes',
+          },
+        ],
+        name: 'returnData',
+        type: 'tuple[]',
+      },
+    ],
+    [
+      results.map((result) => ({
+        success: true,
+        returnData: result as Hex,
+      })),
+    ]
+  )
+  return result
+}

--- a/src/test/mocks/jsonrpc/index.ts
+++ b/src/test/mocks/jsonrpc/index.ts
@@ -151,7 +151,7 @@ function multicall3CallHandler(data: Hex, options: JSONRPCOptions): Hex {
 
   const results = []
 
-  for (const arg of decoded.args[0]) {
+  for (const arg of decoded.args[0] ?? []) {
     results.push(
       handler(
         {

--- a/src/test/mocks/jsonrpc/payments.ts
+++ b/src/test/mocks/jsonrpc/payments.ts
@@ -1,0 +1,42 @@
+/** biome-ignore-all lint/style/noNonNullAssertion: testing */
+
+import type { ExtractAbiFunction } from 'abitype'
+import { decodeFunctionData, encodeAbiParameters, type Hex } from 'viem'
+import { CONTRACT_ABIS } from '../../../utils/constants.ts'
+import type { AbiToType, JSONRPCOptions } from './types.ts'
+
+export type operatorApprovals = ExtractAbiFunction<typeof CONTRACT_ABIS.PAYMENTS, 'operatorApprovals'>
+
+export interface PaymentsOptions {
+  operatorApprovals?: (args: AbiToType<operatorApprovals['inputs']>) => AbiToType<operatorApprovals['outputs']>
+}
+
+/**
+ * Handle pdp verifier calls
+ */
+export function paymentsCallHandler(data: Hex, options: JSONRPCOptions): Hex {
+  const { functionName, args } = decodeFunctionData({
+    abi: CONTRACT_ABIS.PAYMENTS,
+    data: data as Hex,
+  })
+
+  if (options.debug) {
+    console.debug('Payments: calling function', functionName, 'with args', args)
+  }
+
+  switch (functionName) {
+    case 'operatorApprovals': {
+      if (!options.payments?.operatorApprovals) {
+        throw new Error('Payments: operatorApprovals is not defined')
+      }
+      return encodeAbiParameters(
+        CONTRACT_ABIS.PAYMENTS.find((abi) => abi.type === 'function' && abi.name === 'operatorApprovals')!.outputs,
+        options.payments.operatorApprovals(args)
+      )
+    }
+
+    default: {
+      throw new Error(`Payments: unknown function: ${functionName} with args: ${args}`)
+    }
+  }
+}

--- a/src/test/mocks/jsonrpc/pdp.ts
+++ b/src/test/mocks/jsonrpc/pdp.ts
@@ -1,0 +1,57 @@
+/** biome-ignore-all lint/style/noNonNullAssertion: testing */
+
+import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from 'abitype'
+import { decodeFunctionData, encodeAbiParameters, type Hex } from 'viem'
+import { CONTRACT_ABIS } from '../../../utils/constants.ts'
+import { ADDRESSES, type JSONRPCOptions } from './index.ts'
+
+export type dataSetLiveInput = AbiParametersToPrimitiveTypes<
+  ExtractAbiFunction<typeof CONTRACT_ABIS.PDP_VERIFIER, 'dataSetLive'>['inputs']
+>
+
+export type getDataSetListenerInput = AbiParametersToPrimitiveTypes<
+  ExtractAbiFunction<typeof CONTRACT_ABIS.PDP_VERIFIER, 'getDataSetListener'>['inputs']
+>
+
+export type getNextPieceIdInput = AbiParametersToPrimitiveTypes<
+  ExtractAbiFunction<typeof CONTRACT_ABIS.PDP_VERIFIER, 'getNextPieceId'>['inputs']
+>
+
+/**
+ * Handle pdp verifier calls
+ */
+export function pdpVerifierCallHandler(data: Hex, options: JSONRPCOptions): Hex {
+  const { functionName, args } = decodeFunctionData({
+    abi: CONTRACT_ABIS.PDP_VERIFIER,
+    data: data as Hex,
+  })
+
+  if (options.debug) {
+    console.debug('PDP Verifier: calling function', functionName, 'with args', args)
+  }
+
+  switch (functionName) {
+    case 'dataSetLive':
+      return encodeAbiParameters(
+        CONTRACT_ABIS.PDP_VERIFIER.find((abi) => abi.type === 'function' && abi.name === 'dataSetLive')!.outputs,
+        [options.pdpVerifier?.dataSetLive?.(args as dataSetLiveInput) ?? true]
+      )
+
+    case 'getDataSetListener':
+      return encodeAbiParameters(
+        CONTRACT_ABIS.PDP_VERIFIER.find((abi) => abi.type === 'function' && abi.name === 'getDataSetListener')!.outputs,
+        [
+          options.pdpVerifier?.getDataSetListener?.(args as getDataSetListenerInput) ??
+            ADDRESSES.calibration.warmStorage,
+        ]
+      )
+    case 'getNextPieceId':
+      return encodeAbiParameters(
+        CONTRACT_ABIS.PDP_VERIFIER.find((abi) => abi.type === 'function' && abi.name === 'getNextPieceId')!.outputs,
+        [options.pdpVerifier?.getNextPieceId?.(args as getNextPieceIdInput) ?? 2n]
+      )
+    default: {
+      throw new Error(`PDP Verifier: unknown function: ${functionName} with args: ${args}`)
+    }
+  }
+}

--- a/src/test/mocks/jsonrpc/service-registry.ts
+++ b/src/test/mocks/jsonrpc/service-registry.ts
@@ -1,0 +1,99 @@
+/** biome-ignore-all lint/style/noNonNullAssertion: testing */
+
+import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from 'abitype'
+import { decodeFunctionData, encodeAbiParameters, type Hex } from 'viem'
+import { CONTRACT_ABIS } from '../../../utils/constants.ts'
+import { ADDRESSES, type JSONRPCOptions } from './index.ts'
+
+export type ProviderInfo = AbiParametersToPrimitiveTypes<
+  ExtractAbiFunction<typeof CONTRACT_ABIS.SERVICE_PROVIDER_REGISTRY, 'getProviderByAddress'>['outputs']
+>
+
+export type PDPOffering = AbiParametersToPrimitiveTypes<
+  ExtractAbiFunction<typeof CONTRACT_ABIS.SERVICE_PROVIDER_REGISTRY, 'getPDPService'>['outputs']
+>
+
+export type getProviderInput = AbiParametersToPrimitiveTypes<
+  ExtractAbiFunction<typeof CONTRACT_ABIS.SERVICE_PROVIDER_REGISTRY, 'getProvider'>['inputs']
+>
+
+/**
+ * Handle service provider registry calls
+ */
+export function serviceProviderRegistryCallHandler(data: Hex, options: JSONRPCOptions): Hex {
+  const { functionName, args } = decodeFunctionData({
+    abi: CONTRACT_ABIS.SERVICE_PROVIDER_REGISTRY,
+    data: data as Hex,
+  })
+
+  if (options.debug) {
+    console.debug('Service Provider Registry: calling function', functionName, 'with args', args)
+  }
+
+  switch (functionName) {
+    case 'getProviderByAddress': {
+      return encodeAbiParameters(
+        CONTRACT_ABIS.SERVICE_PROVIDER_REGISTRY.find(
+          (abi) => abi.type === 'function' && abi.name === 'getProviderByAddress'
+        )!.outputs,
+        options.serviceRegistry?.getProviderByAddress ?? [
+          {
+            serviceProvider: ADDRESSES.serviceProvider1,
+            payee: ADDRESSES.payee1,
+            name: 'Test Provider',
+            description: 'Test Provider Description',
+            isActive: true,
+          },
+        ]
+      )
+    }
+    case 'getProviderIdByAddress': {
+      return encodeAbiParameters(
+        CONTRACT_ABIS.SERVICE_PROVIDER_REGISTRY.find(
+          (abi) => abi.type === 'function' && abi.name === 'getProviderIdByAddress'
+        )!.outputs,
+        [options.serviceRegistry?.getProviderIdByAddress ?? BigInt(1)]
+      )
+    }
+    case 'getPDPService': {
+      const defaultPDPService: PDPOffering = [
+        {
+          serviceURL: 'https://pdp.example.com',
+          minPieceSizeInBytes: BigInt(1024),
+          maxPieceSizeInBytes: BigInt(1024 * 1024 * 1024),
+          ipniPiece: false,
+          ipniIpfs: false,
+          storagePricePerTibPerMonth: 1000000n,
+          minProvingPeriodInEpochs: 2880n,
+          location: 'US',
+          paymentTokenAddress: '0x0000000000000000000000000000000000000000',
+        },
+        [],
+        true,
+      ]
+      return encodeAbiParameters(
+        CONTRACT_ABIS.SERVICE_PROVIDER_REGISTRY.find((abi) => abi.type === 'function' && abi.name === 'getPDPService')!
+          .outputs,
+        options.serviceRegistry?.getPDPService ?? defaultPDPService
+      )
+    }
+    case 'getProvider': {
+      return encodeAbiParameters(
+        CONTRACT_ABIS.SERVICE_PROVIDER_REGISTRY.find((abi) => abi.type === 'function' && abi.name === 'getProvider')!
+          .outputs,
+        options.serviceRegistry?.getProvider?.(args as getProviderInput) ?? [
+          {
+            serviceProvider: ADDRESSES.serviceProvider1,
+            payee: ADDRESSES.payee1,
+            name: 'Test Provider',
+            description: 'Test Provider Description',
+            isActive: true,
+          },
+        ]
+      )
+    }
+    default: {
+      throw new Error(`Service Provider Registry: unknown function: ${functionName} with args: ${args}`)
+    }
+  }
+}

--- a/src/test/mocks/jsonrpc/types.ts
+++ b/src/test/mocks/jsonrpc/types.ts
@@ -1,0 +1,87 @@
+import type { AbiParameter, AbiParameterKind, AbiParametersToPrimitiveTypes } from 'abitype'
+import type { PaymentsOptions } from './payments.ts'
+import type { PDPVerifierOptions } from './pdp.ts'
+import type { ServiceRegistryOptions } from './service-registry.ts'
+import type { WarmStorageOptions, WarmStorageViewOptions } from './warm-storage.ts'
+
+/**
+ * Alias for AbiParametersToPrimitiveTypes
+ */
+export type AbiToType<
+  abiParameters extends readonly AbiParameter[],
+  abiParameterKind extends AbiParameterKind = AbiParameterKind,
+> = AbiParametersToPrimitiveTypes<abiParameters, abiParameterKind>
+
+/**
+ * Options for the JSONRPC server
+ */
+export interface JSONRPCOptions {
+  debug?: boolean
+  eth_chainId?: string
+  eth_accounts?: string[]
+  warmStorage?: WarmStorageOptions
+  pdpVerifier?: PDPVerifierOptions
+  payments?: PaymentsOptions
+  warmStorageView?: WarmStorageViewOptions
+  serviceRegistry?: ServiceRegistryOptions
+}
+
+/**
+ * JSONRPC types
+ */
+
+/**
+ * Success result
+ */
+export type SuccessResult<result> = {
+  method?: undefined
+  result: result
+  error?: undefined
+}
+
+/**
+ * Error result
+ */
+export type ErrorResult<error> = {
+  method?: undefined
+  result?: undefined
+  error: error
+}
+
+/**
+ * Subscription
+ */
+export type Subscription<result, error> = {
+  method: 'eth_subscription'
+  error?: undefined
+  result?: undefined
+  params:
+    | {
+        subscription: string
+        result: result
+        error?: undefined
+      }
+    | {
+        subscription: string
+        result?: undefined
+        error: error
+      }
+}
+
+/**
+ * RPC response
+ */
+export type RpcResponse<result = any, error = any> = {
+  jsonrpc: `${number}`
+  id: number
+} & (SuccessResult<result> | ErrorResult<error> | Subscription<result, error>)
+
+/**
+ * RPC request
+ */
+export type RpcRequest = {
+  jsonrpc?: '2.0' | undefined
+  method: string
+  params?: any | undefined
+  id?: number | undefined
+}

--- a/src/test/mocks/jsonrpc/warm-storage.ts
+++ b/src/test/mocks/jsonrpc/warm-storage.ts
@@ -1,0 +1,127 @@
+/** biome-ignore-all lint/style/noNonNullAssertion: testing */
+import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from 'abitype'
+import { decodeFunctionData, encodeAbiParameters, type Hex } from 'viem'
+import { CONTRACT_ABIS } from '../../../utils/constants.ts'
+import { ADDRESSES, type JSONRPCOptions } from './index.ts'
+
+export type isProviderApprovedInput = AbiParametersToPrimitiveTypes<
+  ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'isProviderApproved'>['inputs']
+>
+
+export type railToDataSetInput = AbiParametersToPrimitiveTypes<
+  ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'railToDataSet'>['inputs']
+>
+
+export type getClientDataSetsInput = AbiParametersToPrimitiveTypes<
+  ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getClientDataSets'>['inputs']
+>
+export type DataSetInfo = AbiParametersToPrimitiveTypes<
+  ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getClientDataSets'>['outputs']
+>
+
+/**
+ * Handle warm storage calls
+ */
+export function warmStorageCallHandler(data: Hex, options: JSONRPCOptions): Hex {
+  const { functionName, args } = decodeFunctionData({
+    abi: CONTRACT_ABIS.WARM_STORAGE,
+    data: data as Hex,
+  })
+
+  if (options.debug) {
+    console.debug('Warm Storage: calling function', functionName, 'with args', args)
+  }
+  switch (functionName) {
+    case 'pdpVerifierAddress':
+      return encodeAbiParameters(
+        [{ name: '', internalType: 'address', type: 'address' }],
+        [options.warmStorage?.pdpVerifierAddress ?? ADDRESSES.calibration.pdpVerifier]
+      )
+    case 'paymentsContractAddress':
+      return encodeAbiParameters(
+        [{ name: '', internalType: 'address', type: 'address' }],
+        [options.warmStorage?.paymentsContractAddress ?? ADDRESSES.calibration.payments]
+      )
+    case 'usdfcTokenAddress':
+      return encodeAbiParameters(
+        [{ name: '', internalType: 'address', type: 'address' }],
+        [options.warmStorage?.usdfcTokenAddress ?? ADDRESSES.calibration.usdfcToken]
+      )
+    case 'filCDNBeneficiaryAddress':
+      return encodeAbiParameters(
+        [{ name: '', internalType: 'address', type: 'address' }],
+        [options.warmStorage?.filCDNBeneficiaryAddress ?? ADDRESSES.calibration.filCDN]
+      )
+    case 'viewContractAddress':
+      return encodeAbiParameters(
+        [{ name: '', internalType: 'address', type: 'address' }],
+        [options.warmStorage?.viewContractAddress ?? ADDRESSES.calibration.viewContract]
+      )
+    case 'serviceProviderRegistry':
+      return encodeAbiParameters(
+        [{ name: '', internalType: 'address', type: 'address' }],
+        [options.warmStorage?.serviceProviderRegistry ?? ADDRESSES.calibration.spRegistry]
+      )
+    default: {
+      throw new Error(`Warm Storage: unknown function: ${functionName} with args: ${args}`)
+    }
+  }
+}
+
+/**
+ * Handle warm storage calls
+ */
+export function warmStorageViewCallHandler(data: Hex, options: JSONRPCOptions): Hex {
+  const { functionName, args } = decodeFunctionData({
+    abi: CONTRACT_ABIS.WARM_STORAGE_VIEW,
+    data: data as Hex,
+  })
+
+  if (options.debug) {
+    console.debug('Warm Storage View: calling function', functionName, 'with args', args)
+  }
+
+  switch (functionName) {
+    case 'isProviderApproved':
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'isProviderApproved')!
+          .outputs,
+        [options.warmStorageView?.isProviderApproved?.(args as isProviderApprovedInput) ?? true]
+      )
+    case 'getClientDataSets': {
+      const defaultClientDataSets: DataSetInfo = [
+        [
+          {
+            pdpRailId: 1n,
+            cacheMissRailId: 0n,
+            cdnRailId: 0n,
+            payer: ADDRESSES.client1,
+            payee: ADDRESSES.serviceProvider1,
+            serviceProvider: ADDRESSES.serviceProvider1,
+            commissionBps: 100n,
+            clientDataSetId: 0n,
+            pdpEndEpoch: 0n,
+            providerId: 1n,
+            cdnEndEpoch: 0n,
+          },
+        ],
+      ]
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'getClientDataSets')!
+          .outputs,
+        options.warmStorageView?.getClientDataSets?.(args as getClientDataSetsInput) ?? defaultClientDataSets
+      )
+    }
+
+    case 'railToDataSet': {
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'railToDataSet')!.outputs,
+        options.warmStorageView?.railToDataSet?.(args as railToDataSetInput) ?? [1n]
+      )
+    }
+
+    default: {
+      throw new Error(`Warm Storage View: unknown function: ${functionName} with args: ${args}`)
+    }
+  }
+}

--- a/src/test/mocks/jsonrpc/warm-storage.ts
+++ b/src/test/mocks/jsonrpc/warm-storage.ts
@@ -1,23 +1,61 @@
 /** biome-ignore-all lint/style/noNonNullAssertion: testing */
-import type { AbiParametersToPrimitiveTypes, ExtractAbiFunction } from 'abitype'
+import type { ExtractAbiFunction } from 'abitype'
 import { decodeFunctionData, encodeAbiParameters, type Hex } from 'viem'
 import { CONTRACT_ABIS } from '../../../utils/constants.ts'
-import { ADDRESSES, type JSONRPCOptions } from './index.ts'
+import type { AbiToType, JSONRPCOptions } from './types.ts'
 
-export type isProviderApprovedInput = AbiParametersToPrimitiveTypes<
-  ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'isProviderApproved'>['inputs']
->
+/**
+ * Warm Storage View ABI types
+ */
 
-export type railToDataSetInput = AbiParametersToPrimitiveTypes<
-  ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'railToDataSet'>['inputs']
->
+export type isProviderApproved = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'isProviderApproved'>
 
-export type getClientDataSetsInput = AbiParametersToPrimitiveTypes<
-  ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getClientDataSets'>['inputs']
->
-export type DataSetInfo = AbiParametersToPrimitiveTypes<
-  ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getClientDataSets'>['outputs']
->
+export type railToDataSet = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'railToDataSet'>
+
+export type getClientDataSets = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getClientDataSets'>
+
+export type getApprovedProviders = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getApprovedProviders'>
+
+export interface WarmStorageViewOptions {
+  isProviderApproved?: (args: AbiToType<isProviderApproved['inputs']>) => AbiToType<isProviderApproved['outputs']>
+  getClientDataSets?: (args: AbiToType<getClientDataSets['inputs']>) => AbiToType<getClientDataSets['outputs']>
+  railToDataSet?: (args: AbiToType<railToDataSet['inputs']>) => AbiToType<railToDataSet['outputs']>
+  getApprovedProviders?: (args: AbiToType<getApprovedProviders['inputs']>) => AbiToType<getApprovedProviders['outputs']>
+}
+
+/**
+ * Warm Storage ABI types
+ */
+
+export type pdpVerifierAddress = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE, 'pdpVerifierAddress'>
+
+export type paymentsContractAddress = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE, 'paymentsContractAddress'>
+
+export type usdfcTokenAddress = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE, 'usdfcTokenAddress'>
+
+export type filCDNBeneficiaryAddress = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE, 'filCDNBeneficiaryAddress'>
+
+export type viewContractAddress = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE, 'viewContractAddress'>
+
+export type serviceProviderRegistry = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE, 'serviceProviderRegistry'>
+
+export type getServicePrice = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE, 'getServicePrice'>
+
+export interface WarmStorageOptions {
+  pdpVerifierAddress?: (args: AbiToType<pdpVerifierAddress['inputs']>) => AbiToType<pdpVerifierAddress['outputs']>
+  paymentsContractAddress?: (
+    args: AbiToType<paymentsContractAddress['inputs']>
+  ) => AbiToType<paymentsContractAddress['outputs']>
+  usdfcTokenAddress?: (args: AbiToType<usdfcTokenAddress['inputs']>) => AbiToType<usdfcTokenAddress['outputs']>
+  filCDNBeneficiaryAddress?: (
+    args: AbiToType<filCDNBeneficiaryAddress['inputs']>
+  ) => AbiToType<filCDNBeneficiaryAddress['outputs']>
+  viewContractAddress?: (args: AbiToType<viewContractAddress['inputs']>) => AbiToType<viewContractAddress['outputs']>
+  serviceProviderRegistry?: (
+    args: AbiToType<serviceProviderRegistry['inputs']>
+  ) => AbiToType<serviceProviderRegistry['outputs']>
+  getServicePrice?: (args: AbiToType<getServicePrice['inputs']>) => AbiToType<getServicePrice['outputs']>
+}
 
 /**
  * Handle warm storage calls
@@ -32,36 +70,71 @@ export function warmStorageCallHandler(data: Hex, options: JSONRPCOptions): Hex 
     console.debug('Warm Storage: calling function', functionName, 'with args', args)
   }
   switch (functionName) {
-    case 'pdpVerifierAddress':
+    case 'pdpVerifierAddress': {
+      if (!options.warmStorage?.pdpVerifierAddress) {
+        throw new Error('Warm Storage: pdpVerifierAddress is not defined')
+      }
       return encodeAbiParameters(
         [{ name: '', internalType: 'address', type: 'address' }],
-        [options.warmStorage?.pdpVerifierAddress ?? ADDRESSES.calibration.pdpVerifier]
+        options.warmStorage.pdpVerifierAddress(args)
       )
-    case 'paymentsContractAddress':
+    }
+    case 'paymentsContractAddress': {
+      if (!options.warmStorage?.paymentsContractAddress) {
+        throw new Error('Warm Storage: paymentsContractAddress is not defined')
+      }
       return encodeAbiParameters(
         [{ name: '', internalType: 'address', type: 'address' }],
-        [options.warmStorage?.paymentsContractAddress ?? ADDRESSES.calibration.payments]
+        options.warmStorage.paymentsContractAddress(args)
       )
-    case 'usdfcTokenAddress':
+    }
+    case 'usdfcTokenAddress': {
+      if (!options.warmStorage?.usdfcTokenAddress) {
+        throw new Error('Warm Storage: usdfcTokenAddress is not defined')
+      }
       return encodeAbiParameters(
         [{ name: '', internalType: 'address', type: 'address' }],
-        [options.warmStorage?.usdfcTokenAddress ?? ADDRESSES.calibration.usdfcToken]
+        options.warmStorage.usdfcTokenAddress(args)
       )
-    case 'filCDNBeneficiaryAddress':
+    }
+    case 'filCDNBeneficiaryAddress': {
+      if (!options.warmStorage?.filCDNBeneficiaryAddress) {
+        throw new Error('Warm Storage: filCDNBeneficiaryAddress is not defined')
+      }
       return encodeAbiParameters(
         [{ name: '', internalType: 'address', type: 'address' }],
-        [options.warmStorage?.filCDNBeneficiaryAddress ?? ADDRESSES.calibration.filCDN]
+        options.warmStorage.filCDNBeneficiaryAddress(args)
       )
-    case 'viewContractAddress':
+    }
+    case 'viewContractAddress': {
+      if (!options.warmStorage?.viewContractAddress) {
+        throw new Error('Warm Storage: viewContractAddress is not defined')
+      }
       return encodeAbiParameters(
         [{ name: '', internalType: 'address', type: 'address' }],
-        [options.warmStorage?.viewContractAddress ?? ADDRESSES.calibration.viewContract]
+        options.warmStorage.viewContractAddress(args)
       )
-    case 'serviceProviderRegistry':
+    }
+
+    case 'serviceProviderRegistry': {
+      if (!options.warmStorage?.serviceProviderRegistry) {
+        throw new Error('Warm Storage: serviceProviderRegistry is not defined')
+      }
       return encodeAbiParameters(
         [{ name: '', internalType: 'address', type: 'address' }],
-        [options.warmStorage?.serviceProviderRegistry ?? ADDRESSES.calibration.spRegistry]
+        options.warmStorage.serviceProviderRegistry(args)
       )
+    }
+
+    case 'getServicePrice': {
+      if (!options.warmStorage?.getServicePrice) {
+        throw new Error('Warm Storage: getServicePrice is not defined')
+      }
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE.find((abi) => abi.type === 'function' && abi.name === 'getServicePrice')!.outputs,
+        options.warmStorage.getServicePrice(args)
+      )
+    }
     default: {
       throw new Error(`Warm Storage: unknown function: ${functionName} with args: ${args}`)
     }
@@ -82,41 +155,44 @@ export function warmStorageViewCallHandler(data: Hex, options: JSONRPCOptions): 
   }
 
   switch (functionName) {
-    case 'isProviderApproved':
+    case 'isProviderApproved': {
+      if (!options.warmStorageView?.isProviderApproved) {
+        throw new Error('Warm Storage View: isProviderApproved is not defined')
+      }
       return encodeAbiParameters(
         CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'isProviderApproved')!
           .outputs,
-        [options.warmStorageView?.isProviderApproved?.(args as isProviderApprovedInput) ?? true]
+        options.warmStorageView.isProviderApproved(args)
       )
+    }
     case 'getClientDataSets': {
-      const defaultClientDataSets: DataSetInfo = [
-        [
-          {
-            pdpRailId: 1n,
-            cacheMissRailId: 0n,
-            cdnRailId: 0n,
-            payer: ADDRESSES.client1,
-            payee: ADDRESSES.serviceProvider1,
-            serviceProvider: ADDRESSES.serviceProvider1,
-            commissionBps: 100n,
-            clientDataSetId: 0n,
-            pdpEndEpoch: 0n,
-            providerId: 1n,
-            cdnEndEpoch: 0n,
-          },
-        ],
-      ]
+      if (!options.warmStorageView?.getClientDataSets) {
+        throw new Error('Warm Storage View: getClientDataSets is not defined')
+      }
       return encodeAbiParameters(
         CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'getClientDataSets')!
           .outputs,
-        options.warmStorageView?.getClientDataSets?.(args as getClientDataSetsInput) ?? defaultClientDataSets
+        options.warmStorageView.getClientDataSets(args)
       )
     }
 
     case 'railToDataSet': {
+      if (!options.warmStorageView?.railToDataSet) {
+        throw new Error('Warm Storage View: railToDataSet is not defined')
+      }
       return encodeAbiParameters(
         CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'railToDataSet')!.outputs,
-        options.warmStorageView?.railToDataSet?.(args as railToDataSetInput) ?? [1n]
+        options.warmStorageView.railToDataSet(args)
+      )
+    }
+    case 'getApprovedProviders': {
+      if (!options.warmStorageView?.getApprovedProviders) {
+        throw new Error('Warm Storage View: getApprovedProviders is not defined')
+      }
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'getApprovedProviders')!
+          .outputs,
+        options.warmStorageView.getApprovedProviders(args)
       )
     }
 

--- a/src/test/mocks/mockServiceWorker.js
+++ b/src/test/mocks/mockServiceWorker.js
@@ -1,0 +1,344 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.10.5'
+const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ */
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/test/pdp-server.test.ts
+++ b/src/test/pdp-server.test.ts
@@ -615,7 +615,7 @@ describe('PDPServer', () => {
 
       server.use(
         http.get('http://pdp.local/piece/:pieceCid', async () => {
-          return HttpResponse.arrayBuffer(testData)
+          return HttpResponse.arrayBuffer(testData.buffer)
         })
       )
 
@@ -659,7 +659,7 @@ describe('PDPServer', () => {
 
       server.use(
         http.get('http://pdp.local/piece/:pieceCid', async () => {
-          return HttpResponse.arrayBuffer(wrongData)
+          return HttpResponse.arrayBuffer(wrongData.buffer)
         })
       )
 

--- a/src/test/pdp-server.test.ts
+++ b/src/test/pdp-server.test.ts
@@ -14,34 +14,12 @@ import { PDPAuthHelper, PDPServer } from '../pdp/index.ts'
 import type { PDPAddPiecesInput } from '../pdp/server.ts'
 import { asPieceCID, calculate as calculatePieceCID } from '../piece/index.ts'
 
-// Mock server for testing
-class MockPDPServer {
-  private readonly handlers: Map<string, (req: any, res: any) => void> = new Map()
-
-  addHandler(method: string, path: string, handler: (req: any, res: any) => void): void {
-    this.handlers.set(`${method}:${path}`, handler)
-  }
-
-  async start(port: number): Promise<string> {
-    return await new Promise((resolve) => {
-      // Mock implementation - in real tests this would be a proper HTTP server
-      const baseUrl = `http://localhost:${port}`
-      resolve(baseUrl)
-    })
-  }
-
-  async stop(): Promise<void> {
-    return await Promise.resolve()
-  }
-}
-
 // mock server for testing
 const server = setup([])
 
 describe('PDPServer', () => {
   let pdpServer: PDPServer
   let authHelper: PDPAuthHelper
-  let mockServer: MockPDPServer
   let serverUrl: string
 
   const TEST_PRIVATE_KEY = '0x1234567890123456789012345678901234567890123456789012345678901234'
@@ -64,15 +42,10 @@ describe('PDPServer', () => {
     authHelper = new PDPAuthHelper(TEST_CONTRACT_ADDRESS, signer, BigInt(TEST_CHAIN_ID))
 
     // Start mock server
-    mockServer = new MockPDPServer()
     serverUrl = 'http://pdp.local'
 
     // Create PDPServer instance
     pdpServer = new PDPServer(authHelper, serverUrl)
-  })
-
-  afterEach(async () => {
-    await mockServer.stop()
   })
 
   describe('constructor', () => {

--- a/src/test/synapse.test.ts
+++ b/src/test/synapse.test.ts
@@ -388,7 +388,7 @@ describe('Synapse', () => {
           })
         }),
         http.get('https://pdp.example.com/piece/:pieceCid', async () => {
-          return HttpResponse.arrayBuffer(testData)
+          return HttpResponse.arrayBuffer(testData.buffer)
         })
       )
 
@@ -412,7 +412,7 @@ describe('Synapse', () => {
         JSONRPC({ debug: true }),
         http.get<{ cid: string; wallet: string }>(`https://:wallet.calibration.filcdn.io/:cid`, async ({ params }) => {
           deferred.resolve(params)
-          return HttpResponse.arrayBuffer(testData)
+          return HttpResponse.arrayBuffer(testData.buffer)
         }),
         http.get('https://pdp.example.com/pdp/piece', async ({ request }) => {
           const url = new URL(request.url)
@@ -423,7 +423,7 @@ describe('Synapse', () => {
           })
         }),
         http.get('https://pdp.example.com/piece/:pieceCid', async () => {
-          return HttpResponse.arrayBuffer(testData)
+          return HttpResponse.arrayBuffer(testData.buffer)
         })
       )
 

--- a/src/test/synapse.test.ts
+++ b/src/test/synapse.test.ts
@@ -9,27 +9,15 @@ import { ethers } from 'ethers'
 import { setup } from 'iso-web/msw'
 import { HttpResponse, http } from 'msw'
 import pDefer from 'p-defer'
-import { type Address, isAddressEqual } from 'viem'
-
+import { type Address, isAddressEqual, parseUnits } from 'viem'
 import { PaymentsService } from '../payments/index.ts'
 import { Synapse } from '../synapse.ts'
-import { ADDRESSES, JSONRPC, PRIVATE_KEYS } from './mocks/jsonrpc/index.ts'
-import {
-  createMockProvider,
-  createMockProviderInfo,
-  createMockSigner,
-  extendMockProviderCall,
-  MOCK_ADDRESSES,
-  setupProviderRegistryMocks,
-} from './test-utils.ts'
+import { ADDRESSES, JSONRPC, PRIVATE_KEYS, presets } from './mocks/jsonrpc/index.ts'
 
 // mock server for testing
 const server = setup([])
-const TEST_PRIVATE_KEY = '0x1234567890123456789012345678901234567890123456789012345678901234'
 
 describe('Synapse', () => {
-  let mockProvider: ethers.Provider
-  let mockSigner: ethers.Signer
   let signer: ethers.Signer
   let provider: ethers.Provider
   before(async () => {
@@ -43,13 +31,11 @@ describe('Synapse', () => {
     server.resetHandlers()
     provider = new ethers.JsonRpcProvider('https://api.calibration.node.glif.io/rpc/v1')
     signer = new ethers.Wallet(PRIVATE_KEYS.key1, provider)
-    mockProvider = createMockProvider()
-    mockSigner = createMockSigner(MOCK_ADDRESSES.SIGNER, mockProvider)
   })
 
   describe('Instantiation', () => {
     it('should create instance with signer', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({ signer })
       assert.exists(synapse)
       assert.exists(synapse.payments)
@@ -57,7 +43,7 @@ describe('Synapse', () => {
     })
 
     it('should create instance with provider', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({ provider })
       assert.exists(synapse)
       assert.exists(synapse.payments)
@@ -65,7 +51,7 @@ describe('Synapse', () => {
     })
 
     it('should create instance with private key', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const privateKey = '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
       const rpcURL = 'https://api.calibration.node.glif.io/rpc/v1'
       const synapse = await Synapse.create({ privateKey, rpcURL })
@@ -75,14 +61,14 @@ describe('Synapse', () => {
     })
 
     it('should apply NonceManager by default', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({ signer })
       assert.exists(synapse)
       // We can't directly check if NonceManager is applied, but we can verify the instance is created
     })
 
     it('should allow disabling NonceManager', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({
         signer,
         disableNonceManager: true,
@@ -94,7 +80,7 @@ describe('Synapse', () => {
     it.skip('should allow enabling CDN', async () => {
       // Skip this test as it requires real contract interactions
       const synapse = await Synapse.create({
-        signer: mockSigner,
+        signer,
         withCDN: true,
       })
       const storageService = await synapse.createStorage()
@@ -142,6 +128,7 @@ describe('Synapse', () => {
       // const unsupportedProvider = createMockProvider(999999)
       server.use(
         JSONRPC({
+          ...presets.basic,
           eth_chainId: '999999',
         })
       )
@@ -157,6 +144,7 @@ describe('Synapse', () => {
     it('should accept calibration network', async () => {
       server.use(
         JSONRPC({
+          ...presets.basic,
           eth_chainId: '314159',
         })
       )
@@ -167,6 +155,7 @@ describe('Synapse', () => {
     it('should accept mainnet with custom warmStorage address', async () => {
       server.use(
         JSONRPC({
+          ...presets.basic,
           eth_chainId: '314',
         })
       )
@@ -183,8 +172,9 @@ describe('Synapse', () => {
       const customPDPVerifierAddress = '0xabcdef1234567890123456789012345678901234'
       server.use(
         JSONRPC({
+          ...presets.basic,
           warmStorage: {
-            pdpVerifierAddress: customPDPVerifierAddress,
+            pdpVerifierAddress: () => [customPDPVerifierAddress],
           },
         })
       )
@@ -199,7 +189,7 @@ describe('Synapse', () => {
 
     // theres no default pdpVerifierAddress in the SDK anymore
     it.skip('should use default pdpVerifierAddress when not provided', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({
         provider,
       })
@@ -211,7 +201,7 @@ describe('Synapse', () => {
     it.skip('should accept both custom warmStorageAddress and pdpVerifierAddress', async () => {
       const customPDPVerifierAddress = '0x2222222222222222222222222222222222222222'
 
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({
         provider,
         warmStorageAddress: ADDRESSES.mainnet.warmStorage,
@@ -225,7 +215,7 @@ describe('Synapse', () => {
 
   describe('StorageManager access', () => {
     it('should provide access to StorageManager via synapse.storage', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({ signer })
 
       // Should be able to access storage manager
@@ -241,7 +231,7 @@ describe('Synapse', () => {
     })
 
     it('should create storage manager with CDN settings', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({
         signer,
         withCDN: true,
@@ -254,7 +244,7 @@ describe('Synapse', () => {
     })
 
     it('should return same storage manager instance', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({ signer })
 
       const storage1 = synapse.storage
@@ -267,7 +257,7 @@ describe('Synapse', () => {
 
   describe('Payment access', () => {
     it('should provide read-only access to payments', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({ signer })
 
       // Should be able to access payments
@@ -290,7 +280,7 @@ describe('Synapse', () => {
 
   describe('getProviderInfo', () => {
     it('should get provider info for valid approved provider', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
 
       const synapse = await Synapse.create({ provider })
       const providerInfo = await synapse.getProviderInfo(ADDRESSES.serviceProvider1)
@@ -300,7 +290,7 @@ describe('Synapse', () => {
     })
 
     it('should throw for invalid provider address', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({ signer })
 
       try {
@@ -314,19 +304,20 @@ describe('Synapse', () => {
     it('should throw for non-approved provider', async () => {
       server.use(
         JSONRPC({
+          ...presets.basic,
           serviceRegistry: {
-            getProviderIdByAddress: 3n,
+            ...presets.basic.serviceRegistry,
+            getProviderIdByAddress: () => [3n],
           },
           warmStorageView: {
-            isProviderApproved: ([providerId]) => providerId === 1n,
+            isProviderApproved: ([providerId]) => [providerId === 1n],
           },
         })
       )
-      const mockProviderAddress = ADDRESSES.serviceProvider1
 
       try {
         const synapse = await Synapse.create({ signer })
-        await synapse.getProviderInfo(mockProviderAddress)
+        await synapse.getProviderInfo(ADDRESSES.serviceProvider1)
         assert.fail('Should have thrown')
       } catch (error: any) {
         assert.include(error.message, 'not approved')
@@ -336,8 +327,10 @@ describe('Synapse', () => {
     it('should throw when provider not found', async () => {
       server.use(
         JSONRPC({
+          ...presets.basic,
           serviceRegistry: {
-            getProviderByAddress: [
+            ...presets.basic.serviceRegistry,
+            getProviderByAddress: () => [
               {
                 serviceProvider: ADDRESSES.zero,
                 payee: ADDRESSES.zero,
@@ -362,7 +355,7 @@ describe('Synapse', () => {
 
   describe('download', () => {
     it('should validate PieceCID input', async () => {
-      server.use(JSONRPC())
+      server.use(JSONRPC(presets.basic))
       const synapse = await Synapse.create({ signer })
 
       try {
@@ -378,7 +371,7 @@ describe('Synapse', () => {
       // Create test data that matches the expected PieceCID
       const testData = new TextEncoder().encode('test data')
       server.use(
-        JSONRPC(),
+        JSONRPC(presets.basic),
         http.get('https://pdp.example.com/pdp/piece', async ({ request }) => {
           const url = new URL(request.url)
           const pieceCid = url.searchParams.get('pieceCid')
@@ -409,7 +402,7 @@ describe('Synapse', () => {
       const deferred = pDefer<{ cid: string; wallet: string }>()
       const testData = new TextEncoder().encode('test data')
       server.use(
-        JSONRPC({ debug: true }),
+        JSONRPC({ ...presets.basic }),
         http.get<{ cid: string; wallet: string }>(`https://:wallet.calibration.filcdn.io/:cid`, async ({ params }) => {
           deferred.resolve(params)
           return HttpResponse.arrayBuffer(testData.buffer)
@@ -451,16 +444,32 @@ describe('Synapse', () => {
     it('should pass providerAddress option to retriever', async () => {
       let providerAddressReceived: string | undefined
       const testData = new TextEncoder().encode('test data')
-      const mockRetriever = {
-        fetchPiece: async (_pieceCid: any, _client: string, options?: any) => {
-          providerAddressReceived = options?.providerAddress
-          return new Response(testData)
-        },
-      }
 
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          serviceRegistry: {
+            ...presets.basic.serviceRegistry,
+            getProviderByAddress: (data) => {
+              providerAddressReceived = data[0]
+              return presets.basic.serviceRegistry.getProviderByAddress(data)
+            },
+          },
+        }),
+        http.get('https://pdp.example.com/pdp/piece', async ({ request }) => {
+          const url = new URL(request.url)
+          const pieceCid = url.searchParams.get('pieceCid')
+
+          return HttpResponse.json({
+            pieceCid,
+          })
+        }),
+        http.get('https://pdp.example.com/piece/:pieceCid', async () => {
+          return HttpResponse.arrayBuffer(testData.buffer)
+        })
+      )
       const synapse = await Synapse.create({
-        signer: mockSigner,
-        pieceRetriever: mockRetriever,
+        signer,
       })
 
       const testPieceCid = 'bafkzcibcoybm2jlqsbekq6uluyl7xm5ffemw7iuzni5ez3a27iwy4qu3ssebqdq'
@@ -471,15 +480,15 @@ describe('Synapse', () => {
     })
 
     it('should handle download errors', async () => {
-      const mockRetriever = {
-        fetchPiece: async () => {
-          throw new Error('Network error')
-        },
-      }
+      server.use(
+        JSONRPC(presets.basic),
+        http.get('https://pdp.example.com/pdp/piece', async () => {
+          return HttpResponse.error()
+        })
+      )
 
       const synapse = await Synapse.create({
-        signer: mockSigner,
-        pieceRetriever: mockRetriever,
+        signer,
       })
 
       const testPieceCid = 'bafkzcibcoybm2jlqsbekq6uluyl7xm5ffemw7iuzni5ez3a27iwy4qu3ssebqdq'
@@ -488,295 +497,135 @@ describe('Synapse', () => {
         await synapse.download(testPieceCid)
         assert.fail('Should have thrown')
       } catch (error: any) {
-        assert.include(error.message, 'Network error')
+        assert.include(
+          error.message,
+          'All provider retrieval attempts failed and no additional retriever method was configured'
+        )
       }
     })
   })
 
   describe('getStorageInfo', () => {
-    it.skip('should return comprehensive storage information', async () => {
-      // SKIPPED: Complex mock chaining issue with provider registry mocks
-      // Mock provider data
-      const mockProvider1 = createMockProviderInfo({
-        id: 1,
-        serviceProvider: '0x1111111111111111111111111111111111111111',
-        name: 'Test Provider 1',
-        products: {
-          PDP: {
-            type: 'PDP',
-            isActive: true,
-            capabilities: {},
-            data: {
-              serviceURL: 'https://pdp1.example.com',
-              minPieceSizeInBytes: BigInt(1024),
-              maxPieceSizeInBytes: BigInt(32) * BigInt(1024) * BigInt(1024) * BigInt(1024),
-              ipniPiece: false,
-              ipniIpfs: false,
-              storagePricePerTibPerMonth: BigInt(1000000),
-              minProvingPeriodInEpochs: 2880,
-              location: 'US-EAST',
-              paymentTokenAddress: ethers.ZeroAddress,
-            },
-          },
-        },
-      })
-      const mockProvider2 = createMockProviderInfo({
-        id: 2,
-        serviceProvider: '0x2222222222222222222222222222222222222222',
-        name: 'Test Provider 2',
-        products: {
-          PDP: {
-            type: 'PDP',
-            isActive: true,
-            capabilities: {},
-            data: {
-              serviceURL: 'https://pdp2.example.com',
-              minPieceSizeInBytes: BigInt(1024),
-              maxPieceSizeInBytes: BigInt(32) * BigInt(1024) * BigInt(1024) * BigInt(1024),
-              ipniPiece: false,
-              ipniIpfs: false,
-              storagePricePerTibPerMonth: BigInt(2000000),
-              minProvingPeriodInEpochs: 2880,
-              location: 'EU-WEST',
-              paymentTokenAddress: ethers.ZeroAddress,
-            },
-          },
-        },
-      })
+    it('should return comprehensive storage information', async () => {
+      server.use(JSONRPC({ ...presets.basic }))
 
-      // Mock pricing data
-      const mockPricingData = {
-        pricePerTiBPerMonthNoCDN: ethers.parseUnits('2', 18), // 2 USDFC per TiB per month
-        pricePerTiBPerMonthWithCDN: ethers.parseUnits('3', 18), // 3 USDFC per TiB per month
-        tokenAddress: '0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0',
-        epochsPerMonth: 86400,
-      }
+      const synapse = await Synapse.create({ signer })
+      const storageInfo = await synapse.getStorageInfo()
 
-      // Mock allowances will be handled by setupProviderRegistryMocks
+      // Check pricing
+      assert.exists(storageInfo.pricing)
+      assert.exists(storageInfo.pricing.noCDN)
+      assert.exists(storageInfo.pricing.withCDN)
 
-      // Combine registry mocks with pricing mocks in a single function
-      const cleanup = extendMockProviderCall(mockProvider, async (transaction: any) => {
-        const data = transaction.data
+      // Verify pricing calculations (2 USDFC per TiB per month)
+      const expectedNoCDNMonthly = parseUnits('2', 18) // 2 USDFC
+      assert.equal(storageInfo.pricing.noCDN.perTiBPerMonth, expectedNoCDNMonthly)
 
-        // First try the pricing mock
-        if (data?.startsWith('0x5482bdf9') === true) {
-          return ethers.AbiCoder.defaultAbiCoder().encode(
-            ['tuple(uint256,uint256,address,uint256)'],
-            [
-              [
-                mockPricingData.pricePerTiBPerMonthNoCDN,
-                mockPricingData.pricePerTiBPerMonthWithCDN,
-                mockPricingData.tokenAddress,
-                mockPricingData.epochsPerMonth,
-              ],
-            ]
-          )
-        }
+      // Check providers
+      assert.equal(storageInfo.providers.length, 2)
+      assert.equal(storageInfo.providers[0].serviceProvider, ADDRESSES.serviceProvider1)
+      assert.equal(storageInfo.providers[1].serviceProvider, ADDRESSES.serviceProvider2)
 
-        // Mock getApprovedProviders() - returns array of provider IDs
-        if (data?.startsWith('0x266afe1b')) {
-          return ethers.AbiCoder.defaultAbiCoder().encode(['uint256[]'], [[BigInt(1), BigInt(2)]])
-        }
+      // Check service parameters
+      assert.equal(storageInfo.serviceParameters.network, 'calibration')
+      assert.equal(storageInfo.serviceParameters.epochsPerMonth, 86400n)
+      assert.equal(storageInfo.serviceParameters.epochsPerDay, 2880n)
+      assert.equal(storageInfo.serviceParameters.epochDuration, 30)
+      assert.equal(storageInfo.serviceParameters.minUploadSize, 127)
+      assert.equal(storageInfo.serviceParameters.maxUploadSize, 200 * 1024 * 1024)
 
-        return null
-      })
-
-      // Also set up provider registry mocks for the SPRegistry calls
-      const registryCleanup = setupProviderRegistryMocks(mockProvider, {
-        approvedIds: [1, 2],
-        providers: [mockProvider1, mockProvider2],
-      })
-
-      try {
-        const synapse = await Synapse.create({ signer: mockSigner })
-        const storageInfo = await synapse.getStorageInfo()
-
-        // Check pricing
-        assert.exists(storageInfo.pricing)
-        assert.exists(storageInfo.pricing.noCDN)
-        assert.exists(storageInfo.pricing.withCDN)
-
-        // Verify pricing calculations (2 USDFC per TiB per month)
-        const expectedNoCDNMonthly = ethers.parseUnits('2', 18) // 2 USDFC
-        assert.equal(storageInfo.pricing.noCDN.perTiBPerMonth, expectedNoCDNMonthly)
-
-        // Check providers
-        assert.equal(storageInfo.providers.length, 2)
-        assert.equal(storageInfo.providers[0].serviceProvider, mockProvider1.serviceProvider)
-        assert.equal(storageInfo.providers[1].serviceProvider, mockProvider2.serviceProvider)
-
-        // Check service parameters
-        assert.equal(storageInfo.serviceParameters.network, 'calibration')
-        assert.equal(storageInfo.serviceParameters.epochsPerMonth, BigInt(86400))
-        assert.equal(storageInfo.serviceParameters.epochsPerDay, 2880n)
-        assert.equal(storageInfo.serviceParameters.epochDuration, 30)
-        assert.equal(storageInfo.serviceParameters.minUploadSize, 127)
-        assert.equal(storageInfo.serviceParameters.maxUploadSize, 200 * 1024 * 1024)
-
-        // Check allowances
-        assert.exists(storageInfo.allowances)
-        assert.equal(storageInfo.allowances?.service, '0xA94C1139412da84d3bBb152dac22B0943332fD78')
-        assert.equal(storageInfo.allowances?.rateAllowance, BigInt(1000000))
-        assert.equal(storageInfo.allowances?.lockupAllowance, BigInt(10000000))
-      } finally {
-        cleanup()
-        registryCleanup()
-      }
+      // Check allowances
+      assert.exists(storageInfo.allowances)
+      assert.equal(storageInfo.allowances?.service, ADDRESSES.calibration.warmStorage)
+      assert.equal(storageInfo.allowances?.rateAllowance, 1000000n)
+      assert.equal(storageInfo.allowances?.lockupAllowance, 10000000n)
     })
 
     it('should handle missing allowances gracefully', async () => {
-      // No providers for this test
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          payments: {
+            operatorApprovals: () => [false, 0n, 0n, 0n, 0n, 0n],
+          },
+        })
+      )
 
-      // Mock pricing data
-      const mockPricingData = {
-        pricePerTiBPerMonthNoCDN: ethers.parseUnits('2', 18), // 2 USDFC per TiB per month
-        pricePerTiBPerMonthWithCDN: ethers.parseUnits('3', 18), // 3 USDFC per TiB per month
-        tokenAddress: '0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0',
-        epochsPerMonth: 86400,
-      }
+      const synapse = await Synapse.create({ signer })
+      const storageInfo = await synapse.getStorageInfo()
 
-      // Setup with no providers and throw on approval check
-      const registryCleanup = setupProviderRegistryMocks(mockProvider, {
-        approvedIds: [],
-        providers: [],
-        throwOnApproval: true, // This will make allowances return null
+      // Should still return data with null allowances
+      assert.exists(storageInfo.pricing)
+      assert.exists(storageInfo.providers)
+      assert.exists(storageInfo.serviceParameters)
+      assert.deepEqual(storageInfo.allowances, {
+        service: ADDRESSES.calibration.warmStorage,
+        rateAllowance: 0n,
+        lockupAllowance: 0n,
+        rateUsed: 0n,
+        lockupUsed: 0n,
       })
-
-      // Add pricing mocks
-      const pricingCleanup = extendMockProviderCall(mockProvider, async (transaction: any) => {
-        const data = transaction.data
-
-        // Mock getServicePrice
-        if (data?.startsWith('0x5482bdf9') === true) {
-          return ethers.AbiCoder.defaultAbiCoder().encode(
-            ['tuple(uint256,uint256,address,uint256)'],
-            [
-              [
-                mockPricingData.pricePerTiBPerMonthNoCDN,
-                mockPricingData.pricePerTiBPerMonthWithCDN,
-                mockPricingData.tokenAddress,
-                mockPricingData.epochsPerMonth,
-              ],
-            ]
-          )
-        }
-
-        return null
-      })
-
-      try {
-        const synapse = await Synapse.create({ signer: mockSigner })
-        const storageInfo = await synapse.getStorageInfo()
-
-        // Should still return data with null allowances
-        assert.exists(storageInfo.pricing)
-        assert.exists(storageInfo.providers)
-        assert.exists(storageInfo.serviceParameters)
-        assert.isNull(storageInfo.allowances)
-      } finally {
-        registryCleanup()
-        pricingCleanup()
-      }
     })
 
-    it.skip('should filter out zero address providers', async () => {
-      // SKIPPED: Complex mock chaining issue with provider registry mocks
-      // Mock provider data with a zero address
-      const mockProvider1 = createMockProviderInfo({
-        id: 1,
-        serviceProvider: '0x1111111111111111111111111111111111111111',
-        products: {
-          PDP: {
-            type: 'PDP',
-            isActive: true,
-            capabilities: {},
-            data: {
-              serviceURL: 'https://pdp1.example.com',
-              minPieceSizeInBytes: BigInt(1024),
-              maxPieceSizeInBytes: BigInt(32) * BigInt(1024) * BigInt(1024) * BigInt(1024),
-              ipniPiece: false,
-              ipniIpfs: false,
-              storagePricePerTibPerMonth: BigInt(1000000),
-              minProvingPeriodInEpochs: 2880,
-              location: 'US-EAST',
-              paymentTokenAddress: ethers.ZeroAddress,
+    it('should filter out zero address providers', async () => {
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          serviceRegistry: {
+            ...presets.basic.serviceRegistry,
+            getProvider: (data) => {
+              if (data[0] === 1n) {
+                return [
+                  {
+                    serviceProvider: ADDRESSES.serviceProvider1,
+                    payee: ADDRESSES.payee1,
+                    isActive: true,
+                    name: 'Test Provider',
+                    description: 'Test Provider',
+                  },
+                ]
+              }
+              return [
+                {
+                  serviceProvider: ADDRESSES.zero,
+                  payee: ADDRESSES.zero,
+                  isActive: false,
+                  name: '',
+                  description: '',
+                },
+              ]
             },
           },
-        },
-      })
-      // Provider with zero address should be filtered out
-      const mockProvider2 = createMockProviderInfo({
-        id: 2,
-        serviceProvider: ethers.ZeroAddress,
-        active: false,
-      })
+        })
+      )
 
-      // Mock pricing data
-      const mockPricingData = {
-        pricePerTiBPerMonthNoCDN: ethers.parseUnits('2', 18), // 2 USDFC per TiB per month
-        pricePerTiBPerMonthWithCDN: ethers.parseUnits('3', 18), // 3 USDFC per TiB per month
-        tokenAddress: '0xb3042734b608a1B16e9e86B374A3f3e389B4cDf0',
-        epochsPerMonth: 86400,
-      }
+      const synapse = await Synapse.create({ signer })
+      const storageInfo = await synapse.getStorageInfo()
 
-      // Setup registry mocks with both providers (including zero address)
-      const registryCleanup = setupProviderRegistryMocks(mockProvider, {
-        approvedIds: [1, 2],
-        providers: [mockProvider1, mockProvider2],
-        throwOnApproval: true, // No allowances
-      })
-
-      // Add pricing mocks
-      const pricingCleanup = extendMockProviderCall(mockProvider, async (transaction: any) => {
-        const data = transaction.data
-
-        // Mock getServicePrice
-        if (data?.startsWith('0x5482bdf9') === true) {
-          return ethers.AbiCoder.defaultAbiCoder().encode(
-            ['tuple(uint256,uint256,address,uint256)'],
-            [
-              [
-                mockPricingData.pricePerTiBPerMonthNoCDN,
-                mockPricingData.pricePerTiBPerMonthWithCDN,
-                mockPricingData.tokenAddress,
-                mockPricingData.epochsPerMonth,
-              ],
-            ]
-          )
-        }
-
-        return null
-      })
-
-      try {
-        const synapse = await Synapse.create({ signer: mockSigner })
-        const storageInfo = await synapse.getStorageInfo()
-
-        // Should filter out zero address provider
-        assert.equal(storageInfo.providers.length, 1)
-        assert.equal(storageInfo.providers[0].serviceProvider, mockProvider1.serviceProvider)
-      } finally {
-        registryCleanup()
-        pricingCleanup()
-      }
+      // Should filter out zero address provider
+      assert.equal(storageInfo.providers.length, 1)
+      assert.equal(storageInfo.providers[0].serviceProvider, ADDRESSES.serviceProvider1)
     })
 
     it('should handle contract call failures', async () => {
-      // Mock provider to fail
-      const originalCall = mockProvider.call
-      mockProvider.call = async () => {
-        throw new Error('RPC error')
-      }
-
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          warmStorage: {
+            ...presets.basic.warmStorage,
+            getServicePrice: () => {
+              throw new Error('RPC error')
+            },
+          },
+        })
+      )
       try {
-        const synapse = await Synapse.create({ signer: mockSigner })
+        const synapse = await Synapse.create({ signer })
         await synapse.getStorageInfo()
         assert.fail('Should have thrown')
       } catch (error: any) {
         // The error should bubble up from the contract call
         assert.include(error.message, 'RPC error')
-      } finally {
-        mockProvider.call = originalCall
       }
     })
   })


### PR DESCRIPTION
Proposing [msw](https://mswjs.io/) as replacement for all the fetch mocking makes tests more readable and cleaner and avoid a bunch of biome warning.

If you approve i will update the rest of the tests.

- Updated `test:browser` script to include assets from `src/test/mocks`.
- Modified `test:watch` script to use `npm run test:node -- --watch`.
- Added `msw` and `iso-web` as development dependencies for improved mocking in tests.
- Integrated `msw` setup in `pdp-server.test.ts` to replace global fetch mocks with more robust request handlers.
- Enhanced test cases to utilize `msw` for simulating server responses, improving test reliability and maintainability.
