### PR TITLE
fix(metadata): validate metadata values are strings before length check

### DIFF
--- a/packages/synapse-core/src/utils/metadata.ts
+++ b/packages/synapse-core/src/utils/metadata.ts
@@ -65,6 +65,9 @@ export function datasetMetadataObjectToEntry(
     if (entry.key.length > METADATA_LIMITS.MAX_KEY_LENGTH) {
       throw new Error('Metadata key exceeds the maximum length')
     }
+    if (typeof entry.value !== 'string') {
+      throw new Error(`Metadata value must be a string, got ${typeof entry.value} for key "${entry.key}"`)
+    }
     if (entry.value.length > METADATA_LIMITS.MAX_VALUE_LENGTH) {
       throw new Error('Metadata value exceeds the maximum length')
     }
@@ -100,6 +103,9 @@ export function pieceMetadataObjectToEntry(
   for (const entry of entries) {
     if (entry.key.length > METADATA_LIMITS.MAX_KEY_LENGTH) {
       throw new Error('Metadata key exceeds the maximum length')
+    }
+    if (typeof entry.value !== 'string') {
+      throw new Error(`Metadata value must be a string, got ${typeof entry.value} for key "${entry.key}"`)
     }
     if (entry.value.length > METADATA_LIMITS.MAX_VALUE_LENGTH) {
       throw new Error('Metadata value exceeds the maximum length')

--- a/packages/synapse-core/test/metadata.test.ts
+++ b/packages/synapse-core/test/metadata.test.ts
@@ -131,6 +131,22 @@ describe('Metadata Utils', () => {
       const result = datasetMetadataObjectToEntry({ key: maxValue })
       assert.equal(result[0].value, maxValue)
     })
+
+    it('should throw when metadata value is undefined', () => {
+      // Runtime violation of Record<string, string> type — issue #606
+      const metadata = { filosign_user: undefined } as unknown as Record<string, string>
+      assert.throws(() => datasetMetadataObjectToEntry(metadata), /Metadata value must be a string/)
+    })
+
+    it('should throw when metadata value is null', () => {
+      const metadata = { key: null } as unknown as Record<string, string>
+      assert.throws(() => datasetMetadataObjectToEntry(metadata), /Metadata value must be a string/)
+    })
+
+    it('should throw when metadata value is a number', () => {
+      const metadata = { key: 42 } as unknown as Record<string, string>
+      assert.throws(() => datasetMetadataObjectToEntry(metadata), /Metadata value must be a string/)
+    })
   })
 
   describe('pieceMetadataObjectToEntry', () => {
@@ -202,6 +218,17 @@ describe('Metadata Utils', () => {
     it('should throw when value exceeds max length', () => {
       const longValue = 'a'.repeat(METADATA_LIMITS.MAX_VALUE_LENGTH + 1)
       assert.throws(() => pieceMetadataObjectToEntry({ key: longValue }), /value exceeds the maximum length/)
+    })
+
+    it('should throw when metadata value is undefined', () => {
+      // Runtime violation of Record<string, string> type — issue #606
+      const metadata = { ipfsRootCID: undefined } as unknown as Record<string, string>
+      assert.throws(() => pieceMetadataObjectToEntry(metadata), /Metadata value must be a string/)
+    })
+
+    it('should throw when metadata value is null', () => {
+      const metadata = { key: null } as unknown as Record<string, string>
+      assert.throws(() => pieceMetadataObjectToEntry(metadata), /Metadata value must be a string/)
     })
   })
 


### PR DESCRIPTION
Prevents cryptic TypeError when JS consumers pass undefined/null metadata values. Now throws a clear error identifying the invalid key and type.

Fixes: https://github.com/FilOzone/synapse-sdk/issues/606