### PR TITLE
chore(docs): add GitHub Pages deployment workflow and enable GitHub Pages in Astro config

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -55,4 +55,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
-
+  docs:
+    name: Docs
+    concurrency: 
+      group: pages
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install --no-progress --no-package-lock --no-save
+      - run: npm run lint
+      - run: cd docs && npm install && npm run build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./docs/dist
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -78,6 +78,7 @@ export default defineConfig({
         docsPlugin({
           pagination: true,
           typeDocOptions: {
+            githubPages: true,
             entryPointStrategy: 'resolve',
             entryPoints: [
               '../src/index.ts',


### PR DESCRIPTION
- Introduced a new GitHub Actions job for deploying documentation to GitHub Pages.
- Configured permissions and steps for building and deploying the documentation.
- Enabled GitHub Pages support in the Astro configuration for better documentation hosting.