### PR TITLE
chore(lint): put back arrowParentheses and bracketSpacing

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -98,6 +98,8 @@
     "formatter": {
       "jsxQuoteStyle": "double",
       "trailingCommas": "es5",
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
       "semicolons": "asNeeded",
       "quoteStyle": "single"
     },


### PR DESCRIPTION
Removed in https://github.com/FilOzone/synapse-sdk/pull/394

`arrowParentheses` in particular is something I want turned on, IMO it should have been mandatory when arrow functions were introduced, naked functions are significantly more difficult to quickly mentally parse.