### PR TITLE
fix: remove debug logs from provider filtering

### DIFF
--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -643,13 +643,13 @@ export class StorageContext {
             continue
           }
 
-        const serviceStatus = provider.products.PDP?.capabilities?.serviceStatus
-        if (!dev && serviceStatus === '0x646576') {
-          // "dev" in hex
-          continue
-        }
+          const serviceStatus = provider.products.PDP?.capabilities?.serviceStatus
+          if (!dev && serviceStatus === '0x646576') {
+            // "dev" in hex
+            continue
+          }
 
-        yield provider
+          yield provider
         }
       }
 


### PR DESCRIPTION
Remove debug logs from provider filtering that slipped in with #376