### PR TITLE
feat: enhance metadata selection and warm storage service tests

### DIFF
--- a/src/test/metadata-selection.test.ts
+++ b/src/test/metadata-selection.test.ts
@@ -130,54 +130,78 @@ describe('Metadata-based Data Set Selection', () => {
         ...presets.basic,
         warmStorageView: {
           ...presets.basic.warmStorageView,
-          railToDataSet: (args: any) => {
-            const [railId] = args
-            // Map rail IDs directly to data set IDs for this test
-            return [railId] // railId 1 -> dataSetId 1, railId 2 -> dataSetId 2, etc.
-          },
-          getClientDataSets: () => [
-            [
+          clientDataSets: () => [[1n, 2n, 3n]],
+          // Provide base dataset info per dataset id
+          getDataSet: (args: any) => {
+            const [dataSetId] = args as [bigint]
+            if (dataSetId === 1n) {
+              return [
+                {
+                  pdpRailId: 1n,
+                  cacheMissRailId: 0n,
+                  cdnRailId: 0n,
+                  payer: ADDRESSES.client1,
+                  payee: ADDRESSES.serviceProvider1,
+                  serviceProvider: ADDRESSES.serviceProvider1,
+                  commissionBps: 100n,
+                  clientDataSetId: 0n,
+                  pdpEndEpoch: 0n,
+                  providerId: 1n,
+                  cdnEndEpoch: 0n,
+                },
+              ]
+            }
+            if (dataSetId === 2n) {
+              return [
+                {
+                  pdpRailId: 2n,
+                  cacheMissRailId: 0n,
+                  cdnRailId: 100n,
+                  payer: ADDRESSES.client1,
+                  payee: ADDRESSES.serviceProvider1,
+                  serviceProvider: ADDRESSES.serviceProvider1,
+                  commissionBps: 100n,
+                  clientDataSetId: 1n,
+                  pdpEndEpoch: 0n,
+                  providerId: 1n,
+                  cdnEndEpoch: 0n,
+                },
+              ]
+            }
+            if (dataSetId === 3n) {
+              return [
+                {
+                  pdpRailId: 3n,
+                  cacheMissRailId: 0n,
+                  cdnRailId: 0n,
+                  payer: ADDRESSES.client1,
+                  payee: ADDRESSES.serviceProvider2,
+                  serviceProvider: ADDRESSES.serviceProvider2,
+                  commissionBps: 100n,
+                  clientDataSetId: 2n,
+                  pdpEndEpoch: 0n,
+                  providerId: 2n,
+                  cdnEndEpoch: 0n,
+                },
+              ]
+            }
+            // default empty/non-existent
+            return [
               {
-                pdpRailId: 1n,
+                pdpRailId: 0n,
                 cacheMissRailId: 0n,
-                cdnRailId: 0n, // No CDN
-                payer: ADDRESSES.client1,
-                payee: ADDRESSES.serviceProvider1,
-                serviceProvider: ADDRESSES.serviceProvider1,
-                commissionBps: 100n,
+                cdnRailId: 0n,
+                payer: ethers.ZeroAddress,
+                payee: ethers.ZeroAddress,
+                serviceProvider: ethers.ZeroAddress,
+                commissionBps: 0n,
                 clientDataSetId: 0n,
                 pdpEndEpoch: 0n,
-                providerId: 1n,
+                providerId: 0n,
                 cdnEndEpoch: 0n,
               },
-              {
-                pdpRailId: 2n,
-                cacheMissRailId: 0n,
-                cdnRailId: 100n, // Has CDN
-                payer: ADDRESSES.client1,
-                payee: ADDRESSES.serviceProvider1,
-                serviceProvider: ADDRESSES.serviceProvider1,
-                commissionBps: 100n,
-                clientDataSetId: 1n,
-                pdpEndEpoch: 0n,
-                providerId: 1n,
-                cdnEndEpoch: 0n,
-              },
-              {
-                pdpRailId: 3n,
-                cacheMissRailId: 0n,
-                cdnRailId: 0n, // No CDN
-                payer: ADDRESSES.client1,
-                payee: ADDRESSES.serviceProvider2,
-                serviceProvider: ADDRESSES.serviceProvider2,
-                commissionBps: 100n,
-                clientDataSetId: 2n,
-                pdpEndEpoch: 0n,
-                providerId: 2n,
-                cdnEndEpoch: 0n,
-              },
-            ],
-          ],
+            ]
+          },
           getAllDataSetMetadata: (args: any) => {
             const [dataSetId] = args
             if (dataSetId === 1n) {

--- a/src/test/mocks/jsonrpc/index.ts
+++ b/src/test/mocks/jsonrpc/index.ts
@@ -218,6 +218,7 @@ export const presets = {
     },
     warmStorageView: {
       isProviderApproved: () => [true],
+      // Keep legacy getters to satisfy RequiredDeep typing and backward-compat tests
       getClientDataSets: () => [
         [
           {
@@ -236,6 +237,22 @@ export const presets = {
         ],
       ],
       railToDataSet: () => [1n],
+      clientDataSets: () => [[1n]],
+      getDataSet: () => [
+        {
+          pdpRailId: 1n,
+          cacheMissRailId: 0n,
+          cdnRailId: 0n,
+          payer: ADDRESSES.client1,
+          payee: ADDRESSES.serviceProvider1,
+          serviceProvider: ADDRESSES.serviceProvider1,
+          commissionBps: 100n,
+          clientDataSetId: 0n,
+          pdpEndEpoch: 0n,
+          providerId: 1n,
+          cdnEndEpoch: 0n,
+        },
+      ],
       getApprovedProviders: () => [[1n, 2n]],
       getAllDataSetMetadata: (args) => {
         const [dataSetId] = args

--- a/src/test/mocks/jsonrpc/warm-storage.ts
+++ b/src/test/mocks/jsonrpc/warm-storage.ts
@@ -14,6 +14,10 @@ export type railToDataSet = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE
 
 export type getClientDataSets = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getClientDataSets'>
 
+export type clientDataSets = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'clientDataSets'>
+
+export type getDataSet = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getDataSet'>
+
 export type getApprovedProviders = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getApprovedProviders'>
 
 export type getAllDataSetMetadata = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STORAGE_VIEW, 'getAllDataSetMetadata'>
@@ -27,6 +31,8 @@ export type getPieceMetadata = ExtractAbiFunction<typeof CONTRACT_ABIS.WARM_STOR
 export interface WarmStorageViewOptions {
   isProviderApproved?: (args: AbiToType<isProviderApproved['inputs']>) => AbiToType<isProviderApproved['outputs']>
   getClientDataSets?: (args: AbiToType<getClientDataSets['inputs']>) => AbiToType<getClientDataSets['outputs']>
+  clientDataSets?: (args: AbiToType<clientDataSets['inputs']>) => AbiToType<clientDataSets['outputs']>
+  getDataSet?: (args: AbiToType<getDataSet['inputs']>) => AbiToType<getDataSet['outputs']>
   railToDataSet?: (args: AbiToType<railToDataSet['inputs']>) => AbiToType<railToDataSet['outputs']>
   getApprovedProviders?: (args: AbiToType<getApprovedProviders['inputs']>) => AbiToType<getApprovedProviders['outputs']>
   getAllDataSetMetadata?: (
@@ -187,6 +193,27 @@ export function warmStorageViewCallHandler(data: Hex, options: JSONRPCOptions): 
         CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'getClientDataSets')!
           .outputs,
         options.warmStorageView.getClientDataSets(args)
+      )
+    }
+
+    case 'clientDataSets': {
+      if (!options.warmStorageView?.clientDataSets) {
+        throw new Error('Warm Storage View: clientDataSets is not defined')
+      }
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'clientDataSets')!
+          .outputs,
+        options.warmStorageView.clientDataSets(args)
+      )
+    }
+
+    case 'getDataSet': {
+      if (!options.warmStorageView?.getDataSet) {
+        throw new Error('Warm Storage View: getDataSet is not defined')
+      }
+      return encodeAbiParameters(
+        CONTRACT_ABIS.WARM_STORAGE_VIEW.find((abi) => abi.type === 'function' && abi.name === 'getDataSet')!.outputs,
+        options.warmStorageView.getDataSet(args)
       )
     }
 

--- a/src/warm-storage/service.ts
+++ b/src/warm-storage/service.ts
@@ -335,76 +335,50 @@ export class WarmStorageService {
    * @returns Array of enhanced data set information
    */
   async getClientDataSetsWithDetails(client: string, onlyManaged: boolean = false): Promise<EnhancedDataSetInfo[]> {
-    const dataSets = await this.getClientDataSets(client)
     const pdpVerifier = this._getPDPVerifier()
     const viewContract = this._getWarmStorageViewContract()
 
-    // Process all data sets in parallel
-    const enhancedDataSetsPromises = dataSets.map(async (dataSet) => {
+    // Query dataset IDs directly from the view contract
+    const ids: bigint[] = await viewContract.clientDataSets(client)
+    if (ids.length === 0) return []
+
+    // Enhance all in parallel using dataset IDs
+    const enhancedDataSetsPromises = ids.map(async (idBigInt) => {
+      const pdpVerifierDataSetId = Number(idBigInt)
       try {
-        // Get the actual PDPVerifier data set ID from the rail ID (using pdpRailId now)
-        const pdpVerifierDataSetId = Number(await viewContract.railToDataSet(dataSet.pdpRailId))
+        const base = await this.getDataSet(pdpVerifierDataSetId)
 
-        // Check if this is a valid rail (rails should be > 0)
-        // Note: dataSetId can be 0 (legitimate first data set), but pdpRailId should never be 0
-        if (dataSet.pdpRailId === 0) {
-          return onlyManaged
-            ? null // Will be filtered out
-            : {
-                ...dataSet,
-                pdpVerifierDataSetId: 0,
-                nextPieceId: 0,
-                currentPieceCount: 0,
-                isLive: false,
-                isManaged: false,
-                withCDN: dataSet.cdnRailId > 0, // CDN is enabled if cdnRailId is non-zero (should be more reliable than metadata)
-                metadata: Object.create(null) as Record<string, string>,
-              }
-        }
-
-        // Parallelize independent calls
         const [isLive, listenerResult, metadata] = await Promise.all([
           pdpVerifier.dataSetLive(pdpVerifierDataSetId),
           pdpVerifier.getDataSetListener(pdpVerifierDataSetId).catch(() => null),
           this.getDataSetMetadata(pdpVerifierDataSetId).catch(() => Object.create(null) as Record<string, string>),
         ])
 
-        // Check if this data set is managed by our Warm Storage contract
         const isManaged =
           listenerResult != null && listenerResult.toLowerCase() === this._warmStorageAddress.toLowerCase()
 
-        // Skip unmanaged data sets if onlyManaged is true
-        if (onlyManaged && !isManaged) {
-          return null // Will be filtered out
-        }
+        if (onlyManaged && !isManaged) return null
 
-        // Get next piece ID only if the data set is live
-        const nextPieceId = isLive ? await pdpVerifier.getNextPieceId(pdpVerifierDataSetId) : 0
+        const nextPieceId = isLive ? await pdpVerifier.getNextPieceId(pdpVerifierDataSetId) : 0n
 
         return {
-          ...dataSet,
+          ...base,
           pdpVerifierDataSetId,
           nextPieceId: Number(nextPieceId),
           currentPieceCount: Number(nextPieceId),
           isLive,
           isManaged,
-          withCDN: dataSet.cdnRailId > 0, // CDN is enabled if cdnRailId is non-zero
+          withCDN: base.cdnRailId > 0,
           metadata,
         }
       } catch (error) {
-        // Re-throw the error to let the caller handle it
         throw new Error(
-          `Failed to get details for data set with enhanced info ${dataSet.pdpRailId}: ${
-            error instanceof Error ? error.message : String(error)
-          }`
+          `Failed to get details for data set ${pdpVerifierDataSetId}: ${error instanceof Error ? error.message : String(error)}`
         )
       }
     })
 
-    // Wait for all promises to resolve
     const results = await Promise.all(enhancedDataSetsPromises)
-
-    // Filter out null values (from skipped data sets when onlyManaged is true)
     return results.filter((result): result is EnhancedDataSetInfo => result !== null)
   }
 


### PR DESCRIPTION
- getClientDataSetsWithDetails now starts from view clientDataSets(client) IDs and enhances each in parallel (getDataSet, PDPVerifier, metadata).
- Removed railToDataSet indirection/dependence on getClientDataSets for this path.
- Tests and mocks updated; suite passes.

Closes #181