### PR TITLE
fix(session-key): use accountless client for getExpirations reads

### DIFF
--- a/packages/synapse-core/src/session-key/authorization-expiry.ts
+++ b/packages/synapse-core/src/session-key/authorization-expiry.ts
@@ -6,6 +6,8 @@ import {
   ContractFunctionExecutionError,
   type ContractFunctionParameters,
   type ContractFunctionReturnType,
+  createClient,
+  custom,
   type MulticallErrorType,
   type ReadContractErrorType,
   type Transport,
@@ -204,8 +206,17 @@ export async function getExpirations(client: Client<Transport, Chain>, options: 
   const permissions = options.permissions ?? DefaultFwssPermissions
   const expirations: Expirations = Object.fromEntries(permissions.map((permission) => [permission, 0n]))
 
+  // Use a plain client without an account for read-only calls. When a client
+  // has an account, viem includes it as `from` in eth_call. On Filecoin, if
+  // that address is not a deployed actor (common for session keys that have
+  // never held FIL), Lotus rejects the call with "actor not found".
+  const readClient = createClient({
+    chain: client.chain,
+    transport: custom({ request: client.transport.request }),
+  })
+
   try {
-    const result = await multicall(client, {
+    const result = await multicall(readClient, {
       allowFailure: false,
       contracts: permissions.map((permission) =>
         authorizationExpiryCall({
@@ -221,7 +232,7 @@ export async function getExpirations(client: Client<Transport, Chain>, options: 
       expirations[permissions[i]] = result[i]
     }
   } catch (e) {
-    if (!(e instanceof ContractFunctionExecutionError && e.details.includes('actor not found'))) {
+    if (!(e instanceof ContractFunctionExecutionError && e.details?.includes('actor not found') === true)) {
       throw e
     }
   }


### PR DESCRIPTION
@nijoe1 is going to love this one