### PR TITLE
feat: add mainnet address, add --network flag to sp-tool

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -247,7 +247,7 @@ export const CONTRACT_ADDRESSES = {
    * All other contract addresses are discovered from this contract
    */
   WARM_STORAGE: {
-    mainnet: '', // TODO: Get actual mainnet address from deployment
+    mainnet: '0x81DFD9813aDd354f03704F31419b0c6268d46232',
     calibration: '0x80617b65FD2EEa1D7fDe2B4F85977670690ed348',
   } as const satisfies Record<FilecoinNetworkType, string>,
 

--- a/utils/sp-tool.js
+++ b/utils/sp-tool.js
@@ -386,7 +386,8 @@ WarmStorage Commands:
   warm-list   List WarmStorage approved providers
 
 Options:
-  --rpc-url <url>       RPC endpoint (default: calibration)
+  --network <network>   Network to use: 'mainnet' or 'calibration' (default: calibration)
+  --rpc-url <url>       RPC endpoint (overrides network default)
   --key <private-key>   Private key for signing (required for write operations)
   --registry <address>  Registry contract address (overrides discovery)
   --warm <address>      WarmStorage address (for registry discovery or warm commands)
@@ -399,8 +400,11 @@ Options:
   --location <text>     Provider location (e.g., "us-east")
 
 Examples:
-  # Register a new provider (requires 5 FIL fee)
-  node utils/sp-tool.js register --key 0x... --name "My Provider" --http "https://provider.example.com" --payee 0x...
+  # Register a new provider on mainnet (requires 5 FIL fee)
+  node utils/sp-tool.js register --key 0x... --name "My Provider" --http "https://provider.example.com" --network mainnet
+
+  # Register a new provider on calibration (default network)
+  node utils/sp-tool.js register --key 0x... --name "My Provider" --http "https://provider.example.com"
   
   # Add provider to WarmStorage approved list
   node utils/sp-tool.js warm-add --key 0x... --id 2
@@ -414,8 +418,17 @@ Examples:
     process.exit(0)
   }
 
-  // Setup provider
-  const rpcUrl = options['rpc-url'] || 'https://api.calibration.node.glif.io/rpc/v1'
+  // Setup provider based on network flag
+  const network = options.network || 'calibration'
+  if (network !== 'mainnet' && network !== 'calibration') {
+    console.error(`Error: Invalid network '${network}'. Must be 'mainnet' or 'calibration'`)
+    process.exit(1)
+  }
+
+  const defaultRpcUrl = network === 'mainnet'
+    ? 'https://api.node.glif.io/rpc/v1'
+    : 'https://api.calibration.node.glif.io/rpc/v1'
+  const rpcUrl = options['rpc-url'] || defaultRpcUrl
   const provider = new ethers.JsonRpcProvider(rpcUrl)
 
   // Setup signer if needed

--- a/utils/sp-tool.js
+++ b/utils/sp-tool.js
@@ -404,7 +404,7 @@ Examples:
   node utils/sp-tool.js register --key 0x... --name "My Provider" --http "https://provider.example.com" --network mainnet
 
   # Register a new provider on calibration (default network)
-  node utils/sp-tool.js register --key 0x... --name "My Provider" --http "https://provider.example.com"
+  node utils/sp-tool.js register --key 0x... --name "My Provider" --http "https://provider.example.com" --payee 0x...
   
   # Add provider to WarmStorage approved list
   node utils/sp-tool.js warm-add --key 0x... --id 2

--- a/utils/sp-tool.js
+++ b/utils/sp-tool.js
@@ -425,8 +425,15 @@ Examples:
     process.exit(1)
   }
 
-  // Use WebSocket URLs by default for better performance
-  const defaultRpcUrl = RPC_URLS[network].websocket
+  // Use WebSocket URLs by default for better performance, fallback to HTTP if not available
+  let defaultRpcUrl = RPC_URLS[network] && RPC_URLS[network].websocket
+  if (!defaultRpcUrl) {
+    defaultRpcUrl = RPC_URLS[network] && RPC_URLS[network].http
+  }
+  if (!options['rpc-url'] && !defaultRpcUrl) {
+    console.error(`Error: No RPC URL available for network '${network}'. Please provide --rpc-url.`)
+    process.exit(1)
+  }
   const rpcUrl = options['rpc-url'] || defaultRpcUrl
 
   // Smart provider selection based on URL protocol

--- a/utils/sp-tool.js
+++ b/utils/sp-tool.js
@@ -425,9 +425,8 @@ Examples:
     process.exit(1)
   }
 
-  const defaultRpcUrl = network === 'mainnet'
-    ? 'https://api.node.glif.io/rpc/v1'
-    : 'https://api.calibration.node.glif.io/rpc/v1'
+  const defaultRpcUrl =
+    network === 'mainnet' ? 'https://api.node.glif.io/rpc/v1' : 'https://api.calibration.node.glif.io/rpc/v1'
   const rpcUrl = options['rpc-url'] || defaultRpcUrl
   const provider = new ethers.JsonRpcProvider(rpcUrl)
 

--- a/utils/sp-tool.js
+++ b/utils/sp-tool.js
@@ -426,9 +426,9 @@ Examples:
   }
 
   // Use WebSocket URLs by default for better performance, fallback to HTTP if not available
-  let defaultRpcUrl = RPC_URLS[network] && RPC_URLS[network].websocket
+  let defaultRpcUrl = RPC_URLS[network]?.websocket
   if (!defaultRpcUrl) {
-    defaultRpcUrl = RPC_URLS[network] && RPC_URLS[network].http
+    defaultRpcUrl = RPC_URLS[network]?.http
   }
   if (!options['rpc-url'] && !defaultRpcUrl) {
     console.error(`Error: No RPC URL available for network '${network}'. Please provide --rpc-url.`)
@@ -466,35 +466,42 @@ Examples:
   }
 
   // Execute command
-  switch (command) {
-    case 'register':
-      await handleRegister(provider, signer, options)
-      break
-    case 'update':
-      await handleUpdate(provider, signer, options)
-      break
-    case 'deregister':
-      await handleDeregister(provider, signer, options)
-      break
-    case 'info':
-      await handleInfo(provider, options)
-      break
-    case 'list':
-      await handleList(provider, options)
-      break
-    case 'warm-add':
-      await handleWarmAdd(provider, signer, options)
-      break
-    case 'warm-remove':
-      await handleWarmRemove(provider, signer, options)
-      break
-    case 'warm-list':
-      await handleWarmList(provider, options)
-      break
-    default:
-      console.error(`Unknown command: ${command}`)
-      console.log('Run "node utils/sp-tool.js help" for usage information')
-      process.exit(1)
+  try {
+    switch (command) {
+      case 'register':
+        await handleRegister(provider, signer, options)
+        break
+      case 'update':
+        await handleUpdate(provider, signer, options)
+        break
+      case 'deregister':
+        await handleDeregister(provider, signer, options)
+        break
+      case 'info':
+        await handleInfo(provider, options)
+        break
+      case 'list':
+        await handleList(provider, options)
+        break
+      case 'warm-add':
+        await handleWarmAdd(provider, signer, options)
+        break
+      case 'warm-remove':
+        await handleWarmRemove(provider, signer, options)
+        break
+      case 'warm-list':
+        await handleWarmList(provider, options)
+        break
+      default:
+        console.error(`Unknown command: ${command}`)
+        console.log('Run "node utils/sp-tool.js help" for usage information')
+        process.exit(1)
+    }
+  } finally {
+    // Clean up provider connection (important for WebSocket providers)
+    if (provider && typeof provider.destroy === 'function') {
+      await provider.destroy()
+    }
   }
 }
 


### PR DESCRIPTION
- Add mainnet WarmStorage address (0x81DFD9813aDd354f03704F31419b0c6268d46232) to constants
- Add --network flag to sp-tool.js supporting 'mainnet' and 'calibration' (default)
- Automatically select appropriate RPC URL based on network flag
- Update help text with network flag documentation and examples