### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 Check the documentation [website](https://synapse.filecoin.services/)
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/FilOzone/synapse-sdk)
+
 ## Examples
 
 The `examples` folder has many examples on how to start using Synapse in different environments and frameworks.


### PR DESCRIPTION
Added badge for DeepWiki to README for auto deepwiki refreshes as we constantly upgrade the repository.