### PR TITLE
fix: typo in docs header Filecion -> Filecoin

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig({
   },
   integrations: [
     starlight({
-      title: 'Filecion Onchain Cloud',
+      title: 'Filecoin Onchain Cloud',
       logo: { src: './src/assets/foc-logo.svg', alt: 'foc' },
       favicon: 'favicon.ico',
       customCss: ['./src/custom.css'],


### PR DESCRIPTION
This PR fixes a typo in the Filecoin Onchain Cloud documentation header.

<img width="728" height="67" alt="Screenshot 2025-11-10 at 10 21 41" src="https://github.com/user-attachments/assets/be805b84-7803-4e92-87ed-595763680cf7" />
