### PR TITLE
chore: remove simple-git-hooks from devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "mocha": "^11.5.0",
     "playwright-test": "^14.1.12",
-    "simple-git-hooks": "^2.13.1",
     "typescript": "5.8.3",
     "webpack": "^5.99.9",
     "webpack-cli": "^6.0.1"


### PR DESCRIPTION
Ref: https://github.com/FilOzone/synapse-sdk/pull/165#pullrequestreview-3168132030

was accidentally added originally