### PR TITLE
docs: add references to FWSS subgraph repository

### DIFF
--- a/docs/src/content/docs/resources/additional-resources.md
+++ b/docs/src/content/docs/resources/additional-resources.md
@@ -39,12 +39,6 @@ Track storage providers health and reliability.
 - **Mainnet**: <https://dealbot.fwss.io/>
 - **Calibration Testnet**: <https://dealbot-staging.fwss.io>
 
-## FWSS Subgraph
-
-The [FWSS Subgraph](https://github.com/FIL-Builders/fwss-subgraph) indexes on-chain data from the Filecoin Warm Storage Service contracts, making it easy to query data sets, pieces, payment rails, and provider activity using GraphQL.
-
-- **Repository**: [FIL-Builders/fwss-subgraph](https://github.com/FIL-Builders/fwss-subgraph)
-
 ## Network Information
 
 - Mainnet

--- a/docs/src/content/docs/resources/community-projects.md
+++ b/docs/src/content/docs/resources/community-projects.md
@@ -28,6 +28,12 @@ The projects listed below are developed and maintained by community members. For
 - Native Go implementation
 - Suitable for backend services and CLI tools
 
+## Tools
+
+### FWSS Subgraph
+
+**[fwss-subgraph](https://github.com/FIL-Builders/fwss-subgraph)** — Indexes on-chain data from the Filecoin Warm Storage Service contracts, making it easy to query data sets, pieces, payment rails, and provider activity using GraphQL.
+
 ## Contributing
 
 Have a project you'd like to add? Open a pull request to this page with your project details.


### PR DESCRIPTION
Final part of: https://github.com/FilOzone/filecoin-services/issues/412

The FWSS subgraph has been moved to [FIL-Builders/fwss-subgraph](https://github.com/FIL-Builders/fwss-subgraph). Add pointers from synapse-sdk/docs.filecoin.cloud.