### PR TITLE
fix: use providerId or providerAddress if provided with forceCreateDataSet

### DIFF
--- a/docs/src/custom.css
+++ b/docs/src/custom.css
@@ -1,25 +1,25 @@
 .filoz {
-    flex: auto;
-    align-items: center;
-    justify-content: center;
-    display: flex;
-    flex-direction: row;
-    gap: 0.5rem;
+  flex: auto;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
 }
 .filoz svg {
-    margin: 0;
+  margin: 0;
 }
 
-.footer{
-    margin-top: 3rem;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    display: flex;
-    gap: 0.5rem;
+.footer {
+  margin-top: 3rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  display: flex;
+  gap: 0.5rem;
 }
 .footer p {
-    margin: 0;
-    font-size: 0.8rem;
-    color: #666;
+  margin: 0;
+  font-size: 0.8rem;
+  color: #666;
 }


### PR DESCRIPTION
Minor regression in #309, I want to be able to provide either `providerId` or `providerAddress` and them work with `forceCreateDataSet`, they shouldn't be mutually exclusive.