### PR TITLE
fix: getPDPService always returns a pdpOffering

### DIFF
--- a/packages/synapse-sdk/src/test/sp-registry-service.test.ts
+++ b/packages/synapse-sdk/src/test/sp-registry-service.test.ts
@@ -55,19 +55,6 @@ describe('SPRegistryService', () => {
         }
         throw new Error('Provider not found')
       },
-      getProviderProducts: async (id: number) => {
-        if (id === 1) {
-          return [
-            {
-              productType: 0, // PDP
-              isActive: true,
-              capabilityKeys: [],
-              productData: '0x', // Encoded PDP offering
-            },
-          ]
-        }
-        return []
-      },
       providerHasProduct: async (id: number, productType: number) => {
         return id === 1 && productType === 0
       },

--- a/packages/synapse-sdk/src/test/test-utils.ts
+++ b/packages/synapse-sdk/src/test/test-utils.ts
@@ -806,47 +806,6 @@ export function setupProviderRegistryMocks(
       )
     }
 
-    // Mock getProviderProducts(uint256) - returns products for provider
-    if (data?.startsWith('0xb5eb46e1')) {
-      const providerId = parseInt(data.slice(10, 74), 16)
-      const provider = providers.find((p) => p.id === providerId)
-      if (provider?.products?.PDP) {
-        const pdp = provider.products.PDP
-
-        // Encode PDP product data (simplified for testing)
-        const encodedPDP = ethers.AbiCoder.defaultAbiCoder().encode(
-          ['string', 'uint256', 'uint256', 'bool', 'bool', 'uint256', 'uint256', 'string', 'address'],
-          [
-            pdp.data.serviceURL,
-            pdp.data.minPieceSizeInBytes,
-            pdp.data.maxPieceSizeInBytes,
-            pdp.data.ipniPiece,
-            pdp.data.ipniIpfs,
-            pdp.data.storagePricePerTibPerMonth,
-            pdp.data.minProvingPeriodInEpochs,
-            pdp.data.location || '',
-            pdp.data.paymentTokenAddress,
-          ]
-        )
-
-        return ethers.AbiCoder.defaultAbiCoder().encode(
-          ['tuple(uint8,bool,bytes32[],bytes)[]'],
-          [
-            [
-              [
-                0, // productType: PDP
-                pdp.isActive,
-                pdp.capabilities ?? [], // capabilityKeys (empty for simplicity)
-                encodedPDP,
-              ],
-            ],
-          ]
-        )
-      }
-      // Return empty products array
-      return ethers.AbiCoder.defaultAbiCoder().encode(['tuple(uint8,bool,bytes32[],bytes)[]'], [[]])
-    }
-
     // Mock decodePDPOffering(bytes) - decode PDP product data
     if (data?.startsWith('0xdeb0e462')) {
       // For simplicity, return a default PDP offering


### PR DESCRIPTION
Reviewer @rvagg
See also https://github.com/FilOzone/filecoin-services/pull/295
Neither of these issues were caught before because we currently catch all exceptions in SPRegistryService.getPDPService, a bad policy.
I don't remove the catch-all because there are more problems after this; for example, `'should select a random provider when no providerId specified'` will fail when trying to create the data set.
#### Changes
* fix mock contract return typing
* fix outdated mocking for test that was only working because of the type error