### PR TITLE
feat: permit flow integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ filecoin-project-*/
 
 # VIM
 *.swp
+.env

--- a/src/abis/erc20-permit.ts
+++ b/src/abis/erc20-permit.ts
@@ -1,0 +1,16 @@
+export const erc20PermitAbi = [
+  {
+    type: 'function',
+    stateMutability: 'view',
+    name: 'nonces',
+    inputs: [{ name: 'owner', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    stateMutability: 'view',
+    name: 'version',
+    inputs: [],
+    outputs: [{ name: '', type: 'string' }],
+  },
+] as const

--- a/src/payments/service.ts
+++ b/src/payments/service.ts
@@ -6,9 +6,13 @@
 import { ethers } from 'ethers'
 import type { RailInfo, SettlementResult, TokenAmount, TokenIdentifier } from '../types.ts'
 import {
+  CHAIN_IDS,
   CONTRACT_ABIS,
+  CONTRACT_ADDRESSES,
   createError,
+  EIP2612_PERMIT_TYPES,
   getCurrentEpoch,
+  getFilecoinNetworkType,
   SETTLEMENT_FEE,
   TIMING_CONSTANTS,
   TOKENS,
@@ -81,6 +85,163 @@ export class PaymentsService {
       this._paymentsContract = new ethers.Contract(this._paymentsAddress, CONTRACT_ABIS.PAYMENTS, this._signer)
     }
     return this._paymentsContract
+  }
+
+  /**
+   * Generate EIP-2612 permit signature for USDFC token
+   * Handles balance check, domain creation, nonce retrieval, and signature generation
+   * Uses Multicall3 to batch RPC calls for efficiency
+   * @param amount - Amount to permit
+   * @param deadline - Unix timestamp (seconds) when the permit expires
+   * @param contextName - Context name for error messages (e.g., 'depositWithPermit')
+   * @returns Signature object
+   */
+  private async _getPermitSignature(amount: bigint, deadline: bigint, contextName: string): Promise<ethers.Signature> {
+    const signerAddress = await this._signer.getAddress()
+
+    // Get network type (validates network and makes single getNetwork() call internally)
+    const networkType = await getFilecoinNetworkType(this._provider)
+
+    // Derive chainId from network type
+    const chainId = CHAIN_IDS[networkType]
+
+    // Setup Multicall3 for batched RPC calls
+    const multicall3Address = CONTRACT_ADDRESSES.MULTICALL3[networkType]
+    const multicall = new ethers.Contract(multicall3Address, CONTRACT_ABIS.MULTICALL3, this._provider)
+
+    // Create interfaces for encoding/decoding
+    const erc20Interface = new ethers.Interface(CONTRACT_ABIS.ERC20)
+    const permitInterface = new ethers.Interface(CONTRACT_ABIS.ERC20_PERMIT)
+
+    // Prepare multicall batch: balanceOf, name, version (with fallback), nonces
+    const calls = [
+      {
+        target: this._usdfcAddress,
+        allowFailure: false,
+        callData: erc20Interface.encodeFunctionData('balanceOf', [signerAddress]),
+      },
+      {
+        target: this._usdfcAddress,
+        allowFailure: false,
+        callData: erc20Interface.encodeFunctionData('name'),
+      },
+      {
+        target: this._usdfcAddress,
+        allowFailure: true, // Allow failure for version, we'll fallback to '1'
+        callData: permitInterface.encodeFunctionData('version'),
+      },
+      {
+        target: this._usdfcAddress,
+        allowFailure: false,
+        callData: permitInterface.encodeFunctionData('nonces', [signerAddress]),
+      },
+    ]
+
+    // Execute multicall
+    let results: any[]
+    try {
+      results = await multicall.aggregate3.staticCall(calls)
+    } catch (error) {
+      throw createError(
+        'PaymentsService',
+        contextName,
+        'Failed to fetch token information for permit. Ensure token contract is reachable.',
+        error
+      )
+    }
+
+    // Decode results
+    // Result 0: balanceOf
+    let usdfcBalance: bigint
+    try {
+      const decoded = erc20Interface.decodeFunctionResult('balanceOf', results[0].returnData)
+      usdfcBalance = decoded[0]
+    } catch (error) {
+      throw createError('PaymentsService', contextName, 'Failed to decode token balance.', error)
+    }
+
+    // Check balance
+    if (usdfcBalance < amount) {
+      throw createError(
+        'PaymentsService',
+        contextName,
+        `Insufficient USDFC: have ${usdfcBalance.toString()}, need ${amount.toString()}`
+      )
+    }
+
+    // Result 1: name
+    let tokenName: string
+    try {
+      const decoded = erc20Interface.decodeFunctionResult('name', results[1].returnData)
+      tokenName = decoded[0]
+    } catch (error) {
+      throw createError(
+        'PaymentsService',
+        contextName,
+        'Failed to read token name for permit domain. Ensure token contract is reachable.',
+        error
+      )
+    }
+
+    // Result 2: version (with fallback)
+    let domainVersion = '1'
+    if (results[2].success) {
+      try {
+        const decoded = permitInterface.decodeFunctionResult('version', results[2].returnData)
+        const maybeVersion = decoded[0]
+        if (typeof maybeVersion === 'string' && maybeVersion.length > 0) {
+          domainVersion = maybeVersion
+        }
+      } catch {
+        // silently fallback to '1'
+      }
+    }
+
+    // Result 3: nonces
+    let nonce: bigint
+    try {
+      const decoded = permitInterface.decodeFunctionResult('nonces', results[3].returnData)
+      nonce = decoded[0]
+    } catch (error) {
+      throw createError(
+        'PaymentsService',
+        contextName,
+        'Token does not appear to support EIP-2612 permit (nonces() unavailable).',
+        error
+      )
+    }
+
+    // Build EIP-2612 permit domain
+    const domain = {
+      name: tokenName,
+      version: domainVersion,
+      chainId,
+      verifyingContract: this._usdfcAddress,
+    }
+
+    // Create permit value
+    const value = {
+      owner: signerAddress,
+      spender: this._paymentsAddress,
+      value: amount,
+      nonce,
+      deadline,
+    }
+
+    // Sign typed data
+    let signatureHex: string
+    try {
+      signatureHex = await this._signer.signTypedData(domain, EIP2612_PERMIT_TYPES, value)
+    } catch (error) {
+      throw createError(
+        'PaymentsService',
+        contextName,
+        'Failed to sign EIP-2612 permit. Ensure your wallet supports typed data signing.',
+        error
+      )
+    }
+
+    return ethers.Signature.from(signatureHex)
   }
 
   async balance(token: TokenIdentifier = TOKENS.USDFC): Promise<bigint> {
@@ -500,6 +661,161 @@ export class PaymentsService {
     const depositTx = await paymentsContract.deposit(this._usdfcAddress, signerAddress, depositAmountBigint, txOptions)
 
     return depositTx
+  }
+
+  /**
+   * Deposit funds using ERC-2612 permit to approve and deposit in a single transaction
+   * This method creates an EIP-712 typed-data signature for the USDFC token's permit,
+   * then calls the Payments contract `depositWithPermit` to pull funds and credit the account.
+   *
+   * @param amount - Amount of USDFC to deposit (in base units)
+   * @param token - Token identifier (currently only USDFC is supported)
+   * @param deadline - Unix timestamp (seconds) when the permit expires. Defaults to now + 1 hour.
+   * @returns Transaction response object
+   */
+  async depositWithPermit(
+    amount: TokenAmount,
+    token: TokenIdentifier = TOKENS.USDFC,
+    deadline?: number | bigint
+  ): Promise<ethers.TransactionResponse> {
+    // Only support USDFC for now
+    if (token !== TOKENS.USDFC) {
+      throw createError('PaymentsService', 'depositWithPermit', `Unsupported token: ${token}`)
+    }
+
+    const depositAmountBigint = typeof amount === 'bigint' ? amount : BigInt(amount)
+    if (depositAmountBigint <= 0n) {
+      throw createError('PaymentsService', 'depositWithPermit', 'Invalid amount')
+    }
+
+    const signerAddress = await this._signer.getAddress()
+    const paymentsContract = this._getPaymentsContract()
+
+    // Calculate deadline
+    const permitDeadline: bigint =
+      deadline == null
+        ? BigInt(Math.floor(Date.now() / 1000) + TIMING_CONSTANTS.PERMIT_DEADLINE_DURATION)
+        : BigInt(deadline)
+
+    // Get permit signature (includes balance check, domain, nonce, signing)
+    const signature = await this._getPermitSignature(depositAmountBigint, permitDeadline, 'depositWithPermit')
+
+    // Only set explicit nonce if NonceManager is disabled
+    const txOptions: any = {}
+    if (this._disableNonceManager) {
+      const currentNonce = await this._provider.getTransactionCount(signerAddress, 'pending')
+      txOptions.nonce = currentNonce
+    }
+
+    try {
+      const tx = await paymentsContract.depositWithPermit(
+        this._usdfcAddress,
+        signerAddress,
+        depositAmountBigint,
+        permitDeadline,
+        signature.v,
+        signature.r,
+        signature.s,
+        txOptions
+      )
+      return tx
+    } catch (error) {
+      throw createError(
+        'PaymentsService',
+        'depositWithPermit',
+        'Failed to execute depositWithPermit on Payments contract.',
+        error
+      )
+    }
+  }
+
+  /**
+   * Deposit funds using ERC-2612 permit and approve an operator in a single transaction
+   * This signs an EIP-712 permit for the USDFC token and calls the Payments contract
+   * function `depositWithPermitAndApproveOperator` which both deposits and sets operator approval.
+   *
+   * @param amount - Amount of USDFC to deposit (in base units)
+   * @param operator - Service/operator address to approve
+   * @param rateAllowance - Max payment rate per epoch operator can set
+   * @param lockupAllowance - Max lockup amount operator can set
+   * @param maxLockupPeriod - Max lockup period in epochs operator can set
+   * @param token - Token identifier (currently only USDFC supported)
+   * @param deadline - Unix timestamp (seconds) when the permit expires. Defaults to now + 1 hour.
+   * @returns Transaction response object
+   */
+  async depositWithPermitAndApproveOperator(
+    amount: TokenAmount,
+    operator: string,
+    rateAllowance: TokenAmount,
+    lockupAllowance: TokenAmount,
+    maxLockupPeriod: TokenAmount,
+    token: TokenIdentifier = TOKENS.USDFC,
+    deadline?: number | bigint
+  ): Promise<ethers.TransactionResponse> {
+    // Only support USDFC for now
+    if (token !== TOKENS.USDFC) {
+      throw createError('PaymentsService', 'depositWithPermitAndApproveOperator', `Unsupported token: ${token}`)
+    }
+
+    const depositAmountBigint = typeof amount === 'bigint' ? amount : BigInt(amount)
+    if (depositAmountBigint <= 0n) {
+      throw createError('PaymentsService', 'depositWithPermitAndApproveOperator', 'Invalid amount')
+    }
+
+    const rateAllowanceBigint = typeof rateAllowance === 'bigint' ? rateAllowance : BigInt(rateAllowance)
+    const lockupAllowanceBigint = typeof lockupAllowance === 'bigint' ? lockupAllowance : BigInt(lockupAllowance)
+    const maxLockupPeriodBigint = typeof maxLockupPeriod === 'bigint' ? maxLockupPeriod : BigInt(maxLockupPeriod)
+    if (rateAllowanceBigint < 0n || lockupAllowanceBigint < 0n || maxLockupPeriodBigint < 0n) {
+      throw createError('PaymentsService', 'depositWithPermitAndApproveOperator', 'Allowance values cannot be negative')
+    }
+
+    const signerAddress = await this._signer.getAddress()
+    const paymentsContract = this._getPaymentsContract()
+
+    // Calculate deadline
+    const permitDeadline: bigint =
+      deadline == null
+        ? BigInt(Math.floor(Date.now() / 1000) + TIMING_CONSTANTS.PERMIT_DEADLINE_DURATION)
+        : BigInt(deadline)
+
+    // Get permit signature (includes balance check, domain, nonce, signing)
+    const signature = await this._getPermitSignature(
+      depositAmountBigint,
+      permitDeadline,
+      'depositWithPermitAndApproveOperator'
+    )
+
+    // Only set explicit nonce if NonceManager is disabled
+    const txOptions: any = {}
+    if (this._disableNonceManager) {
+      const currentNonce = await this._provider.getTransactionCount(signerAddress, 'pending')
+      txOptions.nonce = currentNonce
+    }
+
+    try {
+      const tx = await paymentsContract.depositWithPermitAndApproveOperator(
+        this._usdfcAddress,
+        signerAddress,
+        depositAmountBigint,
+        permitDeadline,
+        signature.v,
+        signature.r,
+        signature.s,
+        operator,
+        rateAllowanceBigint,
+        lockupAllowanceBigint,
+        maxLockupPeriodBigint,
+        txOptions
+      )
+      return tx
+    } catch (error) {
+      throw createError(
+        'PaymentsService',
+        'depositWithPermitAndApproveOperator',
+        'Failed to execute depositWithPermitAndApproveOperator on Payments contract.',
+        error
+      )
+    }
   }
 
   async withdraw(amount: TokenAmount, token: TokenIdentifier = TOKENS.USDFC): Promise<ethers.TransactionResponse> {

--- a/src/test/payments.test.ts
+++ b/src/test/payments.test.ts
@@ -232,6 +232,31 @@ describe('PaymentsService', () => {
       assert.exists(tx.data)
     })
 
+    it('should deposit with permit', async () => {
+      const depositAmount = ethers.parseUnits('10', 18)
+      const tx = await payments.depositWithPermit(depositAmount)
+      assert.exists(tx)
+      assert.exists(tx.hash)
+    })
+
+    it('should deposit with permit and approve operator', async () => {
+      const depositAmount = ethers.parseUnits('10', 18)
+      const operator = '0x394feCa6bCB84502d93c0c5C03c620ba8897e8f4'
+      const rateAllowance = ethers.parseUnits('5', 18)
+      const lockupAllowance = ethers.parseUnits('100', 18)
+      const maxLockupPeriod = 86400n
+
+      const tx = await payments.depositWithPermitAndApproveOperator(
+        depositAmount,
+        operator,
+        rateAllowance,
+        lockupAllowance,
+        maxLockupPeriod
+      )
+      assert.exists(tx)
+      assert.exists(tx.hash)
+    })
+
     it('should withdraw USDFC tokens', async () => {
       const withdrawAmount = ethers.parseUnits('50', 18)
       const tx = await payments.withdraw(withdrawAmount)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,6 +3,7 @@
  */
 
 import { erc20Abi, multicall3Abi } from 'viem'
+import { erc20PermitAbi } from '../abis/erc20-permit.ts'
 import * as abis from '../abis/gen.ts'
 import type { FilecoinNetworkType } from '../types.ts'
 
@@ -30,6 +31,11 @@ export const CONTRACT_ABIS = {
    * ERC20 ABI - minimal interface needed for balance and approval operations
    */
   ERC20: erc20Abi,
+
+  /**
+   * Minimal ERC20Permit ABI - for reading nonces() and version()
+   */
+  ERC20_PERMIT: erc20PermitAbi,
 
   /**
    * Payments contract ABI - based on fws-payments contract
@@ -68,6 +74,19 @@ export const CONTRACT_ABIS = {
    */
   SESSION_KEY_REGISTRY: abis.sessionKeyRegistryAbi,
 } as const
+
+/**
+ * EIP-2612 typed data schema (Permit)
+ */
+export const EIP2612_PERMIT_TYPES: Record<string, { name: string; type: string }[]> = {
+  Permit: [
+    { name: 'owner', type: 'address' },
+    { name: 'spender', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+  ],
+}
 
 /**
  * Time and size constants
@@ -247,6 +266,12 @@ export const TIMING_CONSTANTS = {
    * in the future, or aligned to F3 expectations
    */
   TRANSACTION_CONFIRMATIONS: 1,
+
+  /**
+   * Default expiry time for EIP-2612 permit signatures (in seconds)
+   * Permits are time-limited approvals that expire after this duration
+   */
+  PERMIT_DEADLINE_DURATION: 3600, // 1 hour
 
   /**
    * Maximum time to wait for a piece addition to be confirmed and acknowledged


### PR DESCRIPTION
This pull request introduces support for ERC-2612 permit-based deposits in the payments system, allowing users to approve and deposit USDFC tokens in a single transaction using EIP-712 signatures. It adds new methods to the `PaymentsService` for permit-based deposits, updates contract ABIs and constants to support EIP-2612, and enhances the test suite and mocks to cover the new functionality.

**ERC-2612 Permit Support and Payments Enhancements:**

* Added a minimal `erc20PermitAbi` for reading `nonces` and `version` from ERC-20 permit tokens (`src/abis/erc20-permit.ts`).
* Updated `CONTRACT_ABIS` to include `ERC20_PERMIT`, and introduced `EIP2612_PERMIT_TYPES` for EIP-712 typed data schema, as well as a `PERMIT_DEADLINE_DURATION` constant for permit expiry (`src/utils/constants.ts`). [[1]](diffhunk://#diff-e8d0a358ae2fb090c56f00a058050983cc9691b7d3622ddd443170017123e7d9R6) [[2]](diffhunk://#diff-e8d0a358ae2fb090c56f00a058050983cc9691b7d3622ddd443170017123e7d9R35-R39) [[3]](diffhunk://#diff-e8d0a358ae2fb090c56f00a058050983cc9691b7d3622ddd443170017123e7d9R78-R90) [[4]](diffhunk://#diff-e8d0a358ae2fb090c56f00a058050983cc9691b7d3622ddd443170017123e7d9R270-R275)

**PaymentsService Additions:**

* Implemented `_getPermitSignature` to generate EIP-2612 permit signatures, handling balance checks, domain creation, nonce retrieval, and signature generation using Multicall3 for efficient RPC batching (`src/payments/service.ts`).
* Added `depositWithPermit` and `depositWithPermitAndApproveOperator` methods to allow deposits and operator approvals using ERC-2612 permits in a single transaction, improving UX and reducing on-chain transactions (`src/payments/service.ts`).

**Testing and Mock Improvements:**

* Added tests for `depositWithPermit` and `depositWithPermitAndApproveOperator` to ensure correct behavior and signature handling (`src/test/payments.test.ts`).
* Enhanced the mock signer to return a valid 65-byte signature for typed data, and improved the mock provider to correctly simulate Multicall3 and ERC-2612 permit-related contract calls (`src/test/test-utils.ts`). [[1]](diffhunk://#diff-52ca3d87f7b4175c798ae994c31c30becb980562b847dbf31eec7d808272956fL49-R53) [[2]](diffhunk://#diff-52ca3d87f7b4175c798ae994c31c30becb980562b847dbf31eec7d808272956fL89-R153) [[3]](diffhunk://#diff-52ca3d87f7b4175c798ae994c31c30becb980562b847dbf31eec7d808272956fR173-R194)