### PR TITLE
fix: parse example CLI flag --chain as number

### DIFF
--- a/examples/cli/src/flags.ts
+++ b/examples/cli/src/flags.ts
@@ -1,7 +1,8 @@
 const possibleChains = [314159, 314] as const
 type Chains = (typeof possibleChains)[number]
 
-const Chain = (chain: Chains) => {
+const Chain = (chainStr: string) => {
+  const chain = Number(chainStr) as Chains
   if (!possibleChains.includes(chain)) {
     throw new Error(
       `Invalid chain: ${chain}. Must be one of: ${possibleChains.join(', ')}`


### PR DESCRIPTION
Before my change:

```
❯ node examples/cli/src/index.ts datasets --chain 314
file:///Users/bajtos/src/filoz/synapse-sdk/examples/cli/src/flags.ts:6
    throw new Error(
          ^

Error: Invalid chain: 314. Must be one of: 314159, 314
```

After the fix:

```
❯ node examples/cli/src/index.ts datasets --chain 314
│
■  Private key not found
│
└  Please run `synapse init` to initialize the CLI
```

Links:
- https://github.com/FilOzone/filecoin-services/issues/359