### PR TITLE
chore: remove outdated NETWORK_FEE mock

### DIFF
--- a/packages/synapse-core/src/mocks/jsonrpc/index.ts
+++ b/packages/synapse-core/src/mocks/jsonrpc/index.ts
@@ -768,7 +768,6 @@ export const presets = {
         999999n, // finalSettledEpoch
         'Terminated rail settlement', // note
       ],
-      NETWORK_FEE: () => parseUnits('0.0013', 18), // 0.0013 FIL
     },
   } as RequiredDeep<JSONRPCOptions>,
 }

--- a/packages/synapse-core/src/mocks/jsonrpc/payments.ts
+++ b/packages/synapse-core/src/mocks/jsonrpc/payments.ts
@@ -30,22 +30,12 @@ export interface PaymentsOptions {
   settleTerminatedRailWithoutValidation?: (
     args: AbiToType<settleTerminatedRailWithoutValidation['inputs']>
   ) => AbiToType<settleTerminatedRailWithoutValidation['outputs']>
-  NETWORK_FEE?: () => bigint
 }
 
 /**
  * Handle payments contract calls
  */
 export function paymentsCallHandler(data: Hex, options: JSONRPCOptions): Hex {
-  // Check for NETWORK_FEE constant (function selector: 0x9be5c024) - constants are accessed as functions but may not be in ABI
-  if (data.startsWith('0x9be5c024')) {
-    if (!options.payments?.NETWORK_FEE) {
-      throw new Error('Payments: NETWORK_FEE is not defined')
-    }
-    const fee = options.payments.NETWORK_FEE()
-    return encodeAbiParameters([{ type: 'uint256' }], [fee])
-  }
-
   const { functionName, args } = decodeFunctionData({
     abi: Abis.payments,
     data: data as Hex,


### PR DESCRIPTION

Reviewer @hugomrdias
I noticed this because of the incorrect comment about public constants not being part of the ABI.
I didn't look into the history of this but the function does not exist anymore and so it can be removed.
I have verified that we don't use it.
#### Changes
* remove NETWORK_FEE mock