### PR TITLE
chore: slow down biome dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,6 @@ updates:
       interval: weekly
     cooldown:
       default-days: 2
+    ignore:
+      - dependency-name: "@biomejs/biome"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Biome's semver abuse is intentional apparently: https://biomejs.dev/internals/versioning/
We're locking the version, but a large portion of our dependabot updates for it break something trivial. So this change I think should slow down the pain.
