### PR TITLE
fix: change FilBeam URL to stats.filbeam.com

### DIFF
--- a/packages/synapse-sdk/src/filbeam/service.ts
+++ b/packages/synapse-sdk/src/filbeam/service.ts
@@ -72,7 +72,7 @@ export class FilBeamService {
    * Get the base stats URL for the current network
    */
   private _getStatsBaseUrl(): string {
-    return this._network === 'mainnet' ? 'https://stats.filbeam.io' : 'https://calibration.stats.filbeam.io'
+    return this._network === 'mainnet' ? 'https://stats.filbeam.com' : 'https://calibration.stats.filbeam.com'
   }
 
   /**

--- a/packages/synapse-sdk/src/test/filbeam-service.test.ts
+++ b/packages/synapse-sdk/src/test/filbeam-service.test.ts
@@ -22,7 +22,7 @@ describe('FilBeamService', () => {
       const service = new FilBeamService('mainnet' as FilecoinNetworkType, mockFetch)
 
       const baseUrl = (service as any)._getStatsBaseUrl()
-      expect(baseUrl).to.equal('https://stats.filbeam.io')
+      expect(baseUrl).to.equal('https://stats.filbeam.com')
     })
 
     it('should use calibration URL for calibration network', () => {
@@ -32,7 +32,7 @@ describe('FilBeamService', () => {
       const service = new FilBeamService('calibration' as FilecoinNetworkType, mockFetch)
 
       const baseUrl = (service as any)._getStatsBaseUrl()
-      expect(baseUrl).to.equal('https://calibration.stats.filbeam.io')
+      expect(baseUrl).to.equal('https://calibration.stats.filbeam.com')
     })
   })
 
@@ -44,7 +44,7 @@ describe('FilBeamService', () => {
       }
 
       const mockFetch = async (input: string | URL | Request): Promise<Response> => {
-        expect(input).to.equal('https://stats.filbeam.io/data-set/test-dataset-id')
+        expect(input).to.equal('https://stats.filbeam.com/data-set/test-dataset-id')
         return {
           status: 200,
           statusText: 'OK',
@@ -68,7 +68,7 @@ describe('FilBeamService', () => {
       }
 
       const mockFetch = async (input: string | URL | Request): Promise<Response> => {
-        expect(input).to.equal('https://calibration.stats.filbeam.io/data-set/123')
+        expect(input).to.equal('https://calibration.stats.filbeam.com/data-set/123')
         return {
           status: 200,
           statusText: 'OK',


### PR DESCRIPTION
Loosely related:
- https://github.com/FilOzone/synapse-sdk/pull/538

Example URLs:
- https://calibration.stats.filbeam.com/data-set/6929
- https://stats.filbeam.com/data-set/2