### PR TITLE
feat: allow custom metadata for data sets & roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ interface SynapseOptions {
 
   // Advanced Configuration
   withCDN?: boolean               // Enable CDN for retrievals (set a default for all new storage operations)
+  metadata?: MetadataEntry[]      // Optional metadata for data sets (key-value pairs)
   pieceRetriever?: PieceRetriever // Optional override for a custom retrieval stack
   disableNonceManager?: boolean   // Disable automatic nonce management
   warmStorageAddress?: string     // Override Warm Storage service contract address (all other addresses are discovered from this contract)
@@ -424,6 +425,7 @@ interface StorageServiceOptions {
   providerAddress?: string                 // Specific provider address to use
   dataSetId?: number                       // Specific data set ID to use
   withCDN?: boolean                        // Enable CDN services
+  metadata?: MetadataEntry[]               // Optional metadata for the data set
   callbacks?: StorageCreationCallbacks     // Progress callbacks
   uploadBatchSize?: number                 // Max uploads per batch (default: 32, min: 1)
 }
@@ -952,7 +954,7 @@ const pdpServer = new PDPServer(authHelper, 'https://pdp.provider.com', 'https:/
 const { txHash, statusUrl } = await pdpServer.createDataSet(
   clientDataSetId,     // number
   payee,               // string (service provider address)
-  withCDN,             // boolean
+  metadata,            // MetadataEntry[] (optional metadata, use [] for none)
   recordKeeper         // string (Warm Storage contract address)
 )
 
@@ -1004,13 +1006,14 @@ const authHelper = new PDPAuthHelper(warmStorageAddress, signer, chainId)
 const createDataSetSig = await authHelper.signCreateDataSet(
   clientDataSetId,    // number
   payeeAddress,       // string
-  withCDN             // boolean
+  metadata            // MetadataEntry[] (optional metadata)
 )
 
 const addPiecesSig = await authHelper.signAddPieces(
   clientDataSetId,    // number
   firstPieceId,       // number
-  pieceDataArray      // Array of { cid: string | PieceCID, rawSize: number }
+  pieceDataArray,     // Array of { cid: string | PieceCID, rawSize: number }
+  metadata            // MetadataEntry[][] (optional per-piece metadata)
 )
 
 // All signatures return { signature, v, r, s, signedData }
@@ -1298,8 +1301,8 @@ pdpServer.createProofSet(serviceProvider, clientDataSetId)
 pdpServer.addRoots(proofSetId, clientDataSetId, nextRootId, rootData)
 
 // After (v0.24.0+)
-pdpServer.createDataSet(serviceProvider, clientDataSetId)
-pdpServer.addPieces(dataSetId, clientDataSetId, nextPieceId, pieceData)
+pdpServer.createDataSet(clientDataSetId, serviceProvider, metadata, recordKeeper)
+pdpServer.addPieces(dataSetId, clientDataSetId, nextPieceId, pieceData, metadata)
 ```
 
 #### Service Provider Registry

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ The SDK automatically handles all the complexity of storage setup for you - sele
 2. **Explicit mode**: Create a context with `synapse.storage.createContext()` for more control. Contexts can be used directly or passed in the options to `synapse.storage.upload()` and `synapse.storage.download()`.
 
 Behind the scenes, the process may be:
-- **Fast (<1 second)**: When reusing existing infrastructure (i.e. an existing data set previously created)
+- **Fast (<1 second)**: When reusing existing data sets that match your requirements (including all metadata)
 - **Slower (2-5 minutes)**: When setting up new blockchain infrastructure (i.e. creating a brand new data set)
 
 #### Basic Usage
@@ -374,6 +374,18 @@ await synapse.storage.upload(data)  // Context created/reused automatically
 // Option 2: Explicit context creation
 const context = await synapse.storage.createContext()
 await context.upload(data)  // Upload to this specific context
+
+// Option 3: Context with metadata requirements
+const context = await synapse.storage.createContext({
+  metadata: [
+    { key: 'withIPFSIndexing', value: '' },
+    { key: 'category', value: 'videos' }
+  ]
+})
+// This will reuse any existing data set that has both of these metadata entries,
+// or create a new one if none match
+// Note: the `withCDN` option is an alias for a { key: 'withCDN', value: '' }
+// metadata entry.
 ```
 
 #### Advanced Usage with Callbacks
@@ -425,7 +437,7 @@ interface StorageServiceOptions {
   providerAddress?: string                 // Specific provider address to use
   dataSetId?: number                       // Specific data set ID to use
   withCDN?: boolean                        // Enable CDN services
-  metadata?: MetadataEntry[]               // Optional metadata for the data set
+  metadata?: MetadataEntry[]               // Metadata requirements for data set selection/creation
   callbacks?: StorageCreationCallbacks     // Progress callbacks
   uploadBatchSize?: number                 // Max uploads per batch (default: 32, min: 1)
 }
@@ -434,6 +446,11 @@ interface StorageServiceOptions {
 // 1. Synapse instance default (set during creation)
 // 2. StorageService override (set during createStorage)
 // 3. Per-method override (set during download)
+
+// Data Set Selection: When creating a context, the SDK attempts to reuse existing
+// data sets that match ALL your requirements. A data set matches if it contains
+// all requested metadata entries with matching values (order doesn't matter).
+// The data set may have additional metadata beyond what you request.
 ```
 
 #### Storage Context Properties

--- a/docs/src/content/docs/guides/migration-guide.mdx
+++ b/docs/src/content/docs/guides/migration-guide.mdx
@@ -82,8 +82,8 @@ pdpServer.createProofSet(serviceProvider, clientDataSetId)
 pdpServer.addRoots(proofSetId, clientDataSetId, nextRootId, rootData)
 
 // After (v0.24.0+)
-pdpServer.createDataSet(serviceProvider, clientDataSetId)
-pdpServer.addPieces(dataSetId, clientDataSetId, nextPieceId, pieceData)
+pdpServer.createDataSet(clientDataSetId, serviceProvider, metadata, recordKeeper)
+pdpServer.addPieces(dataSetId, clientDataSetId, nextPieceId, pieceData, metadata)
 ```
 
 #### Service Provider Registry

--- a/docs/src/content/docs/guides/storage.mdx
+++ b/docs/src/content/docs/guides/storage.mdx
@@ -76,6 +76,7 @@ interface StorageServiceOptions {
   providerAddress?: string                 // Specific provider address to use
   dataSetId?: number                       // Specific data set ID to use
   withCDN?: boolean                        // Enable CDN services
+  metadata?: MetadataEntry[]               // Optional metadata for the data set
   callbacks?: StorageCreationCallbacks     // Progress callbacks
   uploadBatchSize?: number                 // Max uploads per batch (default: 32, min: 1)
 }
@@ -84,6 +85,9 @@ interface StorageServiceOptions {
 // 1. Synapse instance default (set during creation)
 // 2. StorageService override (set during createStorage)
 // 3. Per-method override (set during download)
+
+// The withCDN option exists for backward compatibility and internally converts
+// to metadata: [{ key: 'withCDN', value: '' }] when needed
 ```
 
 #### Storage Context Properties

--- a/docs/src/content/docs/guides/storage.mdx
+++ b/docs/src/content/docs/guides/storage.mdx
@@ -13,7 +13,7 @@ You have two options:
 2. **Explicit mode**: Create a context with `synapse.storage.createContext()` for more control. Contexts can be used directly or passed in the options to `synapse.storage.upload()` and `synapse.storage.download()`.
 
 Behind the scenes, the process may be:
-- **Fast (< 1 second)**: When reusing existing infrastructure (i.e. an existing data set previously created)
+- **Fast (< 1 second)**: When reusing existing data sets that match your requirements (including all metadata)
 - **Slower (2-5 minutes)**: When setting up new blockchain infrastructure (i.e. creating a brand new data set)
 
 #### Basic Usage
@@ -25,6 +25,18 @@ await synapse.storage.upload(data)  // Context created/reused automatically
 // Option 2: Explicit context creation
 const context = await synapse.storage.createContext()
 await context.upload(data)  // Upload to this specific context
+
+// Option 3: Context with metadata requirements
+const context = await synapse.storage.createContext({
+  metadata: [
+    { key: 'withIPFSIndexing', value: '' },
+    { key: 'category', value: 'videos' }
+  ]
+})
+// This will reuse any existing data set that has both of these metadata entries,
+// or create a new one if none match
+// Note: the `withCDN` option is an alias for a { key: 'withCDN', value: '' }
+// metadata entry.
 ```
 
 #### Advanced Usage with Callbacks
@@ -76,7 +88,7 @@ interface StorageServiceOptions {
   providerAddress?: string                 // Specific provider address to use
   dataSetId?: number                       // Specific data set ID to use
   withCDN?: boolean                        // Enable CDN services
-  metadata?: MetadataEntry[]               // Optional metadata for the data set
+  metadata?: MetadataEntry[]               // Metadata requirements for data set selection/creation
   callbacks?: StorageCreationCallbacks     // Progress callbacks
   uploadBatchSize?: number                 // Max uploads per batch (default: 32, min: 1)
 }
@@ -86,8 +98,10 @@ interface StorageServiceOptions {
 // 2. StorageService override (set during createStorage)
 // 3. Per-method override (set during download)
 
-// The withCDN option exists for backward compatibility and internally converts
-// to metadata: [{ key: 'withCDN', value: '' }] when needed
+// Data Set Selection: When creating a context, the SDK attempts to reuse existing
+// data sets that match ALL your requirements. A data set matches if it contains
+// all requested metadata entries with matching values (order doesn't matter).
+// The data set may have additional metadata beyond what you request.
 ```
 
 #### Storage Context Properties

--- a/docs/src/content/docs/intro/getting-started.mdx
+++ b/docs/src/content/docs/intro/getting-started.mdx
@@ -421,7 +421,7 @@ The SDK automatically handles all the complexity of storage setup for you - sele
 2. **Explicit mode**: Create a context with `synapse.storage.createContext()` for more control. Contexts can be used directly or passed in the options to `synapse.storage.upload()` and `synapse.storage.download()`.
 
 Behind the scenes, the process may be:
-- **Fast ( < 1 second)**: When reusing existing infrastructure (i.e. an existing data set previously created)
+- **Fast ( < 1 second)**: When reusing existing data sets that match your requirements (including all metadata)
 - **Slower ( 2-5 minutes)**: When setting up new blockchain infrastructure (i.e. creating a brand new data set)
 
 #### Basic Usage
@@ -433,6 +433,18 @@ await synapse.storage.upload(data)  // Context created/reused automatically
 // Option 2: Explicit context creation
 const context = await synapse.storage.createContext()
 await context.upload(data)  // Upload to this specific context
+
+// Option 3: Context with metadata requirements
+const context = await synapse.storage.createContext({
+  metadata: [
+    { key: 'withIPFSIndexing', value: '' },
+    { key: 'category', value: 'videos' }
+  ]
+})
+// This will reuse any existing data set that has both of these metadata entries,
+// or create a new one if none match
+// Note: the `withCDN` option is an alias for a { key: 'withCDN', value: '' }
+// metadata entry.
 ```
 
 #### Advanced Usage with Callbacks
@@ -484,6 +496,7 @@ interface StorageServiceOptions {
   providerAddress?: string                 // Specific provider address to use
   dataSetId?: number                       // Specific data set ID to use
   withCDN?: boolean                        // Enable CDN services
+  metadata?: MetadataEntry[]               // Metadata requirements for data set selection/creation
   callbacks?: StorageCreationCallbacks     // Progress callbacks
   uploadBatchSize?: number                 // Max uploads per batch (default: 32, min: 1)
 }
@@ -492,6 +505,11 @@ interface StorageServiceOptions {
 // 1. Synapse instance default (set during creation)
 // 2. StorageService override (set during createStorage)
 // 3. Per-method override (set during download)
+
+// Data Set Selection: When creating a context, the SDK attempts to reuse existing
+// data sets that match ALL your requirements. A data set matches if it contains
+// all requested metadata entries with matching values (order doesn't matter).
+// The data set may have additional metadata beyond what you request.
 ```
 
 #### Storage Context Properties

--- a/src/pdp/auth.ts
+++ b/src/pdp/auth.ts
@@ -5,6 +5,7 @@
 import { ethers } from 'ethers'
 import { asPieceCID, type PieceCID } from '../piece/index.ts'
 import type { AuthSignature, MetadataEntry } from '../types.ts'
+import { METADATA_KEYS } from '../utils/constants.ts'
 
 // Declare window.ethereum for TypeScript
 declare global {
@@ -72,7 +73,7 @@ const EIP712_TYPES = {
 export class PDPAuthHelper {
   private readonly signer: ethers.Signer
   private readonly domain: ethers.TypedDataDomain
-  public readonly WITH_CDN_METADATA: MetadataEntry = { key: 'withCDN', value: '' }
+  public readonly WITH_CDN_METADATA: MetadataEntry = { key: METADATA_KEYS.WITH_CDN, value: '' }
 
   constructor(serviceContractAddress: string, signer: ethers.Signer, chainId: bigint) {
     this.signer = signer

--- a/src/pdp/server.ts
+++ b/src/pdp/server.ts
@@ -151,17 +151,16 @@ export class PDPServer {
    * Create a new data set on the PDP server
    * @param clientDataSetId - Unique ID for the client's dataset
    * @param payee - Address that will receive payments (service provider)
-   * @param withCDN - Whether to enable CDN services
+   * @param metadata - Metadata entries for the data set (key-value pairs)
    * @param recordKeeper - Address of the Warm Storage contract
    * @returns Promise that resolves with transaction hash and status URL
    */
   async createDataSet(
     clientDataSetId: number,
     payee: string,
-    withCDN: boolean,
+    metadata: MetadataEntry[],
     recordKeeper: string
   ): Promise<CreateDataSetResponse> {
-    const metadata = withCDN ? [this.getAuthHelper().WITH_CDN_METADATA] : []
     // Generate the EIP-712 signature for data set creation
     const authData = await this.getAuthHelper().signCreateDataSet(clientDataSetId, payee, metadata)
 
@@ -221,33 +220,42 @@ export class PDPServer {
    * @param nextPieceId - The ID to assign to the first piece being added, this should be
    *   the next available ID on chain or the signature will fail to be validated
    * @param pieceDataArray - Array of piece data containing PieceCID CIDs and raw sizes
+   * @param metadata - Optional metadata for each piece (array of arrays, one per piece)
    * @returns Promise that resolves when the pieces are added (201 Created)
    * @throws Error if any CID is invalid
    *
    * @example
    * ```typescript
    * const pieceData = ['bafkzcibcd...']
-   * await pdpTool.addPieces(dataSetId, clientDataSetId, nextPieceId, pieceData)
+   * const metadata = [[{ key: 'snapshotDate', value: '20250711' }]]
+   * await pdpTool.addPieces(dataSetId, clientDataSetId, nextPieceId, pieceData, metadata)
    * ```
    */
   async addPieces(
     dataSetId: number,
     clientDataSetId: number,
     nextPieceId: number,
-    pieceDataArray: PieceCID[] | string[]
+    pieceDataArray: PieceCID[] | string[],
+    metadata?: MetadataEntry[][]
   ): Promise<AddPiecesResponse> {
     if (pieceDataArray.length === 0) {
       throw new Error('At least one piece must be provided')
     }
 
-    const metadata: MetadataEntry[][] = []
     // Validate all PieceCIDs
     for (const pieceData of pieceDataArray) {
       const pieceCid = asPieceCID(pieceData)
       if (pieceCid == null) {
         throw new Error(`Invalid PieceCID: ${String(pieceData)}`)
       }
-      metadata.push([]) // empty metadata for each piece
+    }
+
+    // If no metadata provided, create empty arrays for each piece
+    const finalMetadata = metadata ?? pieceDataArray.map(() => [])
+
+    // Validate metadata length matches pieces
+    if (finalMetadata.length !== pieceDataArray.length) {
+      throw new Error(`Metadata length (${finalMetadata.length}) must match pieces length (${pieceDataArray.length})`)
     }
 
     // Generate the EIP-712 signature for adding pieces
@@ -255,14 +263,14 @@ export class PDPServer {
       clientDataSetId,
       nextPieceId,
       pieceDataArray, // Pass PieceData[] directly to auth helper
-      metadata
+      finalMetadata
     )
 
     // Prepare the extra data for the contract call
     // This needs to match what the Warm Storage contract expects for addPieces
     const extraData = this._encodeAddPiecesExtraData({
       signature: authData.signature,
-      metadata: metadata,
+      metadata: finalMetadata,
     })
 
     // Prepare request body matching the Curio handler expectation

--- a/src/storage/manager.ts
+++ b/src/storage/manager.ts
@@ -247,7 +247,7 @@ export class StorageManager {
     }
 
     // Use the static method from StorageContext for core logic
-    return await StorageContext.performPreflightCheck(size, withCDN, this._warmStorageService, this._synapse.payments)
+    return await StorageContext.performPreflightCheck(this._warmStorageService, this._synapse.payments, size, withCDN)
   }
 
   /**

--- a/src/test/metadata-selection.test.ts
+++ b/src/test/metadata-selection.test.ts
@@ -1,0 +1,269 @@
+/* globals describe it before after */
+import { assert } from 'chai'
+import { ethers } from 'ethers'
+import { setup } from 'iso-web/msw'
+import type { MetadataEntry } from '../types.ts'
+import { METADATA_KEYS } from '../utils/constants.ts'
+import { hasWithCDN, metadataMatches, withCDNToMetadata } from '../utils/metadata.ts'
+import { WarmStorageService } from '../warm-storage/index.ts'
+import { ADDRESSES, JSONRPC, presets } from './mocks/jsonrpc/index.ts'
+
+describe('Metadata-based Data Set Selection', () => {
+  describe('Metadata Utilities', () => {
+    describe('metadataMatches', () => {
+      it('should match when all requested metadata exists in data set', () => {
+        const dataSetMetadata: MetadataEntry[] = [
+          { key: 'environment', value: 'production' },
+          { key: METADATA_KEYS.WITH_CDN, value: '' },
+          { key: 'region', value: 'us-east' },
+        ]
+
+        const requested: MetadataEntry[] = [
+          { key: METADATA_KEYS.WITH_CDN, value: '' },
+          { key: 'environment', value: 'production' },
+        ]
+
+        assert.isTrue(metadataMatches(dataSetMetadata, requested))
+      })
+
+      it('should not match when requested value differs', () => {
+        const dataSetMetadata: MetadataEntry[] = [
+          { key: 'environment', value: 'production' },
+          { key: METADATA_KEYS.WITH_CDN, value: '' },
+        ]
+
+        const requested: MetadataEntry[] = [{ key: 'environment', value: 'development' }]
+
+        assert.isFalse(metadataMatches(dataSetMetadata, requested))
+      })
+
+      it('should not match when requested key is missing', () => {
+        const dataSetMetadata: MetadataEntry[] = [{ key: 'environment', value: 'production' }]
+
+        const requested: MetadataEntry[] = [{ key: METADATA_KEYS.WITH_CDN, value: '' }]
+
+        assert.isFalse(metadataMatches(dataSetMetadata, requested))
+      })
+
+      it('should match empty request with any data set', () => {
+        const dataSetMetadata: MetadataEntry[] = [{ key: 'environment', value: 'production' }]
+
+        const requested: MetadataEntry[] = []
+
+        assert.isTrue(metadataMatches(dataSetMetadata, requested))
+      })
+
+      it('should be order-independent', () => {
+        const dataSetMetadata: MetadataEntry[] = [
+          { key: 'b', value: '2' },
+          { key: 'a', value: '1' },
+          { key: 'c', value: '3' },
+        ]
+
+        const requested: MetadataEntry[] = [
+          { key: 'c', value: '3' },
+          { key: 'a', value: '1' },
+        ]
+
+        assert.isTrue(metadataMatches(dataSetMetadata, requested))
+      })
+
+      it('should allow data set to have extra metadata', () => {
+        const dataSetMetadata: MetadataEntry[] = [
+          { key: METADATA_KEYS.WITH_CDN, value: '' },
+          { key: METADATA_KEYS.WITH_IPFS_INDEXING, value: '' },
+          { key: 'custom', value: 'value' },
+        ]
+
+        const requested: MetadataEntry[] = [{ key: METADATA_KEYS.WITH_CDN, value: '' }]
+
+        assert.isTrue(metadataMatches(dataSetMetadata, requested))
+      })
+    })
+
+    describe('withCDNToMetadata', () => {
+      it('should convert true to metadata entry', () => {
+        const metadata = withCDNToMetadata(true)
+        assert.equal(metadata.length, 1)
+        assert.equal(metadata[0].key, METADATA_KEYS.WITH_CDN)
+        assert.equal(metadata[0].value, '')
+      })
+
+      it('should convert false to empty array', () => {
+        const metadata = withCDNToMetadata(false)
+        assert.equal(metadata.length, 0)
+      })
+    })
+
+    describe('hasWithCDN', () => {
+      it('should detect withCDN key', () => {
+        const metadata: MetadataEntry[] = [
+          { key: 'environment', value: 'production' },
+          { key: METADATA_KEYS.WITH_CDN, value: '' },
+        ]
+        assert.isTrue(hasWithCDN(metadata))
+      })
+
+      it('should return false when withCDN is absent', () => {
+        const metadata: MetadataEntry[] = [{ key: 'environment', value: 'production' }]
+        assert.isFalse(hasWithCDN(metadata))
+      })
+
+      it('should detect withCDN regardless of value', () => {
+        const metadata: MetadataEntry[] = [{ key: METADATA_KEYS.WITH_CDN, value: 'unexpected' }]
+        assert.isTrue(hasWithCDN(metadata))
+      })
+    })
+  })
+
+  describe('WarmStorageService with Metadata', () => {
+    let server: any
+    let warmStorageService: WarmStorageService
+
+    before(async () => {
+      server = setup([])
+      await server.start({ quiet: true })
+    })
+
+    after(() => {
+      server.stop()
+    })
+
+    beforeEach(async () => {
+      server.resetHandlers()
+
+      // Create custom preset that returns different metadata for different data sets
+      const customPreset: any = {
+        ...presets.basic,
+        warmStorageView: {
+          ...presets.basic.warmStorageView,
+          railToDataSet: (args: any) => {
+            const [railId] = args
+            // Map rail IDs directly to data set IDs for this test
+            return [railId] // railId 1 -> dataSetId 1, railId 2 -> dataSetId 2, etc.
+          },
+          getClientDataSets: () => [
+            [
+              {
+                pdpRailId: 1n,
+                cacheMissRailId: 0n,
+                cdnRailId: 0n, // No CDN
+                payer: ADDRESSES.client1,
+                payee: ADDRESSES.serviceProvider1,
+                serviceProvider: ADDRESSES.serviceProvider1,
+                commissionBps: 100n,
+                clientDataSetId: 0n,
+                pdpEndEpoch: 0n,
+                providerId: 1n,
+                cdnEndEpoch: 0n,
+              },
+              {
+                pdpRailId: 2n,
+                cacheMissRailId: 0n,
+                cdnRailId: 100n, // Has CDN
+                payer: ADDRESSES.client1,
+                payee: ADDRESSES.serviceProvider1,
+                serviceProvider: ADDRESSES.serviceProvider1,
+                commissionBps: 100n,
+                clientDataSetId: 1n,
+                pdpEndEpoch: 0n,
+                providerId: 1n,
+                cdnEndEpoch: 0n,
+              },
+              {
+                pdpRailId: 3n,
+                cacheMissRailId: 0n,
+                cdnRailId: 0n, // No CDN
+                payer: ADDRESSES.client1,
+                payee: ADDRESSES.serviceProvider2,
+                serviceProvider: ADDRESSES.serviceProvider2,
+                commissionBps: 100n,
+                clientDataSetId: 2n,
+                pdpEndEpoch: 0n,
+                providerId: 2n,
+                cdnEndEpoch: 0n,
+              },
+            ],
+          ],
+          getAllDataSetMetadata: (args: any) => {
+            const [dataSetId] = args
+            if (dataSetId === 1n) {
+              // Data set 1: no metadata
+              return [[], []]
+            }
+            if (dataSetId === 2n) {
+              // Data set 2: has withCDN
+              return [[METADATA_KEYS.WITH_CDN], ['']]
+            }
+            if (dataSetId === 3n) {
+              // Data set 3: has withIPFSIndexing
+              return [[METADATA_KEYS.WITH_IPFS_INDEXING], ['']]
+            }
+            return [[], []]
+          },
+        },
+        pdpVerifier: {
+          ...presets.basic.pdpVerifier,
+          getNextPieceId: (args: any) => {
+            const [dataSetId] = args
+            if (dataSetId === 1n) return [5n] as const // Has pieces
+            if (dataSetId === 2n) return [0n] as const // Empty
+            if (dataSetId === 3n) return [2n] as const // Has pieces
+            return [0n] as const
+          },
+        },
+      }
+
+      server.use(JSONRPC(customPreset))
+
+      const provider = new ethers.JsonRpcProvider('https://api.calibration.node.glif.io/rpc/v1')
+      warmStorageService = await WarmStorageService.create(provider, ADDRESSES.calibration.warmStorage)
+    })
+
+    it('should fetch metadata for each data set', async () => {
+      const dataSets = await warmStorageService.getClientDataSetsWithDetails(ADDRESSES.client1)
+
+      assert.equal(dataSets.length, 3)
+
+      // Data set 1: no metadata, no CDN from rail
+      assert.equal(dataSets[0].pdpVerifierDataSetId, 1)
+      assert.isFalse(dataSets[0].withCDN)
+      assert.deepEqual(dataSets[0].metadata, [])
+
+      // Data set 2: withCDN metadata, also has CDN rail
+      assert.equal(dataSets[1].pdpVerifierDataSetId, 2)
+      assert.isTrue(dataSets[1].withCDN)
+      assert.deepEqual(dataSets[1].metadata, [{ key: METADATA_KEYS.WITH_CDN, value: '' }])
+
+      // Data set 3: withIPFSIndexing metadata, no CDN
+      assert.equal(dataSets[2].pdpVerifierDataSetId, 3)
+      assert.isFalse(dataSets[2].withCDN)
+      assert.deepEqual(dataSets[2].metadata, [{ key: METADATA_KEYS.WITH_IPFS_INDEXING, value: '' }])
+    })
+
+    it('should prefer data sets with matching metadata', async () => {
+      const dataSets = await warmStorageService.getClientDataSetsWithDetails(ADDRESSES.client1)
+
+      // Filter for data sets with withIPFSIndexing
+      const withIndexing = dataSets.filter((ds) =>
+        metadataMatches(ds.metadata, [{ key: METADATA_KEYS.WITH_IPFS_INDEXING, value: '' }])
+      )
+
+      assert.equal(withIndexing.length, 1)
+      assert.equal(withIndexing[0].pdpVerifierDataSetId, 3)
+
+      // Filter for data sets with withCDN
+      const withCDN = dataSets.filter((ds) =>
+        metadataMatches(ds.metadata, [{ key: METADATA_KEYS.WITH_CDN, value: '' }])
+      )
+
+      assert.equal(withCDN.length, 1)
+      assert.equal(withCDN[0].pdpVerifierDataSetId, 2)
+
+      // Filter for data sets with no specific metadata
+      const noRequirements = dataSets.filter((ds) => metadataMatches(ds.metadata, []))
+
+      assert.equal(noRequirements.length, 3) // All match when no requirements
+    })
+  })
+})

--- a/src/test/metadata.test.ts
+++ b/src/test/metadata.test.ts
@@ -1,0 +1,353 @@
+/* globals describe it before after beforeEach */
+import { assert } from 'chai'
+import { ethers } from 'ethers'
+import { setup } from 'iso-web/msw'
+import { PDPAuthHelper } from '../pdp/auth.ts'
+import { PDPServer } from '../pdp/server.ts'
+import { asPieceCID } from '../piece/index.ts'
+import type { MetadataEntry } from '../types.ts'
+import { METADATA_KEYS } from '../utils/constants.ts'
+import {
+  addPiecesWithMetadataCapture,
+  createDataSetWithMetadataCapture,
+  type MetadataCapture,
+  type PieceMetadataCapture,
+} from './mocks/pdp/handlers.ts'
+
+// Mock server for testing
+const server = setup([])
+
+describe('Metadata Support', () => {
+  const TEST_PRIVATE_KEY = '0x0101010101010101010101010101010101010101010101010101010101010101'
+  const TEST_CONTRACT_ADDRESS = '0x1234567890123456789012345678901234567890'
+  const TEST_CHAIN_ID = 1n
+  const SERVER_URL = 'http://pdp.local'
+
+  let authHelper: PDPAuthHelper
+  let pdpServer: PDPServer
+
+  before(async () => {
+    await server.start({ quiet: true })
+  })
+
+  after(() => {
+    server.stop()
+  })
+
+  beforeEach(() => {
+    server.resetHandlers()
+
+    // Create fresh instances for each test
+    authHelper = new PDPAuthHelper(TEST_CONTRACT_ADDRESS, new ethers.Wallet(TEST_PRIVATE_KEY), TEST_CHAIN_ID)
+    pdpServer = new PDPServer(authHelper, SERVER_URL)
+  })
+
+  describe('PDPServer', () => {
+    it('should handle metadata in createDataSet', async () => {
+      const dataSetMetadata: MetadataEntry[] = [
+        { key: 'project', value: 'my-project' },
+        { key: 'environment', value: 'production' },
+        { key: METADATA_KEYS.WITH_CDN, value: '' },
+      ]
+
+      const mockTxHash = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+      let capturedMetadata: MetadataCapture | null = null
+
+      server.use(
+        createDataSetWithMetadataCapture(
+          mockTxHash,
+          (metadata) => {
+            capturedMetadata = metadata
+          },
+          { baseUrl: SERVER_URL }
+        )
+      )
+
+      const result = await pdpServer.createDataSet(
+        1,
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        dataSetMetadata,
+        TEST_CONTRACT_ADDRESS
+      )
+
+      assert.equal(result.txHash, mockTxHash)
+      assert.exists(capturedMetadata)
+      assert.isNotNull(capturedMetadata)
+      assert.deepEqual((capturedMetadata as any).keys, ['project', 'environment', METADATA_KEYS.WITH_CDN])
+      assert.deepEqual((capturedMetadata as any).values, ['my-project', 'production', ''])
+    })
+
+    it('should handle metadata in addPieces', async () => {
+      const pieces = [asPieceCID('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy') as any]
+      const metadata: MetadataEntry[][] = [
+        [
+          { key: 'contentType', value: 'application/json' },
+          { key: 'version', value: '1.0.0' },
+        ],
+      ]
+
+      const dataSetId = 123
+      const mockTxHash = '0x1234567890abcdef'
+      let capturedPieceMetadata: PieceMetadataCapture | null = null
+
+      server.use(
+        addPiecesWithMetadataCapture(
+          dataSetId,
+          mockTxHash,
+          (metadata) => {
+            capturedPieceMetadata = metadata
+          },
+          { baseUrl: SERVER_URL }
+        )
+      )
+
+      // Test with matching metadata
+      const result = await pdpServer.addPieces(dataSetId, 1, 1, pieces, metadata)
+      assert.equal(result.txHash, mockTxHash)
+      assert.exists(capturedPieceMetadata)
+      assert.isNotNull(capturedPieceMetadata)
+      assert.deepEqual((capturedPieceMetadata as any).keys[0], ['contentType', 'version'])
+      assert.deepEqual((capturedPieceMetadata as any).values[0], ['application/json', '1.0.0'])
+
+      // Test with metadata length mismatch - should throw
+      const mismatchedMetadata: MetadataEntry[][] = [
+        [{ key: 'contentType', value: 'application/json' }],
+        [{ key: 'version', value: '1.0.0' }],
+      ]
+
+      try {
+        await pdpServer.addPieces(dataSetId, 1, 1, pieces, mismatchedMetadata)
+        assert.fail('Should have thrown an error')
+      } catch (error: any) {
+        assert.match(error.message, /Metadata length \(2\) must match pieces length \(1\)/)
+      }
+
+      // Test without metadata (should create empty arrays)
+      capturedPieceMetadata = null
+      const resultNoMetadata = await pdpServer.addPieces(dataSetId, 1, 1, pieces)
+      assert.equal(resultNoMetadata.txHash, mockTxHash)
+      assert.exists(capturedPieceMetadata)
+      assert.isNotNull(capturedPieceMetadata)
+      assert.deepEqual((capturedPieceMetadata as any).keys[0], [])
+      assert.deepEqual((capturedPieceMetadata as any).values[0], [])
+    })
+  })
+
+  describe('Backward Compatibility', () => {
+    it('should convert withCDN boolean to metadata', async () => {
+      const mockTxHash = '0xabcdef1234567890'
+      let capturedMetadata: MetadataCapture | null = null
+
+      server.use(
+        createDataSetWithMetadataCapture(
+          mockTxHash,
+          (metadata) => {
+            capturedMetadata = metadata
+          },
+          { baseUrl: SERVER_URL }
+        )
+      )
+
+      // Test with metadata that includes withCDN
+      const metadataWithCDN: MetadataEntry[] = [
+        { key: 'project', value: 'test' },
+        { key: METADATA_KEYS.WITH_CDN, value: '' },
+      ]
+
+      await pdpServer.createDataSet(
+        1,
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        metadataWithCDN,
+        TEST_CONTRACT_ADDRESS
+      )
+      assert.isNotNull(capturedMetadata)
+      assert.deepEqual((capturedMetadata as any).keys, ['project', METADATA_KEYS.WITH_CDN])
+      assert.deepEqual((capturedMetadata as any).values, ['test', ''])
+
+      // Test with metadata that doesn't include withCDN
+      capturedMetadata = null
+      const metadataWithoutCDN: MetadataEntry[] = [{ key: 'project', value: 'test' }]
+
+      await pdpServer.createDataSet(
+        1,
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        metadataWithoutCDN,
+        TEST_CONTRACT_ADDRESS
+      )
+      assert.isNotNull(capturedMetadata)
+      assert.deepEqual((capturedMetadata as any).keys, ['project'])
+      assert.deepEqual((capturedMetadata as any).values, ['test'])
+    })
+
+    it('should handle StorageContext withCDN backward compatibility', async () => {
+      // This test verifies the logic is correct in the implementation
+      // When withCDN is true and metadata doesn't contain withCDN key,
+      // it should be added automatically
+      const metadata: MetadataEntry[] = [{ key: 'test', value: 'value' }]
+      const withCDN = true
+
+      // Simulate the logic in StorageContext.createDataSet
+      const finalMetadata = [...metadata]
+      if (withCDN && !finalMetadata.some((m) => m.key === METADATA_KEYS.WITH_CDN)) {
+        finalMetadata.push({ key: METADATA_KEYS.WITH_CDN, value: '' })
+      }
+
+      assert.equal(finalMetadata.length, 2)
+      assert.equal(finalMetadata[1].key, METADATA_KEYS.WITH_CDN)
+      assert.equal(finalMetadata[1].value, '')
+    })
+
+    it('should not duplicate withCDN in metadata', async () => {
+      const metadata: MetadataEntry[] = [
+        { key: 'test', value: 'value' },
+        { key: METADATA_KEYS.WITH_CDN, value: '' },
+      ]
+      const withCDN = true
+
+      // Simulate the logic in StorageContext.createDataSet
+      const finalMetadata = [...metadata]
+      if (withCDN && !finalMetadata.some((m) => m.key === METADATA_KEYS.WITH_CDN)) {
+        finalMetadata.push({ key: METADATA_KEYS.WITH_CDN, value: '' })
+      }
+
+      // Should not add another withCDN entry
+      assert.equal(finalMetadata.length, 2)
+      const cdnEntries = finalMetadata.filter((m) => m.key === METADATA_KEYS.WITH_CDN)
+      assert.equal(cdnEntries.length, 1)
+    })
+  })
+
+  describe('StorageManager preflightUpload with metadata', () => {
+    it('should extract withCDN from metadata when provided', async () => {
+      // Test the logic of preflightUpload extracting withCDN from metadata
+
+      // Case 1: withCDN in metadata takes precedence over option
+      const metadataWithCDN: MetadataEntry[] = [
+        { key: 'test', value: 'value' },
+        { key: METADATA_KEYS.WITH_CDN, value: '' },
+      ]
+
+      // Simulate the logic in StorageManager.preflightUpload
+      let withCDN = false // default or from options
+      const withCDNEntry = metadataWithCDN.find((m) => m.key === METADATA_KEYS.WITH_CDN)
+      if (withCDNEntry != null) {
+        withCDN = true
+      }
+
+      assert.isTrue(withCDN, 'Should detect withCDN in metadata')
+
+      // Case 2: metadata without withCDN should not set it to true
+      const metadataWithoutCDN: MetadataEntry[] = [{ key: 'test', value: 'value' }]
+
+      withCDN = false
+      const withCDNEntry2 = metadataWithoutCDN.find((m) => m.key === METADATA_KEYS.WITH_CDN)
+      if (withCDNEntry2 != null) {
+        withCDN = true
+      }
+
+      assert.isFalse(withCDN, 'Should not detect withCDN when not in metadata')
+
+      // Case 3: Empty metadata should not affect withCDN
+      const emptyMetadata: MetadataEntry[] = []
+
+      withCDN = true // existing value
+      const withCDNEntry3 = emptyMetadata.find((m) => m.key === METADATA_KEYS.WITH_CDN)
+      if (withCDNEntry3 != null) {
+        withCDN = true // only set if found
+      }
+
+      assert.isTrue(withCDN, 'Should preserve existing withCDN when metadata is empty')
+
+      // Case 4: withCDN with non-empty value should trigger warning but still enable CDN (contract behavior)
+      const metadataWithNonEmptyValue: MetadataEntry[] = [{ key: METADATA_KEYS.WITH_CDN, value: 'unexpected-value' }]
+
+      // Simulate the actual logic from StorageManager.preflightUpload
+      withCDN = false // Reset for this test case
+      const withCDNEntry4 = metadataWithNonEmptyValue.find((m) => m.key === METADATA_KEYS.WITH_CDN)
+      if (withCDNEntry4 != null) {
+        // The contract only checks for key presence, not value
+        if (withCDNEntry4.value !== '') {
+          // In actual code, this would console.warn
+          assert.equal(withCDNEntry4.value, 'unexpected-value', 'Should detect non-empty value')
+        }
+        withCDN = true // Enable CDN when key exists
+      }
+
+      assert.isTrue(withCDN, 'Should enable CDN when key exists, regardless of value (contract behavior)')
+    })
+
+    it('should follow precedence: metadata > option > default', async () => {
+      // Test precedence order for withCDN determination
+
+      // Simulate preflightUpload logic with different scenarios
+      const defaultWithCDN = false
+
+      // Scenario 1: metadata with withCDN overrides everything
+      let options: { withCDN?: boolean; metadata?: MetadataEntry[] } = {
+        withCDN: false,
+        metadata: [{ key: METADATA_KEYS.WITH_CDN, value: '' }],
+      }
+
+      let withCDN = options.withCDN ?? defaultWithCDN
+      if (options.metadata != null) {
+        const withCDNEntry = options.metadata.find((m) => m.key === METADATA_KEYS.WITH_CDN)
+        if (withCDNEntry != null) {
+          withCDN = true
+        }
+      }
+
+      assert.isTrue(withCDN, 'Metadata should override option')
+
+      // Scenario 2: option used when metadata doesn't have withCDN
+      options = {
+        withCDN: true,
+        metadata: [{ key: 'other', value: 'value' }],
+      }
+
+      withCDN = options.withCDN ?? defaultWithCDN
+      if (options.metadata != null) {
+        const withCDNEntry = options.metadata.find((m) => m.key === METADATA_KEYS.WITH_CDN)
+        if (withCDNEntry != null) {
+          withCDN = true
+        }
+      }
+
+      assert.isTrue(withCDN, 'Option should be used when metadata lacks withCDN')
+
+      // Scenario 3: metadata with non-empty withCDN value should still override (with warning)
+      options = {
+        withCDN: false, // Option says false
+        metadata: [{ key: METADATA_KEYS.WITH_CDN, value: 'non-empty' }], // Metadata has key (non-empty value)
+      }
+
+      withCDN = options.withCDN ?? defaultWithCDN
+      if (options.metadata != null) {
+        const withCDNEntry = options.metadata.find((m) => m.key === METADATA_KEYS.WITH_CDN)
+        if (withCDNEntry != null) {
+          // Contract only checks key presence
+          if (withCDNEntry.value !== '') {
+            // Would console.warn in actual code
+          }
+          withCDN = true // Enable CDN when key exists
+        }
+      }
+
+      assert.isTrue(withCDN, 'Metadata with withCDN key should override option, even with non-empty value')
+
+      // Scenario 4: default used when neither option nor metadata has withCDN
+      options = {
+        metadata: [{ key: 'other', value: 'value' }],
+      }
+
+      withCDN = options.withCDN ?? defaultWithCDN
+      if (options.metadata != null) {
+        const withCDNEntry = options.metadata.find((m) => m.key === METADATA_KEYS.WITH_CDN)
+        if (withCDNEntry != null) {
+          withCDN = true
+        }
+      }
+
+      assert.isFalse(withCDN, 'Default should be used when no withCDN specified')
+    })
+  })
+})

--- a/src/test/mocks/jsonrpc/index.ts
+++ b/src/test/mocks/jsonrpc/index.ts
@@ -237,6 +237,39 @@ export const presets = {
       ],
       railToDataSet: () => [1n],
       getApprovedProviders: () => [[1n, 2n]],
+      getAllDataSetMetadata: (args) => {
+        const [dataSetId] = args
+        if (dataSetId === 1n) {
+          return [
+            ['environment', 'withCDN'], // keys
+            ['test', ''], // values
+          ]
+        }
+        return [[], []] // empty metadata for other data sets
+      },
+      getDataSetMetadata: (args) => {
+        const [dataSetId, key] = args
+        if (dataSetId === 1n && key === 'withCDN') return [true, '']
+        if (dataSetId === 1n && key === 'environment') return [true, 'test']
+        return [false, ''] // key not found
+      },
+      getAllPieceMetadata: (args) => {
+        const [dataSetId, pieceId] = args
+        if (dataSetId === 1n && pieceId === 0n) {
+          return [
+            ['withIPFSIndexing', 'ipfsRootCID'], // keys
+            ['', 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'], // values
+          ]
+        }
+        return [[], []] // empty metadata for other pieces
+      },
+      getPieceMetadata: (args) => {
+        const [dataSetId, pieceId, key] = args
+        if (dataSetId === 1n && pieceId === 0n && key === 'withIPFSIndexing') return [true, '']
+        if (dataSetId === 1n && pieceId === 0n && key === 'ipfsRootCID')
+          return [true, 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi']
+        return [false, ''] // key not found
+      },
     },
     pdpVerifier: {
       dataSetLive: () => [true],

--- a/src/test/mocks/jsonrpc/warm-storage.ts
+++ b/src/test/mocks/jsonrpc/warm-storage.ts
@@ -16,11 +16,25 @@ export type getClientDataSets = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STO
 
 export type getApprovedProviders = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getApprovedProviders'>
 
+export type getAllDataSetMetadata = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getAllDataSetMetadata'>
+
+export type getDataSetMetadata = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getDataSetMetadata'>
+
+export type getAllPieceMetadata = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getAllPieceMetadata'>
+
+export type getPieceMetadata = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getPieceMetadata'>
+
 export interface WarmStorageViewOptions {
   isProviderApproved?: (args: AbiToType<isProviderApproved['inputs']>) => AbiToType<isProviderApproved['outputs']>
   getClientDataSets?: (args: AbiToType<getClientDataSets['inputs']>) => AbiToType<getClientDataSets['outputs']>
   railToDataSet?: (args: AbiToType<railToDataSet['inputs']>) => AbiToType<railToDataSet['outputs']>
   getApprovedProviders?: (args: AbiToType<getApprovedProviders['inputs']>) => AbiToType<getApprovedProviders['outputs']>
+  getAllDataSetMetadata?: (
+    args: AbiToType<getAllDataSetMetadata['inputs']>
+  ) => AbiToType<getAllDataSetMetadata['outputs']>
+  getDataSetMetadata?: (args: AbiToType<getDataSetMetadata['inputs']>) => AbiToType<getDataSetMetadata['outputs']>
+  getAllPieceMetadata?: (args: AbiToType<getAllPieceMetadata['inputs']>) => AbiToType<getAllPieceMetadata['outputs']>
+  getPieceMetadata?: (args: AbiToType<getPieceMetadata['inputs']>) => AbiToType<getPieceMetadata['outputs']>
 }
 
 /**
@@ -193,6 +207,46 @@ export function warmStorageViewCallHandler(data: Hex, options: JSONRPCOptions): 
         CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'getApprovedProviders')!
           .outputs,
         options.warmStorageView.getApprovedProviders(args)
+      )
+    }
+    case 'getAllDataSetMetadata': {
+      if (!options.warmStorageView?.getAllDataSetMetadata) {
+        throw new Error('Warm Storage View: getAllDataSetMetadata is not defined')
+      }
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'getAllDataSetMetadata')!
+          .outputs,
+        options.warmStorageView.getAllDataSetMetadata(args)
+      )
+    }
+    case 'getDataSetMetadata': {
+      if (!options.warmStorageView?.getDataSetMetadata) {
+        throw new Error('Warm Storage View: getDataSetMetadata is not defined')
+      }
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'getDataSetMetadata')!
+          .outputs,
+        options.warmStorageView.getDataSetMetadata(args)
+      )
+    }
+    case 'getAllPieceMetadata': {
+      if (!options.warmStorageView?.getAllPieceMetadata) {
+        throw new Error('Warm Storage View: getAllPieceMetadata is not defined')
+      }
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'getAllPieceMetadata')!
+          .outputs,
+        options.warmStorageView.getAllPieceMetadata(args)
+      )
+    }
+    case 'getPieceMetadata': {
+      if (!options.warmStorageView?.getPieceMetadata) {
+        throw new Error('Warm Storage View: getPieceMetadata is not defined')
+      }
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'getPieceMetadata')!
+          .outputs,
+        options.warmStorageView.getPieceMetadata(args)
       )
     }
 

--- a/src/test/mocks/pdp/handlers.ts
+++ b/src/test/mocks/pdp/handlers.ts
@@ -1,0 +1,285 @@
+/**
+ * MSW HTTP handlers for PDP Server endpoints
+ *
+ * These handlers can be used to mock PDP Server HTTP responses in tests
+ */
+
+import { ethers } from 'ethers'
+import { HttpResponse, http } from 'msw'
+import type { PDPAddPiecesInput } from '../../../pdp/server.ts'
+
+export interface PDPMockOptions {
+  baseUrl?: string
+  debug?: boolean
+}
+
+export interface MetadataCapture {
+  keys: string[]
+  values: string[]
+}
+
+export interface PieceMetadataCapture {
+  keys: string[][]
+  values: string[][]
+}
+
+/**
+ * Creates a handler for successful data set creation
+ */
+export function createDataSetHandler(txHash: string, options: PDPMockOptions = {}) {
+  const baseUrl = options.baseUrl ?? 'http://pdp.local'
+
+  return http.post(`${baseUrl}/pdp/data-sets`, async ({ request }) => {
+    if (options.debug) {
+      const body = await request.json()
+      console.debug('PDP Mock: createDataSet request', body)
+    }
+
+    // Validate that request contains required fields
+    const body = (await request.json()) as any
+    if (!body.extraData) {
+      return new HttpResponse(JSON.stringify({ error: 'Missing extraData' }), { status: 400 })
+    }
+
+    // Parse extraData to verify metadata encoding
+    try {
+      const abiCoder = ethers.AbiCoder.defaultAbiCoder()
+      const decoded = abiCoder.decode(['address', 'string[]', 'string[]', 'bytes'], body.extraData)
+
+      if (options.debug) {
+        console.debug('PDP Mock: decoded metadata keys', decoded[1])
+        console.debug('PDP Mock: decoded metadata values', decoded[2])
+      }
+    } catch (error) {
+      if (options.debug) {
+        console.debug('PDP Mock: failed to decode extraData', error)
+      }
+    }
+
+    return new HttpResponse(null, {
+      status: 201,
+      headers: { Location: `/pdp/data-sets/created/${txHash}` },
+    })
+  })
+}
+
+/**
+ * Creates a handler for successful piece addition
+ */
+export function addPiecesHandler(dataSetId: number, txHash: string, options: PDPMockOptions = {}) {
+  const baseUrl = options.baseUrl ?? 'http://pdp.local'
+
+  return http.post<{ id: string }, PDPAddPiecesInput>(
+    `${baseUrl}/pdp/data-sets/:id/pieces`,
+    async ({ params, request }) => {
+      if (params.id !== dataSetId.toString()) {
+        return new HttpResponse(null, { status: 404 })
+      }
+
+      const body = await request.json()
+
+      if (options.debug) {
+        console.debug('PDP Mock: addPieces request', body)
+      }
+
+      // Validate that request contains required fields
+      if (!body.extraData) {
+        return new HttpResponse(JSON.stringify({ error: 'Missing extraData' }), { status: 400 })
+      }
+
+      // Parse extraData to verify metadata encoding
+      try {
+        const abiCoder = ethers.AbiCoder.defaultAbiCoder()
+        const decoded = abiCoder.decode(['bytes', 'string[][]', 'string[][]'], body.extraData)
+
+        if (options.debug) {
+          console.debug('PDP Mock: decoded piece metadata', decoded[1])
+          console.debug('PDP Mock: decoded piece metadata values', decoded[2])
+        }
+      } catch (error) {
+        if (options.debug) {
+          console.debug('PDP Mock: failed to decode extraData', error)
+        }
+      }
+
+      return new HttpResponse(null, {
+        status: 201,
+        headers: { Location: `/pdp/data-sets/${dataSetId}/pieces/added/${txHash}` },
+      })
+    }
+  )
+}
+
+/**
+ * Creates a handler for data set creation status check
+ */
+export function dataSetCreationStatusHandler(
+  txHash: string,
+  response: { ok: boolean | null; dataSetId?: number },
+  options: PDPMockOptions = {}
+) {
+  const baseUrl = options.baseUrl ?? 'http://pdp.local'
+
+  return http.get(`${baseUrl}/pdp/data-sets/created/:txHash`, ({ params }) => {
+    if (params.txHash !== txHash) {
+      return new HttpResponse(null, { status: 404 })
+    }
+
+    return HttpResponse.json(response, { status: 200 })
+  })
+}
+
+/**
+ * Creates a handler for piece addition status check
+ */
+export function pieceAdditionStatusHandler(
+  dataSetId: number,
+  txHash: string,
+  response: any,
+  options: PDPMockOptions = {}
+) {
+  const baseUrl = options.baseUrl ?? 'http://pdp.local'
+
+  return http.get(`${baseUrl}/pdp/data-sets/:id/pieces/added/:txHash`, ({ params }) => {
+    if (params.id !== dataSetId.toString() || params.txHash !== txHash) {
+      return new HttpResponse(null, { status: 404 })
+    }
+
+    return HttpResponse.json(response, { status: 200 })
+  })
+}
+
+/**
+ * Creates a handler for finding pieces
+ */
+export function findPieceHandler(pieceCid: string, found: boolean, options: PDPMockOptions = {}) {
+  const baseUrl = options.baseUrl ?? 'http://pdp.local'
+
+  return http.get(`${baseUrl}/pdp/piece/`, ({ request }) => {
+    const url = new URL(request.url)
+    const queryCid = url.searchParams.get('pieceCid')
+
+    if (queryCid !== pieceCid) {
+      return HttpResponse.json({ pieceCid: null }, { status: 200 })
+    }
+
+    if (!found) {
+      return HttpResponse.json({ pieceCid: null }, { status: 200 })
+    }
+
+    return HttpResponse.json({ pieceCid }, { status: 200 })
+  })
+}
+
+/**
+ * Helper to decode metadata from extraData
+ */
+export function decodeMetadataFromExtraData(extraData: string): MetadataCapture {
+  const abiCoder = ethers.AbiCoder.defaultAbiCoder()
+  const decoded = abiCoder.decode(['address', 'string[]', 'string[]', 'bytes'], extraData)
+  return {
+    keys: decoded[1] as string[],
+    values: decoded[2] as string[],
+  }
+}
+
+/**
+ * Helper to decode piece metadata from extraData
+ */
+export function decodePieceMetadataFromExtraData(extraData: string): PieceMetadataCapture {
+  const abiCoder = ethers.AbiCoder.defaultAbiCoder()
+  const decoded = abiCoder.decode(['bytes', 'string[][]', 'string[][]'], extraData)
+  return {
+    keys: decoded[1] as string[][],
+    values: decoded[2] as string[][],
+  }
+}
+
+/**
+ * Creates a handler that captures metadata from createDataSet requests
+ * @param txHash - Transaction hash to return in Location header
+ * @param captureCallback - Callback to store captured metadata
+ * @param options - Additional options
+ */
+export function createDataSetWithMetadataCapture(
+  txHash: string,
+  captureCallback: (metadata: MetadataCapture) => void,
+  options: PDPMockOptions = {}
+) {
+  const baseUrl = options.baseUrl ?? 'http://pdp.local'
+
+  return http.post(`${baseUrl}/pdp/data-sets`, async ({ request }) => {
+    const body = (await request.json()) as any
+
+    if (!body.extraData) {
+      return new HttpResponse(JSON.stringify({ error: 'Missing extraData' }), { status: 400 })
+    }
+
+    try {
+      const metadata = decodeMetadataFromExtraData(body.extraData)
+      captureCallback(metadata)
+
+      if (options.debug) {
+        console.debug('PDP Mock: captured metadata', metadata)
+      }
+    } catch (error) {
+      if (options.debug) {
+        console.debug('PDP Mock: failed to decode extraData', error)
+      }
+    }
+
+    return new HttpResponse(null, {
+      status: 201,
+      headers: { Location: `/pdp/data-sets/created/${txHash}` },
+    })
+  })
+}
+
+/**
+ * Creates a handler that captures piece metadata from addPieces requests
+ * @param dataSetId - Data set ID to match
+ * @param txHash - Transaction hash to return in Location header
+ * @param captureCallback - Callback to store captured metadata
+ * @param options - Additional options
+ */
+export function addPiecesWithMetadataCapture(
+  dataSetId: number,
+  txHash: string,
+  captureCallback: (metadata: PieceMetadataCapture) => void,
+  options: PDPMockOptions = {}
+) {
+  const baseUrl = options.baseUrl ?? 'http://pdp.local'
+
+  return http.post<{ id: string }, PDPAddPiecesInput>(
+    `${baseUrl}/pdp/data-sets/:id/pieces`,
+    async ({ params, request }) => {
+      if (params.id !== dataSetId.toString()) {
+        return new HttpResponse(null, { status: 404 })
+      }
+
+      const body = await request.json()
+
+      if (!body.extraData) {
+        return new HttpResponse(JSON.stringify({ error: 'Missing extraData' }), { status: 400 })
+      }
+
+      try {
+        const metadata = decodePieceMetadataFromExtraData(body.extraData)
+        captureCallback(metadata)
+
+        if (options.debug) {
+          console.debug('PDP Mock: captured piece metadata', metadata)
+        }
+      } catch (error) {
+        if (options.debug) {
+          console.debug('PDP Mock: failed to decode extraData', error)
+        }
+      }
+
+      return new HttpResponse(null, {
+        status: 201,
+        headers: { Location: `/pdp/data-sets/${dataSetId}/pieces/added/${txHash}` },
+      })
+    }
+  )
+}

--- a/src/test/pdp-server.test.ts
+++ b/src/test/pdp-server.test.ts
@@ -84,7 +84,7 @@ describe('PDPServer', () => {
       const result = await pdpServer.createDataSet(
         0, // clientDataSetId
         '0x70997970C51812dc3A010C7d01b50e0d17dc79C8', // payee
-        false, // withCDN
+        [], // metadata (empty for no CDN)
         TEST_CONTRACT_ADDRESS // recordKeeper
       )
 

--- a/src/test/retriever-chain.test.ts
+++ b/src/test/retriever-chain.test.ts
@@ -95,6 +95,7 @@ const mockDataSet: EnhancedDataSetInfo = {
   currentPieceCount: 5,
   isLive: true,
   isManaged: true,
+  metadata: [],
 }
 
 describe('ChainRetriever', () => {

--- a/src/test/warm-storage-metadata.test.ts
+++ b/src/test/warm-storage-metadata.test.ts
@@ -1,0 +1,84 @@
+/* globals describe it before after beforeEach */
+import { assert } from 'chai'
+import { ethers } from 'ethers'
+import { setup } from 'iso-web/msw'
+import { METADATA_KEYS } from '../utils/constants.ts'
+import { WarmStorageService } from '../warm-storage/index.ts'
+import { ADDRESSES, JSONRPC, presets } from './mocks/jsonrpc/index.ts'
+
+describe('WarmStorageService Metadata', () => {
+  let server: any
+  let warmStorageService: WarmStorageService
+
+  before(async () => {
+    server = setup([])
+    await server.start({ quiet: true })
+  })
+
+  after(() => {
+    server.stop()
+  })
+
+  beforeEach(async () => {
+    server.resetHandlers()
+    server.use(JSONRPC(presets.basic))
+
+    const provider = new ethers.JsonRpcProvider('https://api.calibration.node.glif.io/rpc/v1')
+    warmStorageService = await WarmStorageService.create(provider, ADDRESSES.calibration.warmStorage)
+  })
+
+  describe('Data Set Metadata', () => {
+    it('should get all data set metadata', async () => {
+      const metadata = await warmStorageService.getDataSetMetadata(1)
+
+      assert.equal(metadata.length, 2)
+      assert.deepEqual(metadata[0], { key: 'environment', value: 'test' })
+      assert.deepEqual(metadata[1], { key: METADATA_KEYS.WITH_CDN, value: '' })
+    })
+
+    it('should get specific data set metadata by key', async () => {
+      const value = await warmStorageService.getDataSetMetadataByKey(1, METADATA_KEYS.WITH_CDN)
+      assert.equal(value, '')
+
+      const envValue = await warmStorageService.getDataSetMetadataByKey(1, 'environment')
+      assert.equal(envValue, 'test')
+
+      const nonExistent = await warmStorageService.getDataSetMetadataByKey(1, 'nonexistent')
+      assert.isNull(nonExistent)
+    })
+
+    it('should return empty metadata for non-existent data set', async () => {
+      const metadata = await warmStorageService.getDataSetMetadata(999)
+      assert.equal(metadata.length, 0)
+    })
+  })
+
+  describe('Piece Metadata', () => {
+    it('should get all piece metadata', async () => {
+      const metadata = await warmStorageService.getPieceMetadata(1, 0)
+
+      assert.equal(metadata.length, 2)
+      assert.deepEqual(metadata[0], { key: METADATA_KEYS.WITH_IPFS_INDEXING, value: '' })
+      assert.deepEqual(metadata[1], {
+        key: METADATA_KEYS.IPFS_ROOT_CID,
+        value: 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+      })
+    })
+
+    it('should get specific piece metadata by key', async () => {
+      const indexingValue = await warmStorageService.getPieceMetadataByKey(1, 0, METADATA_KEYS.WITH_IPFS_INDEXING)
+      assert.equal(indexingValue, '')
+
+      const cidValue = await warmStorageService.getPieceMetadataByKey(1, 0, METADATA_KEYS.IPFS_ROOT_CID)
+      assert.equal(cidValue, 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi')
+
+      const nonExistent = await warmStorageService.getPieceMetadataByKey(1, 0, 'nonexistent')
+      assert.isNull(nonExistent)
+    })
+
+    it('should return empty metadata for non-existent piece', async () => {
+      const metadata = await warmStorageService.getPieceMetadata(1, 999)
+      assert.equal(metadata.length, 0)
+    })
+  })
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,6 +232,8 @@ export interface EnhancedDataSetInfo extends DataSetInfo {
   isManaged: boolean
   /** Whether the data set is using CDN (derived from cdnRailId > 0) */
   withCDN: boolean
+  /** Metadata associated with this data set */
+  metadata: MetadataEntry[]
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -262,8 +262,18 @@ export interface SettlementResult {
   note: string
 }
 
+// ============================================================================
+// Storage Context Creation Types
+// ============================================================================
+// These types are used when creating or selecting storage contexts
+// (provider + data set pairs)
+// ============================================================================
+
 /**
  * Callbacks for storage service creation process
+ *
+ * These callbacks provide visibility into the context creation process,
+ * including provider selection and data set creation/reuse.
  */
 export interface StorageCreationCallbacks {
   /**
@@ -303,7 +313,14 @@ export interface StorageCreationCallbacks {
 }
 
 /**
- * Storage service implementation options
+ * Options for creating or selecting a storage context
+ *
+ * Used by StorageManager.createContext() and indirectly by StorageManager.upload()
+ * when auto-creating contexts. Allows specification of:
+ * - Provider selection (by ID or address)
+ * - Data set selection or creation
+ * - CDN enablement and metadata
+ * - Creation process callbacks
  */
 export interface StorageServiceOptions {
   /** Specific provider ID to use (optional) */
@@ -314,6 +331,8 @@ export interface StorageServiceOptions {
   dataSetId?: number
   /** Whether to enable CDN services */
   withCDN?: boolean
+  /** Custom metadata for the data set (key-value pairs) */
+  metadata?: MetadataEntry[]
   /** Force creation of a new data set, even if a candidate exists */
   forceCreateDataSet?: boolean
   /** Callbacks for creation process */
@@ -343,8 +362,24 @@ export interface PreflightInfo {
   selectedDataSetId: number | null
 }
 
+// ============================================================================
+// Upload Types
+// ============================================================================
+// The SDK provides different upload options for different use cases:
+//
+// 1. UploadCallbacks - Progress callbacks only (used by all upload methods)
+// 2. UploadOptions - For StorageContext.upload() (adds piece metadata)
+// 3. StorageManagerUploadOptions - For StorageManager.upload() (internal type
+//    that combines context creation + upload in one call)
+// ============================================================================
+
 /**
- * Upload progress callbacks
+ * Callbacks for tracking upload progress
+ *
+ * These callbacks provide visibility into the upload process stages:
+ * 1. Upload completion (piece uploaded to provider)
+ * 2. Piece addition (transaction submitted to chain)
+ * 3. Confirmation (transaction confirmed on-chain)
  */
 export interface UploadCallbacks {
   /** Called when upload to service provider completes */
@@ -353,6 +388,17 @@ export interface UploadCallbacks {
   onPieceAdded?: (transaction?: ethers.TransactionResponse) => void
   /** Called when the service provider agrees that the piece addition is confirmed on-chain */
   onPieceConfirmed?: (pieceIds: number[]) => void
+}
+
+/**
+ * Options for uploading individual pieces to an existing storage context
+ *
+ * Used by StorageContext.upload() for uploading data to a specific provider
+ * and data set that has already been created/selected.
+ */
+export interface UploadOptions extends UploadCallbacks {
+  /** Custom metadata for this specific piece (key-value pairs) */
+  metadata?: MetadataEntry[]
 }
 
 /**

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -157,6 +157,46 @@ export const SIZE_CONSTANTS = {
 } as const
 
 /**
+ * Common metadata keys
+ */
+export const METADATA_KEYS = {
+  /**
+   * Key used to request that CDN services should be enabled for a data set. The presence of this
+   * key does not strictly guarantee that CDN services will be provided, but the Warm Storage
+   * contract will attempt to enable payment for CDN services if this key is present.
+   *
+   * The value for this key is always an empty string.
+   *
+   * Only valid for *data set* metadata.
+   */
+  WITH_CDN: 'withCDN',
+
+  /**
+   * Key used to request that a PDP server perform IPFS indexing and announcing to IPNI should be
+   * enabled for a piece. The contents of the associated piece is assumed to be indexable (i.e. a
+   * CAR or a PoDSI container). The presence of this key does not guarantee that indexing will be
+   * performed or succeed.
+   *
+   * The value for this key is always an empty string.
+   *
+   * Only valid for *piece* metadata.
+   */
+  WITH_IPFS_INDEXING: 'withIPFSIndexing',
+
+  /**
+   * Key used to indicate a root CID of an IPFS DAG contained within the associated piece. The
+   * presence of this key implies that the piece contains IPLD blocks in a suitable format (i.e. a
+   * CAR or a PoDSI container). The presence of this key does not guarantee that the CID is valid,
+   * that the piece contains IPLD blocks, or that the piece actually contains the referenced DAG.
+   *
+   * The value for this key must be a valid CID string.
+   *
+   * Only valid for *piece* metadata.
+   */
+  IPFS_ROOT_CID: 'ipfsRootCID',
+} as const
+
+/**
  * Timing constants for blockchain operations
  */
 export const TIMING_CONSTANTS = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -173,13 +173,14 @@ export const METADATA_KEYS = {
 
   /**
    * Key used to request that a PDP server perform IPFS indexing and announcing to IPNI should be
-   * enabled for a piece. The contents of the associated piece is assumed to be indexable (i.e. a
-   * CAR or a PoDSI container). The presence of this key does not guarantee that indexing will be
+   * enabled for all pieces in a data set. The contents of the associated data sets are assumed to
+   * be indexable (i.e. a CAR or a PoDSI container) and the PDP server will be requested to perform
+   * best-effort indexing. The presence of this key does not guarantee that indexing will be
    * performed or succeed.
    *
    * The value for this key is always an empty string.
    *
-   * Only valid for *piece* metadata.
+   * Only valid for *data set* metadata.
    */
   WITH_IPFS_INDEXING: 'withIPFSIndexing',
 

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,0 +1,52 @@
+import type { MetadataEntry } from '../types.ts'
+import { METADATA_KEYS } from './constants.ts'
+
+/**
+ * Checks if a data set's metadata matches the requested metadata.
+ *
+ * The data set must contain all requested metadata entries with matching values.
+ * The data set may have additional metadata entries that are not in the requested set.
+ * Order of entries does not matter.
+ *
+ * @param dataSetMetadata - The metadata from the data set
+ * @param requestedMetadata - The metadata requirements to match
+ * @returns true if all requested metadata entries are present with matching values
+ */
+export function metadataMatches(dataSetMetadata: MetadataEntry[], requestedMetadata: MetadataEntry[]): boolean {
+  // If no metadata is requested, any data set matches
+  if (requestedMetadata.length === 0) {
+    return true
+  }
+
+  // For each requested metadata entry, check if it exists in dataSet with same value
+  for (const requested of requestedMetadata) {
+    const found = dataSetMetadata.find((m) => m.key === requested.key)
+    if (found == null || found.value !== requested.value) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Converts a boolean withCDN flag to metadata format for backward compatibility.
+ *
+ * @param withCDN - Whether to request CDN support
+ * @returns MetadataEntry array with withCDN key if true, empty array if false
+ */
+export function withCDNToMetadata(withCDN: boolean): MetadataEntry[] {
+  if (withCDN) {
+    return [{ key: METADATA_KEYS.WITH_CDN, value: '' }]
+  }
+  return []
+}
+
+/**
+ * Checks if metadata contains the withCDN key.
+ *
+ * @param metadata - The metadata to check
+ * @returns true if metadata contains withCDN key (regardless of value)
+ */
+export function hasWithCDN(metadata: MetadataEntry[]): boolean {
+  return metadata.some((m) => m.key === METADATA_KEYS.WITH_CDN)
+}

--- a/src/warm-storage/service.ts
+++ b/src/warm-storage/service.ts
@@ -29,7 +29,7 @@ import { ethers } from 'ethers'
 import type { PaymentsService } from '../payments/service.ts'
 import type { DataSetCreationStatusResponse, PDPServer } from '../pdp/server.ts'
 import { PDPVerifier } from '../pdp/verifier.ts'
-import type { DataSetInfo, EnhancedDataSetInfo } from '../types.ts'
+import type { DataSetInfo, EnhancedDataSetInfo, MetadataEntry } from '../types.ts'
 import { CONTRACT_ADDRESSES, SIZE_CONSTANTS, TIME_CONSTANTS, TIMING_CONSTANTS } from '../utils/constants.ts'
 import { CONTRACT_ABIS, createError, getFilecoinNetworkType, TOKENS } from '../utils/index.ts'
 
@@ -677,6 +677,66 @@ export class WarmStorageService {
 
     // Timeout
     throw new Error(`Data set creation timed out after ${maxWaitTime / 1000} seconds`)
+  }
+
+  // ========== Metadata Operations ==========
+
+  /**
+   * Get all metadata for a data set
+   * @param dataSetId - The data set ID
+   * @returns Array of metadata entries (key-value pairs)
+   */
+  async getDataSetMetadata(dataSetId: number): Promise<MetadataEntry[]> {
+    const viewContract = this._getWarmStorageViewContract()
+    const [keys, values] = await viewContract.getAllDataSetMetadata(dataSetId)
+
+    const metadata: MetadataEntry[] = []
+    for (let i = 0; i < keys.length; i++) {
+      metadata.push({ key: keys[i], value: values[i] })
+    }
+    return metadata
+  }
+
+  /**
+   * Get specific metadata key for a data set
+   * @param dataSetId - The data set ID
+   * @param key - The metadata key to retrieve
+   * @returns The metadata value if it exists, null otherwise
+   */
+  async getDataSetMetadataByKey(dataSetId: number, key: string): Promise<string | null> {
+    const viewContract = this._getWarmStorageViewContract()
+    const [exists, value] = await viewContract.getDataSetMetadata(dataSetId, key)
+    return exists ? value : null
+  }
+
+  /**
+   * Get all metadata for a piece in a data set
+   * @param dataSetId - The data set ID
+   * @param pieceId - The piece ID
+   * @returns Array of metadata entries (key-value pairs)
+   */
+  async getPieceMetadata(dataSetId: number, pieceId: number): Promise<MetadataEntry[]> {
+    const viewContract = this._getWarmStorageViewContract()
+    const [keys, values] = await viewContract.getAllPieceMetadata(dataSetId, pieceId)
+
+    const metadata: MetadataEntry[] = []
+    for (let i = 0; i < keys.length; i++) {
+      metadata.push({ key: keys[i], value: values[i] })
+    }
+    return metadata
+  }
+
+  /**
+   * Get specific metadata key for a piece in a data set
+   * @param dataSetId - The data set ID
+   * @param pieceId - The piece ID
+   * @param key - The metadata key to retrieve
+   * @returns The metadata value if it exists, null otherwise
+   */
+  async getPieceMetadataByKey(dataSetId: number, pieceId: number, key: string): Promise<string | null> {
+    const viewContract = this._getWarmStorageViewContract()
+    const [exists, value] = await viewContract.getPieceMetadata(dataSetId, pieceId, key)
+    return exists ? value : null
   }
 
   // ========== Storage Cost Operations ==========

--- a/src/warm-storage/service.ts
+++ b/src/warm-storage/service.ts
@@ -358,13 +358,15 @@ export class WarmStorageService {
                 isLive: false,
                 isManaged: false,
                 withCDN: dataSet.cdnRailId > 0, // CDN is enabled if cdnRailId is non-zero (should be more reliable than metadata)
+                metadata: [] as MetadataEntry[],
               }
         }
 
         // Parallelize independent calls
-        const [isLive, listenerResult] = await Promise.all([
+        const [isLive, listenerResult, metadata] = await Promise.all([
           pdpVerifier.dataSetLive(pdpVerifierDataSetId),
           pdpVerifier.getDataSetListener(pdpVerifierDataSetId).catch(() => null),
+          this.getDataSetMetadata(pdpVerifierDataSetId).catch(() => [] as MetadataEntry[]),
         ])
 
         // Check if this data set is managed by our Warm Storage contract
@@ -387,6 +389,7 @@ export class WarmStorageService {
           isLive,
           isManaged,
           withCDN: dataSet.cdnRailId > 0, // CDN is enabled if cdnRailId is non-zero
+          metadata,
         }
       } catch (error) {
         // Re-throw the error to let the caller handle it


### PR DESCRIPTION
Closes #201 

* Expose `metadata: MetadataEntry[]` on the main APIs for both context creation (createDataSet) and piece upload (addRoots)
* There's some minor breaking changes for internal components in here but not on the main API, I've tried to keep it smooth and consistent so `withCDN` is still a boolean but it'll merge with what you explicitly provide
* We have a `METADATA_KEYS` in our constants now, these are "common metadata keys" (not exhaustive or prescriptive), including: `WITH_CDN: 'withCDN'` (per data set), `WITH_IPFS_INDEXING: 'withIPFSIndexing'` (per data set), `IPFS_ROOT_CID: 'ipfsRootCID'` (per piece).
* When auto-selecting a data set for you to re-use it takes into account _all_ of your metadata now, not just the `withCDN` flag. So if you ask for a specific set of metadata in a data set and you don't have one that has all that metadata (unordered match) then it'll make you a new one. You can always use `forceCreateDataSet` or `dataSetId` to get around this auto matching. This is backward compatible because `withCDN` is in there but it also means that we fetch all the metadata for all your datasets so there's extra chain operations in setup unfortunately (previously we could infer `withCDN` from the rail information, but we now have to get all metadata so we can compare). Probably another round of effort in here to multicall3 some of this stuff, I just didn't want to do it here because it's so verbose to write and test (can be done later).