### PR TITLE
chore: upgrade Biome Schema to v2.3.11

### DIFF
--- a/examples/script-tag/biome.json
+++ b/examples/script-tag/biome.json
@@ -1,6 +1,6 @@
 {
   "root": false,
-  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "files": {
     "ignoreUnknown": true
   },


### PR DESCRIPTION
Fix the following error when running `npm run lint:fix`:

```
❯ npm run lint:fix

> synapse@0.0.0 lint:fix
> biome check --no-errors-on-unmatched --files-ignore-unknown=true --fix .

examples/script-tag/biome.json:3:14 deserialize ━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ℹ The configuration schema version does not match the CLI version 2.3.11

    1 │ {
    2 │   "root": false,
  > 3 │   "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
      │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    4 │   "files": {
    5 │     "ignoreUnknown": true

  ℹ   Expected:                     2.3.11
      Found:                        2.3.8


  ℹ Run the command biome migrate to migrate the configuration file.


Checked 246 files in 767ms. No fixes applied.
Found 1 info.
```
