### PR TITLE
chore: update Sentry DSN in telemetry service

### DIFF
--- a/packages/synapse-sdk/src/telemetry/service.ts
+++ b/packages/synapse-sdk/src/telemetry/service.ts
@@ -111,7 +111,8 @@ export class TelemetryService {
     }
 
     this.sentry.init({
-      dsn: 'https://0010de27f563e184fc5d5afae4423bc2@o4510235322023936.ingest.us.sentry.io/4510302078828544',
+      // Maps to Sentry project "synapse-sdk-2" on the backend.
+      dsn: 'https://7a07cc9e3b5bf5a8fada2f25dc76cd49@o4510235322023936.ingest.us.sentry.io/4510308233445376',
       // Setting this option to false will prevent the SDK from sending default PII data to Sentry.
       // For example, automatic IP address collection on events
       sendDefaultPii: false,


### PR DESCRIPTION
Updated Sentry DSN for telemetry service to use "[synapse-sdk-2](https://filoz.sentry.io/settings/projects/synapse-sdk-2/)" so that we have a clean metric slate based off the changes from https://github.com/FilOzone/synapse-sdk/pull/398