### PR TITLE
fix(mocks): mock BatchJsonrpc errors with their request `id`

### DIFF
--- a/packages/synapse-sdk/src/test/mocks/jsonrpc/index.ts
+++ b/packages/synapse-sdk/src/test/mocks/jsonrpc/index.ts
@@ -1,4 +1,3 @@
-import { AbiCoder } from 'ethers'
 import { HttpResponse, http } from 'msw'
 import type { RequiredDeep } from 'type-fest'
 import {
@@ -68,7 +67,7 @@ function jsonrpcHandler(item: RpcRequest, options?: JSONRPCOptions): RpcResponse
             : 'Unknown error',
         data:
           error instanceof Error
-            ? `0x08c379a0${AbiCoder.defaultAbiCoder().encode(['string'], [error.message]).slice(2)}`
+            ? `0x08c379a0${encodeAbiParameters([{ type: 'string' }], [error.message]).slice(2)}`
             : '0x',
       },
       id: id ?? 1,


### PR DESCRIPTION
Reviewer @rvagg @hugomrdias
The previous batch jsonrpc mocking would not have the matching id for the failed request's response.
#### Context
This would cause this jsonrpc error in my testing:
```
     Error: missing response for request (value=[ { "error": { "code": -32000, "data": "0x08c379a00x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001750726f766964657220646f6573206e6f74206578697374000000000000000000", "message": "Provider does not exist" }, "id": 1, "jsonrpc": "2.0" } ], info={ "payload": { "id": 10, "jsonrpc": "2.0", "method": "eth_call", "params": [ { "data": "0x5c42d0790000000000000000000000000000000000000000000000000000000000000003", "to": "0x0000000000000000000000000000000000000001" }, "latest" ] } }, code=BAD_DATA, version=6.15.0)
```
The error is because the response `value=` does not have a matching `id` (10), because of this issue with our batch jsonrpc mocking.

#### Fix
I mock so that the error will be similar to an actual contract error from calibnet lotus.
Individual:
```
{
  "error": {
    "code": 11,
    "message": "message execution failed (exit=[33], revert reason=[message failed with backtrace:\n00: f0176092 (method 3844450837) -- contract reverted at 75 (33)\n01: f0176092 (method 6) -- contract reverted at 15151 (33)\n (RetCode=33)], vm error=[Error(Provider does not exist)])",
    "data": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001750726f766964657220646f6573206e6f74206578697374000000000000000000"
  },
  "id": 14,
  "jsonrpc": "2.0"
}
```
Batched:
```
[
  {
    "error": {
      "code": 11,
      "message": "message execution failed (exit=[33], revert reason=[message failed with backtrace:\n00: f0176092 (method 3844450837) -- contract reverted at 75 (33)\n01: f0176092 (method 6) -- contract reverted at 15151 (33)\n (RetCode=33)], vm error=[Error(Provider does not exist)])",
      "data": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001750726f766964657220646f6573206e6f74206578697374000000000000000000"
    },
    "id": 14,
    "jsonrpc": "2.0"
  }
]
```
#### Changes
* mock batch jsonrpc 