### PR TITLE
fix(deps): add cooldown to align dependabot with pnpm maturity rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,5 @@ updates:
     open-pull-requests-limit: 5
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 2


### PR DESCRIPTION
Adds 2-day cooldown to match pnpm's minimumReleaseAge (2880 minutes).

Caveats:
- No automatic sync: dependabot doesn't read pnpm-workspace.yaml
- No per-package exclusions: minimumReleaseAgeExclude not supported
- Edge cases may still occur if dependabot pins exact versions

Closes: https://github.com/FilOzone/synapse-sdk/issues/534