### PR TITLE
fix: Use clientAddress for next dataset ID

### DIFF
--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -247,12 +247,12 @@ export class StorageContext {
     performance.mark('synapse:createDataSet-start')
 
     const signer = synapse.getSigner()
-    const [signerAddress, clientAddress] = await Promise.all([signer.getAddress(), synapse.getClient().getAddress()])
+    const clientAddress = await synapse.getClient().getAddress()
 
     // Create a new data set
 
     // Get next client dataset ID
-    const nextDatasetId = await warmStorageService.getNextClientDataSetId(signerAddress)
+    const nextDatasetId = await warmStorageService.getNextClientDataSetId(clientAddress)
 
     // Create auth helper for signing
     const warmStorageAddress = synapse.getWarmStorageAddress()


### PR DESCRIPTION
This pull request makes a targeted fix in the `StorageContext` class to ensure the correct address is used when creating a new dataset. Specifically, it changes the logic to consistently use the `clientAddress` instead of the `signerAddress` when retrieving the next client dataset ID. This helps prevent potential mismatches or errors related to address usage.

- Address usage correction:
  * Updated the call to `warmStorageService.getNextClientDataSetId` to use `clientAddress` instead of `signerAddress` in the `StorageContext` class, ensuring consistency and correctness in dataset ID assignment.