### PR TITLE
fix(storage):forward the isApproved and use that in storage info 

### DIFF
--- a/packages/synapse-sdk/src/storage/manager.ts
+++ b/packages/synapse-sdk/src/storage/manager.ts
@@ -345,6 +345,8 @@ export class StorageManager {
           const approval = await this._synapse.payments.serviceApproval(warmStorageAddress, TOKENS.USDFC)
           return {
             service: warmStorageAddress,
+            // Forward whether operator is approved so callers can react accordingly
+            isApproved: approval.isApproved,
             rateAllowance: approval.rateAllowance,
             lockupAllowance: approval.lockupAllowance,
             rateUsed: approval.rateUsed,

--- a/packages/synapse-sdk/src/telemetry/utils.ts
+++ b/packages/synapse-sdk/src/telemetry/utils.ts
@@ -1,6 +1,5 @@
 import type * as SentryBrowser from '@sentry/browser'
 import type * as SentryNode from '@sentry/node'
-import { createError as originalCreateError } from '../utils/errors.ts'
 
 /**
  * The telemetry module here and elsewhere needs to know whether we're running in a browser context or not.

--- a/packages/synapse-sdk/src/test/synapse.test.ts
+++ b/packages/synapse-sdk/src/test/synapse.test.ts
@@ -674,8 +674,9 @@ describe('Synapse', () => {
       assert.equal(storageInfo.serviceParameters.minUploadSize, 127)
       assert.equal(storageInfo.serviceParameters.maxUploadSize, 200 * 1024 * 1024)
 
-      // Check allowances
+      // Check allowances (including operator approval flag)
       assert.exists(storageInfo.allowances)
+      assert.equal(storageInfo.allowances?.isApproved, true)
       assert.equal(storageInfo.allowances?.service, ADDRESSES.calibration.warmStorage)
       assert.equal(storageInfo.allowances?.rateAllowance, 1000000n)
       assert.equal(storageInfo.allowances?.lockupAllowance, 10000000n)
@@ -699,6 +700,7 @@ describe('Synapse', () => {
       assert.exists(storageInfo.providers)
       assert.exists(storageInfo.serviceParameters)
       assert.deepEqual(storageInfo.allowances, {
+        isApproved: false,
         service: ADDRESSES.calibration.warmStorage,
         rateAllowance: 0n,
         lockupAllowance: 0n,

--- a/packages/synapse-sdk/src/types.ts
+++ b/packages/synapse-sdk/src/types.ts
@@ -465,6 +465,8 @@ export interface StorageInfo {
 
   /** Current user allowances (null if wallet not connected) */
   allowances: {
+    /** Whether the service operator is approved to act on behalf of the wallet */
+    isApproved: boolean
     /** Service contract address */
     service: string
     /** Maximum payment rate per epoch allowed */


### PR DESCRIPTION
Fixes #203 


* Added an `isApproved` boolean field to the `allowances` object in the `StorageInfo` interface to indicate whether the operator is approved.
* Updated the `StorageManager` to forward the `isApproved` flag from the underlying approval check so that callers receive this information directly.