### PR TITLE
excludeProviderIds

### DIFF
--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -488,6 +488,7 @@ export class StorageContext {
       requestedMetadata,
       warmStorageService,
       providerResolver,
+      options.excludeProviderIds,
       options.forceCreateDataSet,
       options.withIpni,
       options.dev
@@ -704,6 +705,7 @@ export class StorageContext {
     requestedMetadata: Record<string, string>,
     warmStorageService: WarmStorageService,
     providerResolver: ProviderResolver,
+    excludeProviderIds?: number[],
     forceCreateDataSet?: boolean,
     withIpni?: boolean,
     dev?: boolean
@@ -730,7 +732,7 @@ export class StorageContext {
 
       // Create async generator that yields providers lazily
       async function* generateProviders(): AsyncGenerator<ProviderInfo> {
-        const yieldedProviders = new Set<string>()
+        const skipProviderIds = new Set<number>(excludeProviderIds)
 
         // First, yield providers from existing data sets (in sorted order)
         for (const dataSet of sorted) {
@@ -742,8 +744,8 @@ export class StorageContext {
             )
             continue
           }
-          if (!yieldedProviders.has(provider.serviceProvider.toLowerCase())) {
-            yieldedProviders.add(provider.serviceProvider.toLowerCase())
+          if (!skipProviderIds.has(provider.id)) {
+            skipProviderIds.add(provider.id)
             yield provider
           }
         }
@@ -783,7 +785,9 @@ export class StorageContext {
     }
 
     // No existing data sets - select from all approved providers
-    const allProviders = await providerResolver.getApprovedProviders()
+    const allProviders = (await providerResolver.getApprovedProviders()).filter(
+      (provider: ProviderInfo) => excludeProviderIds?.includes(provider.id) !== true
+    )
 
     if (allProviders.length === 0) {
       throw createError('StorageContext', 'smartSelectProvider', 'No approved service providers available')

--- a/packages/synapse-sdk/src/storage/manager.ts
+++ b/packages/synapse-sdk/src/storage/manager.ts
@@ -252,7 +252,10 @@ export class StorageManager {
 
     if (canUseDefault) {
       // Check if we have a default context with compatible metadata
-      if (this._defaultContext != null) {
+      if (
+        this._defaultContext != null &&
+        options?.excludeProviderIds?.includes(this._defaultContext.provider.id) !== true
+      ) {
         // Combine the current request metadata with effective withCDN setting
         const requestedMetadata = combineMetadata(options?.metadata, effectiveWithCDN)
 

--- a/packages/synapse-sdk/src/types.ts
+++ b/packages/synapse-sdk/src/types.ts
@@ -333,6 +333,8 @@ export interface StorageCreationCallbacks {
 export interface StorageServiceOptions {
   /** Specific provider ID to use (optional) */
   providerId?: number
+  /** Do not select any of these providers */
+  excludeProviderIds?: number[]
   /** Specific provider address to use (optional) */
   providerAddress?: string
   /** Specific data set ID to use (optional) */


### PR DESCRIPTION

Reviewer @rvagg
#### Context
https://github.com/FilOzone/synapse-sdk/issues/282 / https://github.com/FilOzone/synapse-sdk/issues/312
#### Changes
* StorageServiceOptions.excludeProviderIds
* check if the default provider Id is excluded
* skipProviderIds in generator selectProviderWithPing 
* filter allProviders before generator in selectRandomProvider 