### PR TITLE
docs: note withCDN option in getting started docs

### DIFF
--- a/docs/src/content/docs/getting-started/index.mdx
+++ b/docs/src/content/docs/getting-started/index.mdx
@@ -77,7 +77,7 @@ async function main() {
   const synapse = await Synapse.create({
     privateKey: "YOUR_PRIVATE_KEY",
     rpcURL: RPC_URLS.calibration.http,
-    // Uncomment to supercharge retrievability with Filecoin Beam
+    // Uncomment for high-performance incentive-aligned data retrievability through Filecoin Beam
     // withCDN: true
   })
 


### PR DESCRIPTION
Adding a reference to Filecoin Beam in the Synapse getting started guide. 