### PR TITLE
FilCDNBeneficiary

### DIFF
--- a/src/warm-storage/service.ts
+++ b/src/warm-storage/service.ts
@@ -114,7 +114,7 @@ export class WarmStorageService {
     pdpVerifier: string
     payments: string
     usdfcToken: string
-    // filCDN: string
+    filCDNBeneficiary: string
     viewContract: string
     serviceProviderRegistry: string
   }
@@ -129,7 +129,7 @@ export class WarmStorageService {
       pdpVerifier: string
       payments: string
       usdfcToken: string
-      // filCDN: string
+      filCDNBeneficiary: string
       viewContract: string
       serviceProviderRegistry: string
     }
@@ -171,11 +171,11 @@ export class WarmStorageService {
         allowFailure: false,
         callData: iface.encodeFunctionData('usdfcTokenAddress'),
       },
-      // {
-      //   target: warmStorageAddress,
-      //   allowFailure: false,
-      //   callData: iface.encodeFunctionData('filCDNAddress'),
-      // },
+      {
+        target: warmStorageAddress,
+        allowFailure: false,
+        callData: iface.encodeFunctionData('filCDNBeneficiaryAddress'),
+      },
       {
         target: warmStorageAddress,
         allowFailure: false,
@@ -194,7 +194,7 @@ export class WarmStorageService {
       pdpVerifier: iface.decodeFunctionResult('pdpVerifierAddress', results[0].returnData)[0],
       payments: iface.decodeFunctionResult('paymentsContractAddress', results[1].returnData)[0],
       usdfcToken: iface.decodeFunctionResult('usdfcTokenAddress', results[2].returnData)[0],
-      // filCDN: iface.decodeFunctionResult('filCDNAddress', results[3].returnData)[0],
+      filCDNBeneficiary: iface.decodeFunctionResult('filCDNBeneficiaryAddress', results[3].returnData)[0],
       viewContract: iface.decodeFunctionResult('viewContractAddress', results[4].returnData)[0],
       serviceProviderRegistry: iface.decodeFunctionResult('serviceProviderRegistry', results[5].returnData)[0],
     }


### PR DESCRIPTION
Reviewer @hugomrdias
There is now both filCDNBeneficiary and filCDNController.
We don't use either of these addresses actually.
The filCDNController is on the view contract so we shouldn't fetch it in this first batch.
#### Changes
* fetch the filCDNBeneficiary