### PR TITLE
refactor: normalize use of time&size constants

### DIFF
--- a/src/pdp/auth.ts
+++ b/src/pdp/auth.ts
@@ -305,7 +305,7 @@ export class PDPAuthHelper {
    * const auth = new PDPAuthHelper(contractAddress, signer, chainId)
    * const pieceData = [{
    *   cid: 'bafkzcibc...', // PieceCID of aggregated data
-   *   rawSize: 1024 * 1024     // Raw size in bytes before padding
+   *   rawSize: Number(SIZE_CONSTANTS.MiB)     // Raw size in bytes before padding
    * }]
    * const signature = await auth.signAddPieces(
    *   0,           // Same dataset ID as data set creation

--- a/src/sp-registry/service.ts
+++ b/src/sp-registry/service.ts
@@ -84,8 +84,8 @@ export class SPRegistryService {
    *   description: 'High-performance storage service',
    *   pdpOffering: {
    *     serviceURL: 'https://provider.example.com',
-   *     minPieceSizeInBytes: BigInt(1024),
-   *     maxPieceSizeInBytes: BigInt(1024 * 1024 * 1024),
+   *     minPieceSizeInBytes: SIZE_CONSTANTS.KiB,
+   *     maxPieceSizeInBytes: SIZE_CONSTANTS.GiB,
    *     // ... other PDP fields
    *   },
    *   capabilities: { 'region': 'us-east', 'tier': 'premium' }

--- a/src/subgraph/service.ts
+++ b/src/subgraph/service.ts
@@ -29,6 +29,7 @@ import { fromHex, toHex } from 'multiformats/bytes'
 import { CID } from 'multiformats/cid'
 import { asPieceCID } from '../piece/index.ts'
 import type { PieceCID, ProviderInfo, SubgraphConfig, SubgraphRetrievalService } from '../types.ts'
+import { SIZE_CONSTANTS, TIME_CONSTANTS } from '../utils/constants.ts'
 import { createError } from '../utils/errors.ts'
 import { QUERIES } from './queries.ts'
 
@@ -300,12 +301,12 @@ export class SubgraphService implements SubgraphRetrievalService {
           capabilities: {},
           data: {
             serviceURL,
-            minPieceSizeInBytes: BigInt(1024),
-            maxPieceSizeInBytes: BigInt(1024 * 1024 * 1024),
+            minPieceSizeInBytes: SIZE_CONSTANTS.KiB,
+            maxPieceSizeInBytes: SIZE_CONSTANTS.GiB,
             ipniPiece: false,
             ipniIpfs: false,
             storagePricePerTibPerMonth: BigInt(1000000),
-            minProvingPeriodInEpochs: 2880,
+            minProvingPeriodInEpochs: Number(TIME_CONSTANTS.EPOCHS_PER_DAY),
             location: 'Unknown',
             paymentTokenAddress: '0x0000000000000000000000000000000000000000',
           },

--- a/src/test/mocks/jsonrpc/index.ts
+++ b/src/test/mocks/jsonrpc/index.ts
@@ -9,7 +9,7 @@ import {
   multicall3Abi,
   parseUnits,
 } from 'viem'
-import { CONTRACT_ADDRESSES } from '../../../utils/constants.ts'
+import { CONTRACT_ADDRESSES, TIME_CONSTANTS } from '../../../utils/constants.ts'
 import { paymentsCallHandler } from './payments.ts'
 import { pdpVerifierCallHandler } from './pdp.ts'
 import { serviceProviderRegistryCallHandler } from './service-registry.ts'
@@ -212,7 +212,7 @@ export const presets = {
           pricePerTiBPerMonthNoCDN: parseUnits('2', 18),
           pricePerTiBPerMonthWithCDN: parseUnits('3', 18),
           tokenAddress: ADDRESSES.calibration.usdfcToken,
-          epochsPerMonth: 86400n,
+          epochsPerMonth: TIME_CONSTANTS.EPOCHS_PER_MONTH,
         },
       ],
     },

--- a/src/test/payments.test.ts
+++ b/src/test/payments.test.ts
@@ -7,7 +7,7 @@
 import { assert } from 'chai'
 import { ethers } from 'ethers'
 import { PaymentsService } from '../payments/index.ts'
-import { CONTRACT_ADDRESSES, TOKENS } from '../utils/index.ts'
+import { CONTRACT_ADDRESSES, TIME_CONSTANTS, TOKENS } from '../utils/index.ts'
 import { createMockProvider, createMockSigner, MOCK_ADDRESSES } from './test-utils.ts'
 
 describe('PaymentsService', () => {
@@ -134,7 +134,7 @@ describe('PaymentsService', () => {
         serviceAddress,
         rateAllowance,
         lockupAllowance,
-        86400n // 30 days max lockup period
+        TIME_CONSTANTS.EPOCHS_PER_MONTH // 30 days max lockup period
       )
       assert.exists(tx)
       assert.exists(tx.hash)
@@ -161,7 +161,7 @@ describe('PaymentsService', () => {
 
     it('should throw for unsupported token in service operations', async () => {
       try {
-        await payments.approveService(serviceAddress, 100n, 1000n, 86400n, 'FIL' as any)
+        await payments.approveService(serviceAddress, 100n, 1000n, TIME_CONSTANTS.EPOCHS_PER_MONTH, 'FIL' as any)
         assert.fail('Should have thrown')
       } catch (error: any) {
         assert.include(error.message, 'not supported')

--- a/src/test/sp-registry-service.test.ts
+++ b/src/test/sp-registry-service.test.ts
@@ -3,6 +3,7 @@ import { assert } from 'chai'
 import { ethers } from 'ethers'
 import { SPRegistryService } from '../sp-registry/service.ts'
 import { PRODUCTS } from '../sp-registry/types.ts'
+import { SIZE_CONSTANTS } from '../utils/constants.ts'
 
 describe('SPRegistryService', () => {
   let mockProvider: ethers.Provider
@@ -75,8 +76,8 @@ describe('SPRegistryService', () => {
           return {
             offering: {
               serviceURL: 'https://provider.example.com',
-              minPieceSizeInBytes: BigInt(1024),
-              maxPieceSizeInBytes: BigInt(1024 * 1024 * 1024),
+              minPieceSizeInBytes: SIZE_CONSTANTS.KiB,
+              maxPieceSizeInBytes: SIZE_CONSTANTS.GiB,
               ipniPiece: true,
               ipniIpfs: false,
               storagePricePerTibPerMonth: BigInt(1000000),
@@ -98,7 +99,7 @@ describe('SPRegistryService', () => {
         return {
           serviceURL: 'https://provider.example.com',
           minPieceSizeInBytes: BigInt(1024),
-          maxPieceSizeInBytes: BigInt(1024 * 1024 * 1024),
+          maxPieceSizeInBytes: SIZE_CONSTANTS,
           ipniPiece: true,
           ipniIpfs: false,
           storagePricePerTibPerMonth: BigInt(1000000),
@@ -325,8 +326,8 @@ describe('SPRegistryService', () => {
 
       if (product?.type === 'PDP') {
         assert.equal(product.data.serviceURL, 'https://provider.example.com')
-        assert.equal(product.data.minPieceSizeInBytes, BigInt(1024))
-        assert.equal(product.data.maxPieceSizeInBytes, BigInt(1024 * 1024 * 1024))
+        assert.equal(product.data.minPieceSizeInBytes, SIZE_CONSTANTS.KiB)
+        assert.equal(product.data.maxPieceSizeInBytes, SIZE_CONSTANTS.GiB)
         assert.isTrue(product.data.ipniPiece)
         assert.isFalse(product.data.ipniIpfs)
         assert.equal(product.data.location, 'US-EAST')
@@ -336,8 +337,8 @@ describe('SPRegistryService', () => {
     it('should add new product', async () => {
       const pdpData = {
         serviceURL: 'https://new.example.com',
-        minPieceSizeInBytes: BigInt(1024),
-        maxPieceSizeInBytes: BigInt(1024 * 1024 * 1024),
+        minPieceSizeInBytes: SIZE_CONSTANTS.KiB,
+        maxPieceSizeInBytes: SIZE_CONSTANTS.GiB,
         ipniPiece: true,
         ipniIpfs: false,
         storagePricePerTibPerMonth: BigInt(1000000),
@@ -355,8 +356,8 @@ describe('SPRegistryService', () => {
       // SKIPPED: Mock implementation issue
       const pdpData = {
         serviceURL: 'https://updated.example.com',
-        minPieceSizeInBytes: BigInt(2048),
-        maxPieceSizeInBytes: BigInt(2 * 1024 * 1024 * 1024),
+        minPieceSizeInBytes: SIZE_CONSTANTS.KiB * 2n,
+        maxPieceSizeInBytes: SIZE_CONSTANTS.GiB * 2n,
         ipniPiece: true,
         ipniIpfs: true,
         storagePricePerTibPerMonth: BigInt(2000000),

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -17,7 +17,7 @@
 import { ethers } from 'ethers'
 import type { SPRegistryService } from '../sp-registry/index.ts'
 import type { ProviderInfo } from '../sp-registry/types.ts'
-import { CONTRACT_ABIS, CONTRACT_ADDRESSES } from '../utils/constants.ts'
+import { CONTRACT_ABIS, CONTRACT_ADDRESSES, SIZE_CONSTANTS, TIME_CONSTANTS } from '../utils/constants.ts'
 import { ProviderResolver } from '../utils/provider-resolver.ts'
 import type { WarmStorageService } from '../warm-storage/index.ts'
 
@@ -123,7 +123,7 @@ export function createMockProvider(chainId: number = 314159): ethers.Provider {
         // Return mock pricing data: 2 USDFC per TiB per month, USDFC address, 86400 epochs per month
         const pricePerTiBPerMonth = ethers.parseUnits('2', 18) // 2 USDFC with 18 decimals
         const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration // Mock USDFC address
-        const epochsPerMonth = 86400n
+        const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
         return ethers.AbiCoder.defaultAbiCoder().encode(
           ['uint256', 'address', 'uint256'],
           [pricePerTiBPerMonth, tokenAddress, epochsPerMonth]
@@ -156,7 +156,7 @@ export function createMockProvider(chainId: number = 314159): ethers.Provider {
         const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18) // 2 USDFC per TiB per month
         const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18) // 3 USDFC per TiB per month with CDN
         const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration // USDFC on calibration
-        const epochsPerMonth = 86400n
+        const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
         return ethers.AbiCoder.defaultAbiCoder().encode(
           ['tuple(uint256,uint256,address,uint256)'],
           [[pricePerTiBPerMonthNoCDN, pricePerTiBPerMonthWithCDN, tokenAddress, epochsPerMonth]]
@@ -207,7 +207,7 @@ export function createMockProvider(chainId: number = 314159): ethers.Provider {
           0n, // lockupAllowance
           0n, // rateUsed
           0n, // lockupUsed
-          86400n, // maxLockupPeriod (30 days)
+          TIME_CONSTANTS.EPOCHS_PER_MONTH, // maxLockupPeriod (30 days)
         ])
       }
       // Mock getRailsForPayerAndToken response - function selector: 0x9b85e253
@@ -888,8 +888,8 @@ export function createMockProviderInfo(overrides?: Partial<ProviderInfo>): Provi
         capabilities: {},
         data: {
           serviceURL: 'https://provider.example.com',
-          minPieceSizeInBytes: BigInt(1024),
-          maxPieceSizeInBytes: BigInt(1024 * 1024 * 1024),
+          minPieceSizeInBytes: SIZE_CONSTANTS.KiB,
+          maxPieceSizeInBytes: SIZE_CONSTANTS.GiB,
           ipniPiece: false,
           ipniIpfs: false,
           storagePricePerTibPerMonth: BigInt(1000000),
@@ -921,8 +921,8 @@ export function createSimpleProvider(props: {
         capabilities: {},
         data: {
           serviceURL: props.serviceURL,
-          minPieceSizeInBytes: BigInt(1024),
-          maxPieceSizeInBytes: BigInt(1024 * 1024 * 1024),
+          minPieceSizeInBytes: SIZE_CONSTANTS.KiB,
+          maxPieceSizeInBytes: SIZE_CONSTANTS.GiB,
           ipniPiece: false,
           ipniIpfs: false,
           storagePricePerTibPerMonth: BigInt(1000000),

--- a/src/test/warm-storage-service.test.ts
+++ b/src/test/warm-storage-service.test.ts
@@ -7,7 +7,7 @@
 import { assert } from 'chai'
 import { ethers } from 'ethers'
 import { filecoinWarmStorageServiceAbi, filecoinWarmStorageServiceStateViewAbi } from '../abis/gen.ts'
-import { CONTRACT_ADDRESSES, TIME_CONSTANTS } from '../utils/constants.ts'
+import { CONTRACT_ADDRESSES, SIZE_CONSTANTS, TIME_CONSTANTS } from '../utils/constants.ts'
 import { WarmStorageService } from '../warm-storage/index.ts'
 import { createMockProvider, extendMockProviderCall, MOCK_ADDRESSES } from './test-utils.ts'
 
@@ -1073,7 +1073,7 @@ describe('WarmStorageService', () => {
             const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18)
             const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18)
             const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration
-            const epochsPerMonth = 86400n
+            const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
             // Encode as a tuple (struct)
             const servicePriceInfo = {
               pricePerTiBPerMonthNoCDN: pricePerTiBPerMonthNoCDN,
@@ -1086,7 +1086,7 @@ describe('WarmStorageService', () => {
           return `0x${'0'.repeat(64)}`
         }
 
-        const sizeInBytes = 1024 * 1024 * 1024 // 1 GiB
+        const sizeInBytes = Number(SIZE_CONSTANTS.GiB) // 1 GiB
         const costs = await warmStorageService.calculateStorageCost(sizeInBytes)
 
         assert.exists(costs.perEpoch)
@@ -1125,7 +1125,7 @@ describe('WarmStorageService', () => {
             const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18)
             const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18)
             const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration
-            const epochsPerMonth = 86400n
+            const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
             const servicePriceInfo = {
               pricePerTiBPerMonthNoCDN: pricePerTiBPerMonthNoCDN,
               pricePerTiBPerMonthWithCDN: pricePerTiBPerMonthWithCDN,
@@ -1137,8 +1137,8 @@ describe('WarmStorageService', () => {
           return `0x${'0'.repeat(64)}`
         }
 
-        const costs1GiB = await warmStorageService.calculateStorageCost(1024 * 1024 * 1024)
-        const costs10GiB = await warmStorageService.calculateStorageCost(10 * 1024 * 1024 * 1024)
+        const costs1GiB = await warmStorageService.calculateStorageCost(Number(SIZE_CONSTANTS.GiB))
+        const costs10GiB = await warmStorageService.calculateStorageCost(Number(10n * SIZE_CONSTANTS.GiB))
 
         // 10 GiB should cost approximately 10x more than 1 GiB
         // Allow for small rounding differences in bigint division
@@ -1148,7 +1148,7 @@ describe('WarmStorageService', () => {
         // Verify the relationship holds for day and month calculations
         assert.equal(costs10GiB.perDay.toString(), (costs10GiB.perEpoch * 2880n).toString())
         // For month calculation, allow for rounding errors due to integer division
-        const expectedMonth = costs10GiB.perEpoch * 86400n
+        const expectedMonth = costs10GiB.perEpoch * TIME_CONSTANTS.EPOCHS_PER_MONTH
         const monthRatio = Number(costs10GiB.perMonth) / Number(expectedMonth)
         assert.closeTo(monthRatio, 1, 0.0001) // Allow 0.01% difference due to rounding
       })
@@ -1170,7 +1170,7 @@ describe('WarmStorageService', () => {
             const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18)
             const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18)
             const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration
-            const epochsPerMonth = 86400n
+            const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
             // Encode as a tuple (struct)
             const servicePriceInfo = {
               pricePerTiBPerMonthNoCDN: pricePerTiBPerMonthNoCDN,
@@ -1183,7 +1183,7 @@ describe('WarmStorageService', () => {
           return await originalCall.call(mockProvider, transaction)
         }
 
-        await warmStorageService.calculateStorageCost(1024 * 1024 * 1024)
+        await warmStorageService.calculateStorageCost(Number(SIZE_CONSTANTS.GiB))
         assert.isTrue(getServicePriceCalled, 'Should have called getServicePrice on WarmStorage contract')
       })
     })
@@ -1217,7 +1217,7 @@ describe('WarmStorageService', () => {
             const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18)
             const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18)
             const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration
-            const epochsPerMonth = 86400n
+            const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
             const servicePriceInfo = {
               pricePerTiBPerMonthNoCDN: pricePerTiBPerMonthNoCDN,
               pricePerTiBPerMonthWithCDN: pricePerTiBPerMonthWithCDN,
@@ -1230,7 +1230,7 @@ describe('WarmStorageService', () => {
         }
 
         const check = await warmStorageService.checkAllowanceForStorage(
-          10 * 1024 * 1024 * 1024, // 10 GiB
+          Number(10n * SIZE_CONSTANTS.GiB), // 10 GiB
           false,
           mockPaymentsService
         )
@@ -1288,7 +1288,7 @@ describe('WarmStorageService', () => {
             const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18)
             const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18)
             const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration
-            const epochsPerMonth = 86400n
+            const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
             const servicePriceInfo = {
               pricePerTiBPerMonthNoCDN: pricePerTiBPerMonthNoCDN,
               pricePerTiBPerMonthWithCDN: pricePerTiBPerMonthWithCDN,
@@ -1301,7 +1301,7 @@ describe('WarmStorageService', () => {
         }
 
         const check = await warmStorageService.checkAllowanceForStorage(
-          1024 * 1024, // 1 MiB - small amount
+          Number(SIZE_CONSTANTS.MiB), // 1 MiB - small amount
           false,
           mockPaymentsService
         )
@@ -1347,7 +1347,7 @@ describe('WarmStorageService', () => {
             const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18)
             const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18)
             const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration
-            const epochsPerMonth = 86400n
+            const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
             const servicePriceInfo = {
               pricePerTiBPerMonthNoCDN: pricePerTiBPerMonthNoCDN,
               pricePerTiBPerMonthWithCDN: pricePerTiBPerMonthWithCDN,
@@ -1360,7 +1360,7 @@ describe('WarmStorageService', () => {
         }
 
         const check = await warmStorageService.checkAllowanceForStorage(
-          1024 * 1024 * 1024, // 1 GiB
+          Number(SIZE_CONSTANTS.GiB), // 1 GiB
           false,
           mockPaymentsService
         )
@@ -1404,7 +1404,7 @@ describe('WarmStorageService', () => {
             const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18)
             const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18)
             const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration
-            const epochsPerMonth = 86400n
+            const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
             const servicePriceInfo = {
               pricePerTiBPerMonthNoCDN: pricePerTiBPerMonthNoCDN,
               pricePerTiBPerMonthWithCDN: pricePerTiBPerMonthWithCDN,
@@ -1419,7 +1419,7 @@ describe('WarmStorageService', () => {
         // Test with custom lockup period of 20 days
         const customLockupDays = 20
         const check = await warmStorageService.checkAllowanceForStorage(
-          1024 * 1024 * 1024, // 1 GiB
+          Number(SIZE_CONSTANTS.GiB), // 1 GiB
           false,
           mockPaymentsService,
           customLockupDays
@@ -1431,7 +1431,7 @@ describe('WarmStorageService', () => {
 
         // Compare with default (10 days) to ensure they're different
         const defaultCheck = await warmStorageService.checkAllowanceForStorage(
-          1024 * 1024 * 1024, // 1 GiB
+          Number(SIZE_CONSTANTS.GiB), // 1 GiB
           false,
           mockPaymentsService
         )
@@ -1483,7 +1483,7 @@ describe('WarmStorageService', () => {
             const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18)
             const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18)
             const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration
-            const epochsPerMonth = 86400n
+            const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
             const servicePriceInfo = {
               pricePerTiBPerMonthNoCDN: pricePerTiBPerMonthNoCDN,
               pricePerTiBPerMonthWithCDN: pricePerTiBPerMonthWithCDN,
@@ -1497,7 +1497,7 @@ describe('WarmStorageService', () => {
 
         const prep = await warmStorageService.prepareStorageUpload(
           {
-            dataSize: 10 * 1024 * 1024 * 1024, // 10 GiB
+            dataSize: Number(10n * SIZE_CONSTANTS.GiB), // 10 GiB
             withCDN: false,
           },
           mockPaymentsService
@@ -1563,7 +1563,7 @@ describe('WarmStorageService', () => {
             const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18)
             const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18)
             const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration
-            const epochsPerMonth = 86400n
+            const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
             const servicePriceInfo = {
               pricePerTiBPerMonthNoCDN: pricePerTiBPerMonthNoCDN,
               pricePerTiBPerMonthWithCDN: pricePerTiBPerMonthWithCDN,
@@ -1577,7 +1577,7 @@ describe('WarmStorageService', () => {
 
         const prep = await warmStorageService.prepareStorageUpload(
           {
-            dataSize: 10 * 1024 * 1024 * 1024, // 10 GiB
+            dataSize: Number(10n * SIZE_CONSTANTS.GiB), // 10 GiB
             withCDN: false,
           },
           mockPaymentsService
@@ -1631,7 +1631,7 @@ describe('WarmStorageService', () => {
             const pricePerTiBPerMonthNoCDN = ethers.parseUnits('2', 18)
             const pricePerTiBPerMonthWithCDN = ethers.parseUnits('3', 18)
             const tokenAddress = CONTRACT_ADDRESSES.USDFC.calibration
-            const epochsPerMonth = 86400n
+            const epochsPerMonth = TIME_CONSTANTS.EPOCHS_PER_MONTH
             const servicePriceInfo = {
               pricePerTiBPerMonthNoCDN: pricePerTiBPerMonthNoCDN,
               pricePerTiBPerMonthWithCDN: pricePerTiBPerMonthWithCDN,
@@ -1645,7 +1645,7 @@ describe('WarmStorageService', () => {
 
         const prep = await warmStorageService.prepareStorageUpload(
           {
-            dataSize: 1024 * 1024, // 1 MiB - small amount
+            dataSize: Number(SIZE_CONSTANTS.MiB), // 1 MiB - small amount
             withCDN: false,
           },
           mockPaymentsService

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -125,17 +125,22 @@ export const SIZE_CONSTANTS = {
   /**
    * Bytes in 1 MiB
    */
-  MiB: 1024n * 1024n,
+  MiB: 1n << 20n,
 
   /**
    * Bytes in 1 GiB
    */
-  GiB: 1024n * 1024n * 1024n,
+  GiB: 1n << 30n,
 
   /**
    * Bytes in 1 TiB
    */
-  TiB: 1024n * 1024n * 1024n * 1024n,
+  TiB: 1n << 40n,
+
+  /**
+   * Bytes in 1 PiB
+   */
+  PiB: 1n << 50n,
 
   /**
    * Maximum upload size (200 MiB)

--- a/src/warm-storage/service.ts
+++ b/src/warm-storage/service.ts
@@ -903,7 +903,7 @@ export class WarmStorageService {
    * @example
    * ```typescript
    * const prep = await warmStorageService.prepareStorageUpload(
-   *   { dataSize: 1024 * 1024 * 1024, withCDN: true },
+   *   { dataSize: Number(SIZE_CONSTANTS.GiB), withCDN: true },
    *   paymentsService
    * )
    *
@@ -975,7 +975,7 @@ export class WarmStorageService {
             this._warmStorageAddress,
             allowanceCheck.rateAllowanceNeeded,
             allowanceCheck.lockupAllowanceNeeded,
-            86400n, // 30 days max lockup period
+            TIME_CONSTANTS.EPOCHS_PER_MONTH, // 30 days max lockup period
             TOKENS.USDFC
           ),
       })

--- a/utils/benchmark.js
+++ b/utils/benchmark.js
@@ -6,7 +6,7 @@ import { Synapse } from '../dist/synapse.js'
 const PRIVATE_KEY = process.env.PRIVATE_KEY
 const RPC_URL = process.env.RPC_URL || 'https://api.calibration.node.glif.io/rpc/v1'
 const PROVIDER_ADDRESS = process.env.PROVIDER_ADDRESS
-const PIECE_SIZE = 100 * 1024 * 1024 // 100 MiB
+const PIECE_SIZE = Number(100n * SIZE_CONSTANTS.MiB) // 100 MiB
 const NUM_RUNS = 4
 const PANDORA_ADDRESS = process.env.PANDORA_ADDRESS
 
@@ -70,7 +70,7 @@ async function generateRandomData(size) {
 async function runBenchmark() {
   console.log('Starting Synapse SDK Benchmark')
   console.log(`Provider: ${PROVIDER_ADDRESS}`)
-  console.log(`Piece size: ${PIECE_SIZE / (1024 * 1024)} MiB`)
+  console.log(`Piece size: ${PIECE_SIZE / Number(SIZE_CONSTANTS.MiB)} MiB`)
   console.log(`Number of runs: ${NUM_RUNS}`)
   console.log('')
 

--- a/utils/example-storage-e2e.js
+++ b/utils/example-storage-e2e.js
@@ -65,7 +65,7 @@ async function main() {
     console.log(`File size: ${formatBytes(fileData.length)}`)
 
     // Check size limit (200 MiB)
-    const MAX_SIZE = 200 * 1024 * 1024
+    const MAX_SIZE = SIZE_CONSTANTS.MAX_UPLOAD_SIZE
     if (fileData.length > MAX_SIZE) {
       throw new Error(`File size exceeds maximum allowed size of ${formatBytes(MAX_SIZE)}`)
     }

--- a/utils/post-deploy-setup.js
+++ b/utils/post-deploy-setup.js
@@ -101,7 +101,7 @@ import { WarmStorageService } from '../dist/warm-storage/service.js'
 // Constants for payment approvals
 const RATE_ALLOWANCE_PER_EPOCH = ethers.parseUnits('0.1', 18) // 0.1 USDFC per epoch
 const LOCKUP_ALLOWANCE = ethers.parseUnits('10', 18) // 10 USDFC lockup allowance
-const MAX_LOCKUP_PERIOD = 86400n // 30 days in epochs (30 * 2880 epochs/day)
+const MAX_LOCKUP_PERIOD = TIME_CONSTANTS.EPOCHS_PER_MONTH // 30 days in epochs (30 * 2880 epochs/day)
 const INITIAL_DEPOSIT_AMOUNT = ethers.parseUnits('1', 18) // 1 USDFC initial deposit
 
 // Default PDP configuration values


### PR DESCRIPTION
Noticed the sizes were 1024n * 1024n when looking at synapse code while working on filecoin pin, and that there repeated multiplications and magic numbers in the codebase.

This PR reduces magic number usage, preventing future devs from making size mistakes, makes code more self-documenting (no more need to add comment of expected size if named constant is used), and also updates SIZE_CONSTANTS to use bit-shifts for byte-sizes instead of multiplication.
