### PR TITLE
fix: validate operator address and allowance for custom operators

### DIFF
--- a/packages/synapse-core/src/pay/payments.ts
+++ b/packages/synapse-core/src/pay/payments.ts
@@ -1,4 +1,13 @@
-import { type Account, type Address, type Chain, type Client, maxUint256, parseSignature, type Transport } from 'viem'
+import {
+  type Account,
+  type Address,
+  type Chain,
+  type Client,
+  isAddressEqual,
+  maxUint256,
+  parseSignature,
+  type Transport,
+} from 'viem'
 import {
   type SimulateContractErrorType,
   simulateContract,
@@ -66,10 +75,15 @@ export async function depositAndApprove(client: Client<Transport, Chain, Account
   const token = options.token ?? chain.contracts.usdfc.address
   const operator = options.operator ?? chain.contracts.fwss.address
 
-  const isCustomOperator = options.operator !== undefined && options.operator !== chain.contracts.fwss.address
+  const isCustomOperator =
+    options.operator !== undefined && !isAddressEqual(options.operator, chain.contracts.fwss.address)
   if (isCustomOperator) {
-    if (options.rateAllowance === undefined || options.lockupAllowance === undefined) {
-      throw new ValidationError('Custom operator requires explicit rateAllowance and lockupAllowance')
+    if (
+      options.rateAllowance === undefined ||
+      options.lockupAllowance === undefined ||
+      options.maxLockupPeriod === undefined
+    ) {
+      throw new ValidationError('Custom operator requires explicit rateAllowance, lockupAllowance and maxLockupPeriod')
     }
   }
 

--- a/packages/synapse-core/src/pay/set-operator-approval.ts
+++ b/packages/synapse-core/src/pay/set-operator-approval.ts
@@ -12,7 +12,7 @@ import type {
   WaitForTransactionReceiptErrorType,
   WriteContractErrorType,
 } from 'viem'
-import { maxUint256, parseEventLogs } from 'viem'
+import { isAddressEqual, maxUint256, parseEventLogs } from 'viem'
 import { simulateContract, waitForTransactionReceipt, writeContract } from 'viem/actions'
 import type { filecoinPay as paymentsAbi } from '../abis/index.ts'
 import * as Abis from '../abis/index.ts'
@@ -210,10 +210,15 @@ export function setOperatorApprovalCall(
   const token = options.token ?? chain.contracts.usdfc.address
   const operator = options.operator ?? chain.contracts.fwss.address
 
-  const isCustomOperator = options.operator !== undefined && options.operator !== chain.contracts.fwss.address
+  const isCustomOperator =
+    options.operator !== undefined && !isAddressEqual(options.operator, chain.contracts.fwss.address)
   if (options.approve && isCustomOperator) {
-    if (options.rateAllowance === undefined || options.lockupAllowance === undefined) {
-      throw new ValidationError('Custom operator requires explicit rateAllowance and lockupAllowance')
+    if (
+      options.rateAllowance === undefined ||
+      options.lockupAllowance === undefined ||
+      options.maxLockupPeriod === undefined
+    ) {
+      throw new ValidationError('Custom operator requires explicit rateAllowance, lockupAllowance and maxLockupPeriod')
     }
   }
 

--- a/packages/synapse-core/test/deposit-and-approve.test.ts
+++ b/packages/synapse-core/test/deposit-and-approve.test.ts
@@ -1,0 +1,56 @@
+import assert from 'assert'
+import { type Address, createWalletClient, http } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { calibration } from '../src/chains.ts'
+import { PRIVATE_KEYS } from '../src/mocks/jsonrpc/index.ts'
+import { depositAndApprove } from '../src/pay/payments.ts'
+
+describe('depositAndApprove', () => {
+  const account = privateKeyToAccount(PRIVATE_KEYS.key1)
+  const client = createWalletClient({
+    account,
+    chain: calibration,
+    transport: http(),
+  })
+
+  describe('custom operator validation', () => {
+    it('should throw ValidationError when custom operator is provided without allowances', async () => {
+      const customOperator = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as Address
+      await assert.rejects(
+        () =>
+          depositAndApprove(client, {
+            amount: 1000n,
+            operator: customOperator,
+          }),
+        /Custom operator requires explicit rateAllowance, lockupAllowance and maxLockupPeriod/
+      )
+    })
+
+    it('should throw ValidationError when custom operator has rateAllowance and lockupAllowance but not maxLockupPeriod', async () => {
+      const customOperator = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as Address
+      await assert.rejects(
+        () =>
+          depositAndApprove(client, {
+            amount: 1000n,
+            operator: customOperator,
+            rateAllowance: 1000n,
+            lockupAllowance: 2000n,
+          }),
+        /Custom operator requires explicit rateAllowance, lockupAllowance and maxLockupPeriod/
+      )
+    })
+
+    it('should NOT throw validation error when using default operator without allowances', async () => {
+      await assert.rejects(
+        () =>
+          depositAndApprove(client, {
+            amount: 1000n,
+          }),
+        (err: Error) => {
+          assert.ok(!err.message.includes('Custom operator requires explicit'))
+          return true
+        }
+      )
+    })
+  })
+})

--- a/packages/synapse-core/test/set-operator-approval.test.ts
+++ b/packages/synapse-core/test/set-operator-approval.test.ts
@@ -121,6 +121,7 @@ describe('setOperatorApproval', () => {
         operator: customOperator,
         rateAllowance: 1000000n,
         lockupAllowance: 5000000n,
+        maxLockupPeriod: 86400n,
       })
 
       assert.equal(call.args[1], customOperator)
@@ -165,11 +166,11 @@ describe('setOperatorApproval', () => {
             approve: true,
             operator: customOperator,
           }),
-        /Custom operator requires explicit rateAllowance and lockupAllowance/
+        /Custom operator requires explicit rateAllowance, lockupAllowance and maxLockupPeriod/
       )
     })
 
-    it('should throw ValidationError when custom operator has only rateAllowance', () => {
+    it('should throw ValidationError when custom operator has only rateAllowance and lockupAllowance but not maxLockupPeriod', () => {
       const customOperator = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as Address
       assert.throws(
         () =>
@@ -178,8 +179,9 @@ describe('setOperatorApproval', () => {
             approve: true,
             operator: customOperator,
             rateAllowance: 1000n,
+            lockupAllowance: 2000n,
           }),
-        /Custom operator requires explicit rateAllowance and lockupAllowance/
+        /Custom operator requires explicit rateAllowance, lockupAllowance and maxLockupPeriod/
       )
     })
 
@@ -356,6 +358,7 @@ describe('setOperatorApproval', () => {
         operator: customOperator,
         rateAllowance: 1000000n,
         lockupAllowance: 5000000n,
+        maxLockupPeriod: 86400n,
       })
 
       assert.ok(capturedArgs)


### PR DESCRIPTION
Closes #613 

**Problem**
When a custom operator is provided without explicit allowances, the system defaults to maxUint256, granting unlimited spending power to a potentially untrusted address.

**Solution**
Added `ValidationError` in `setOperatorApprovalCall` and `depositAndApprove` that throws when a non-default operator is used without explicit `rateAllowance` and `lockupAllowance`. Default FWSS operator behavior is unchanged.

**Changes**
`synapse-core/src/pay/set-operator-approval.ts` _— validation on approve_
`synapse-core/src/pay/payments.ts` — _validation on deposit+approve_
`synapse-core/test/set-operator-approval.test.ts` — _3 new tests, 2 updated_