### PR TITLE
chore(ci): add apps/** to CI paths list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
       - master
     paths:
       - "packages/**"
+      - "apps/**"
       - .github/workflows/ci.yml
       - package.json
       - pnpm-lock.yaml
@@ -12,6 +13,7 @@ on:
   pull_request:
     paths:
       - "packages/**"
+      - "apps/**"
       - .github/workflows/ci.yml
       - package.json
       - pnpm-lock.yaml


### PR DESCRIPTION
Ref: https://github.com/FilOzone/synapse-sdk/pull/536

The above PR isn't triggered by CI even though it's updating a dependency in a package.json.

It only impacts `lint` and `build`, we don't have tests in there, but I think build would be a good thing for dependabot updates at least.