### PR TITLE
feat: add createDataSetWithPieces method for combined dataset creation and piece addition

### DIFF
--- a/packages/synapse-sdk/src/pdp/index.ts
+++ b/packages/synapse-sdk/src/pdp/index.ts
@@ -13,6 +13,7 @@ export { PDPAuthHelper } from './auth.ts'
 export type {
   AddPiecesResponse,
   CreateDataSetResponse,
+  CreateDataSetWithPiecesResponse,
   DataSetCreationStatusResponse,
   FindPieceResponse,
   PieceAdditionStatusResponse,


### PR DESCRIPTION
- Introduced `createDataSetWithPieces` method in `PDPServer` to allow creating a new data set with pieces in a single operation.
- Added corresponding type `CreateDataSetWithPiecesResponse` for the new response structure.
- Implemented `uploadAndCreate` method in `StorageContext` and `StorageManager` to streamline data upload and dataset creation.
- Enhanced tests to cover scenarios for successful dataset creation with and without pieces, including validation for piece metadata and CID.

Ref https://github.com/filecoin-project/curio/issues/678
Curio PR: https://github.com/filecoin-project/curio/pull/687