### PR TITLE
fix: viem dep mismatch

### DIFF
--- a/examples/cli/tsconfig.json
+++ b/examples/cli/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
+    "erasableSyntaxOnly": false, // allow enums in deps
     "outDir": "./dist"
   },
   "include": ["src"],

--- a/packages/synapse-core/package.json
+++ b/packages/synapse-core/package.json
@@ -205,7 +205,7 @@
     "@types/assert": "^1.5.11",
     "@types/mocha": "catalog:",
     "@types/node": "catalog:",
-    "@wagmi/cli": "^2.7.0",
+    "@wagmi/cli": "^2.8.0",
     "abitype": "catalog:",
     "assert": "^2.1.0",
     "mocha": "catalog:",

--- a/packages/synapse-react/package.json
+++ b/packages/synapse-react/package.json
@@ -87,7 +87,8 @@
     "@biomejs/biome": "catalog:",
     "@types/node": "catalog:",
     "type-fest": "^5.1.0",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "viem": "catalog:"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
@wagmi/cli and viem were out of sync and causing lint errors on master and some PRs..

use workspace catalog for viem, and use @wagmi/cli that uses the correct version of viem we need.

Also fixes examples/cli so code we don't own isn't causing lint errors.


### Small snippet of type errors that were showing:

```shell
│ Analyzing
│ 33% [1 / 3] [1 running] build
│ ❌ [build] exited with exit code 1. Output:
│ src/utils/viem.ts:37:3 - error TS2322: Type '{ account: { address: 0x${string}; type: "json-rpc"; }; batch?: { multicall?…
│ Type '{ account: { address: 0x${string}; type: "json-rpc"; }; batch?: { multicall?: boolean | { batchSize?: number | un…
│ Types of property 'chain' are incompatible.
│ Type 'Chain | undefined' is not assignable to type 'Chain'.
│ Type 'undefined' is not assignable to type 'Chain'.
│ Type 'undefined' is not assignable to type '{ blockExplorers?: { [key: string]: ChainBlockExplorer; default: Chai…
│ 37 return createClient({
│ ~~~~~~
│ src/utils/viem.ts:38:5 - error TS2322: Type 'import("/Users/sgtpooki/code/work/filoz/filozone/synapse-sdk/packages/synapse-…
│ Type 'Chain' is not assignable to type 'ChainConfig<ChainFormatters | undefined, Record<string, unknown> | undefined>'.
│ Types of property 'fees' are incompatible.
```
