### PR TITLE
feat: deposit to any address

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ This document serves as context for LLM agent sessions working with the Synapse 
 ### Key Components
 
 - `Synapse`: Main SDK entry; minimal interface with `payments` property and `storage` manager; strict network validation (mainnet/calibration).
-- `PaymentsService`: Payment operations - deposits, withdrawals, balances, service approvals.
+- `PaymentsService`: Payment operations - deposits, withdrawals, balances, service approvals. The `deposit()` method accepts an optional `DepositOptions` object with `to` property to deposit funds to a different address than the signer, plus callback functions for visibility.
 - `SPRegistryService`: Service provider registry - registration, updates, product management, provider discovery.
 - `WarmStorageService`: Storage coordination - costs, allowances, data sets. Factory method `WarmStorageService.create(provider, address)`. Source of all contract addresses via discovery.
 - `StorageManager/StorageContext`: Storage operations with auto-managed or explicit contexts.
@@ -208,6 +208,7 @@ WarmStorageService (storage coordination)
 - Manages payment rails between parties
 - Supports operator approvals for account management
 - Address discovered from WarmStorage
+- **Deposit Flexibility**: The `deposit(token, to, amount)` function allows depositing to any address, not just the signer. SDK's `PaymentsService.deposit()` exposes this via `DepositOptions` object with optional `to` property.
 
 #### 5. Curio Storage Provider (Service Node)
 

--- a/docs/src/content/docs/intro/components.mdx
+++ b/docs/src/content/docs/intro/components.mdx
@@ -22,6 +22,10 @@ const depositTx = await paymentsService.deposit(amount) // amount in base units
 console.log(`Deposit transaction: ${depositTx.hash}`)
 await depositTx.wait() // Wait for confirmation
 
+// Optional: Deposit to a different address
+const recipientAddress = '0x1234...'
+await paymentsService.deposit(amount, TOKENS.USDFC, { to: recipientAddress })
+
 // Check account info
 const info = await paymentsService.accountInfo() // Uses USDFC by default
 console.log('Available funds:', info.availableFunds)

--- a/docs/src/content/docs/intro/getting-started.mdx
+++ b/docs/src/content/docs/intro/getting-started.mdx
@@ -170,6 +170,10 @@ const depositTx = await synapse.payments.deposit(requiredAmount, TOKENS.USDFC, {
 console.log(`Deposit transaction: ${depositTx.hash}`)
 await depositTx.wait()
 
+// Optional: Deposit to a different address (e.g., for a service or another user)
+const recipientAddress = '0x1234...'
+await synapse.payments.deposit(amount, TOKENS.USDFC, { to: recipientAddress })
+
 // Service operator approvals (required before creating data sets)
 const warmStorageAddress = await synapse.getWarmStorageAddress()
 
@@ -377,7 +381,7 @@ await synapse.storage.download(pieceCid, { context: storageContext })
 
 **Token Operations:**
 
-- `deposit(amount, token?, callbacks?)` - Deposit funds to payments contract (handles approval automatically), returns `TransactionResponse`
+- `deposit(amount, token?, options?)` - Deposit funds to payments contract (handles approval automatically). Options include `to` (recipient address), and callbacks for visibility. Returns `TransactionResponse`
 - `withdraw(amount, token?)` - Withdraw funds from payments contract, returns `TransactionResponse`
 - `approve(spender, amount, token?)` - Approve token spending (for manual control), returns `TransactionResponse`
 - `allowance(spender, token?)` - Check current token allowance

--- a/packages/synapse-sdk/src/payments/index.ts
+++ b/packages/synapse-sdk/src/payments/index.ts
@@ -1,5 +1,5 @@
 /**
- * Exports the PaymentsService and DepositCallbacks types
+ * Exports the PaymentsService and DepositOptions types
  *
  * @module Payments
  * @example
@@ -8,5 +8,5 @@
  * ```
  */
 
-export type { DepositCallbacks } from './service.ts'
+export type { DepositOptions } from './service.ts'
 export { PaymentsService } from './service.ts'


### PR DESCRIPTION
This pull request adds support for depositing funds to a different recipient address using the `PaymentsService.deposit()` method, and updates related documentation and type definitions to reflect this new flexibility. The change replaces the previous `DepositCallbacks` parameter with a more general `DepositOptions` object, which now includes an optional `to` property for specifying the recipient address, as well as callback functions for transaction visibility.

**SDK API enhancements:**

* The `PaymentsService.deposit()` method now accepts an optional `DepositOptions` object, which includes an optional `to` property to specify a recipient address other than the signer. This replaces the previous `DepositCallbacks` parameter. [[1]](diffhunk://#diff-295e3bf6a9ceaf5092588db43bd925bc9ce2d8a02262c11f6cba7dbaecad50b6L606-R608) [[2]](diffhunk://#diff-295e3bf6a9ceaf5092588db43bd925bc9ce2d8a02262c11f6cba7dbaecad50b6L22-R26) [[3]](diffhunk://#diff-8f0930977d7e061a4c5737f596245fa7502178779699d9fa919910e3c276fc1cL2-R2) [[4]](diffhunk://#diff-8f0930977d7e061a4c5737f596245fa7502178779699d9fa919910e3c276fc1cL11-R11)
* The deposit transaction now uses the address provided in `options.to` (if present) as the recipient; otherwise, it defaults to the signer's address. [[1]](diffhunk://#diff-295e3bf6a9ceaf5092588db43bd925bc9ce2d8a02262c11f6cba7dbaecad50b6R621) [[2]](diffhunk://#diff-295e3bf6a9ceaf5092588db43bd925bc9ce2d8a02262c11f6cba7dbaecad50b6L661-R664)
* All deposit operation callbacks are now accessed through the `DepositOptions` object.

**Documentation updates:**

* The documentation and code examples in `AGENTS.md`, `getting-started.mdx`, and `components.mdx` have been updated to describe and demonstrate the new `to` option for deposits, including sample usage for depositing to another address. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L20-R20) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R211) [[3]](diffhunk://#diff-c94cc37d907ce4c63e716de33e64f0319937e83fbd6ce0ac471e2c58b691b80bR173-R176) [[4]](diffhunk://#diff-c627cf6cc7f69732e42b9d6151505d03e5d8020c6d646ada96bec5d37e4d3ea2R25-R28) [[5]](diffhunk://#diff-c94cc37d907ce4c63e716de33e64f0319937e83fbd6ce0ac471e2c58b691b80bL380-R384)