### PR TITLE
ci: configure release-please workflow to use trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
       - master
 
 permissions:
+  id-token: write  # Required for OIDC
   contents: write
   issues: write
   pull-requests: write
@@ -41,13 +42,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          registry-url: "https://registry.npmjs.org"
+          registry-url: "https://registry.npmjs.org"     
+      # Ensure npm 11.5.1 or later is installed
+      - run: npm install -g npm@latest
       - run: pnpm install
       - run: pnpm run lint
       - run: pnpm run build
       - run: pnpm -r --filter './packages/**' publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
   docs:
     needs: release
     if: |


### PR DESCRIPTION
This PR configures the release-please workflow to use trusted publishing. It is needed because NPM classic tokens (presumably used in this repository currently) are going to be deprecated in November.

Before this PR can be merged, package maintainer should configure trusted publishing on npmjs.org.

After this PR is merged, we can delete the NPM_TOKEN secret from the repository secrets.

#### How to configure trusted publishing on npmjs.org?

1. Go to https://www.npmjs.com/package/@filoz/synapse-core/access
1. Click on the GitHub Actions button in the Trusted Publishing section
1. Fill out the form with the following details:
    - Organization: `FilOzone`
    - Repository: `synapse-sdk`
    - Workflow: `release-please.yml`
1. Go to https://www.npmjs.com/package/@filoz/synapse-sdk/access
1. Click on the GitHub Actions button in the Trusted Publishing section
1. Fill out the form with the following details:
    - Organization: `FilOzone`
    - Repository: `synapse-sdk`
    - Workflow: `release-please.yml`
1. Go to https://www.npmjs.com/package/@filoz/synapse-react/access
1. Click on the GitHub Actions button in the Trusted Publishing section
1. Fill out the form with the following details:
    - Organization: `FilOzone`
    - Repository: `synapse-sdk`
    - Workflow: `release-please.yml`