### PR TITLE
fix(timing): increase transaction propagation timeout to 180s

### DIFF
--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -1458,16 +1458,16 @@ describe('StorageService', () => {
       }
     })
 
-    it.skip('should retry transaction fetch for up to 30 seconds', async () => {
+    it.skip('should retry transaction fetch for up to 180 seconds', async () => {
       // This test validates that the transaction retry logic is implemented
-      // The implementation retries getTransaction() for up to 30 seconds (TIMING_CONSTANTS.TRANSACTION_PROPAGATION_TIMEOUT_MS)
+      // The implementation retries getTransaction() for up to 180 seconds (TIMING_CONSTANTS.TRANSACTION_PROPAGATION_TIMEOUT_MS)
       // with a 2-second interval (TIMING_CONSTANTS.TRANSACTION_PROPAGATION_POLL_INTERVAL_MS)
       // before throwing an error if the transaction is not found
     })
 
-    it.skip('should fail after 30 seconds if transaction never appears', async () => {
-      // This test validates that the transaction retry logic times out after 30 seconds
-      // If a transaction is not found after TIMING_CONSTANTS.TRANSACTION_PROPAGATION_TIMEOUT_MS (30 seconds),
+    it.skip('should fail after 180 seconds if transaction never appears', async () => {
+      // This test validates that the transaction retry logic times out after 180 seconds
+      // If a transaction is not found after TIMING_CONSTANTS.TRANSACTION_PROPAGATION_TIMEOUT_MS (180 seconds),
       // the implementation throws an error indicating the transaction was not found
     })
 

--- a/packages/synapse-sdk/src/utils/constants.ts
+++ b/packages/synapse-sdk/src/utils/constants.ts
@@ -228,9 +228,10 @@ export const TIMING_CONSTANTS = {
   /**
    * How long to wait for a transaction to appear on the network
    * This is used when we have a transaction hash but need to fetch the transaction object
-   * Filecoin has 30-second epochs, so this gives one full epoch for propagation
+   * Filecoin has 30-second epochs, so this gives six full epochs for propagation
+   * Matches viem's standard timeout for transaction receipt (180s)
    */
-  TRANSACTION_PROPAGATION_TIMEOUT_MS: 30000, // 30 seconds (1 epoch)
+  TRANSACTION_PROPAGATION_TIMEOUT_MS: 180000, // 180 seconds (3 minutes, 6 epochs)
 
   /**
    * How often to poll when waiting for a transaction to appear


### PR DESCRIPTION
Closes: #359 

Increases the transaction propagation timeout from 30 seconds to 180 seconds (3 minutes) to match viem's standard timeout for transaction receipts. 