### PR TITLE
docs(ci): enable localStorage in Node.js 25 to avoid build error

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -21,3 +21,6 @@ pnpm-debug.log*
 .DS_Store
 src/content/docs/api
 .wrangler/
+
+# Node.js v25 localStorage file
+.astro-localstorage.json

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "NODE_OPTIONS=\"--localstorage-file=.astro-localstorage.json\" astro build",
     "preview": "astro preview",
     "astro": "astro"
   },


### PR DESCRIPTION
Node.js 25 became "current" and our CI is now testing it. We now have a failure because "localStorage" is now a thing in Node.js but it's not properly enabled without the arg. So @typescript/vfs, which in the browser detects a "localStorage" and tries to use it (but previously in Node.js wouldn't find it so wouldn't try) finds an implementation that's incomplete.

This change activates it, so we don't get the error. But we don't really need it, so this can be wound back when we have a fix in vfs or somewhere else in the stack.

Ref: https://github.com/nodejs/node/pull/57666
Ref: https://github.com/microsoft/TypeScript-Website/issues/3449
Ref: https://github.com/microsoft/TypeScript-Website/pull/3450