### PR TITLE
feat: new usdfc dataset sybil fee

### DIFF
--- a/docs/src/content/docs/developer-guides/storage/storage-costs.mdx
+++ b/docs/src/content/docs/developer-guides/storage/storage-costs.mdx
@@ -20,6 +20,7 @@ An **epoch** is Filecoin's block time, which is 30 seconds. Storage costs are ca
 | Component | Cost | Notes |
 | -------------- | ------------------ | -------------------------------------------------------- |
 | **Storage** | $2.50/TiB/month | Minimum $0.06/month per data set (~24.567 GiB threshold) |
+| **Sybil Fee** | 0.1 USDFC (one-time) | Per new data set creation; prevents state-growth spam |
 | **CDN Egress** | $14/TiB downloaded | 1 USDFC top-up ≈ 71.5 GiB of downloads |
 | **CDN Setup** | 1 USDFC (one-time) | Per data set; reusing existing data sets incurs no cost |
 

--- a/packages/synapse-core/src/abis/generated.ts
+++ b/packages/synapse-core/src/abis/generated.ts
@@ -386,6 +386,14 @@ export const errorsAbi = [
   },
   {
     type: 'error',
+    inputs: [
+      { name: 'index', internalType: 'uint256', type: 'uint256' },
+      { name: 'providerId', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'ProviderIdMismatchAtIndex',
+  },
+  {
+    type: 'error',
     inputs: [{ name: 'providerId', internalType: 'uint256', type: 'uint256' }],
     name: 'ProviderNotInApprovedList',
   },
@@ -428,6 +436,7 @@ export const errorsAbi = [
     name: 'RailNotFullySettled',
   },
   { type: 'error', inputs: [], name: 'ServiceContractMustTerminateRail' },
+  { type: 'error', inputs: [], name: 'StorageProviderChangesNotSupported' },
   {
     type: 'error',
     inputs: [
@@ -1745,6 +1754,11 @@ export const filecoinWarmStorageServiceAbi = [
         name: '_sessionKeyRegistry',
         internalType: 'contract SessionKeyRegistry',
         type: 'address',
+      },
+      {
+        name: '_reinitializer_version',
+        internalType: 'uint64',
+        type: 'uint64',
       },
     ],
     stateMutability: 'nonpayable',
@@ -3114,6 +3128,14 @@ export const filecoinWarmStorageServiceAbi = [
   },
   {
     type: 'error',
+    inputs: [
+      { name: 'index', internalType: 'uint256', type: 'uint256' },
+      { name: 'providerId', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'ProviderIdMismatchAtIndex',
+  },
+  {
+    type: 'error',
     inputs: [{ name: 'providerId', internalType: 'uint256', type: 'uint256' }],
     name: 'ProviderNotInApprovedList',
   },
@@ -3151,6 +3173,7 @@ export const filecoinWarmStorageServiceAbi = [
     name: 'RailNotFullySettled',
   },
   { type: 'error', inputs: [], name: 'ServiceContractMustTerminateRail' },
+  { type: 'error', inputs: [], name: 'StorageProviderChangesNotSupported' },
   {
     type: 'error',
     inputs: [
@@ -3525,7 +3548,20 @@ export const filecoinWarmStorageServiceStateViewConfig = {
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x85e366Cf9DD2c0aE37E963d9556F5f4718d6417C)
  */
 export const pdpVerifierAbi = [
-  { type: 'constructor', inputs: [], stateMutability: 'nonpayable' },
+  {
+    type: 'constructor',
+    inputs: [
+      { name: '_initializerVersion', internalType: 'uint64', type: 'uint64' },
+      { name: '_usdfcTokenAddress', internalType: 'address', type: 'address' },
+      { name: '_usdfcSybilFee', internalType: 'uint256', type: 'uint256' },
+      {
+        name: '_paymentsContractAddress',
+        internalType: 'address',
+        type: 'address',
+      },
+    ],
+    stateMutability: 'nonpayable',
+  },
   {
     type: 'function',
     inputs: [],
@@ -3557,8 +3593,29 @@ export const pdpVerifierAbi = [
   {
     type: 'function',
     inputs: [],
+    name: 'PAYMENTS_CONTRACT_ADDRESS',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
     name: 'UPGRADE_INTERFACE_VERSION',
     outputs: [{ name: '', internalType: 'string', type: 'string' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'USDFC_SYBIL_FEE',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'USDFC_TOKEN_ADDRESS',
+    outputs: [{ name: '', internalType: 'address', type: 'address' }],
     stateMutability: 'view',
   },
   {
@@ -3584,6 +3641,27 @@ export const pdpVerifierAbi = [
     name: 'addPieces',
     outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
     stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      {
+        name: 'plannedUpgrade',
+        internalType: 'struct PDPVerifier.PlannedUpgrade',
+        type: 'tuple',
+        components: [
+          {
+            name: 'nextImplementation',
+            internalType: 'address',
+            type: 'address',
+          },
+          { name: 'afterEpoch', internalType: 'uint96', type: 'uint96' },
+        ],
+      },
+    ],
+    name: 'announcePlannedUpgrade',
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
     type: 'function',
@@ -3687,6 +3765,26 @@ export const pdpVerifierAbi = [
       { name: 'limit', internalType: 'uint256', type: 'uint256' },
     ],
     name: 'getActivePieces',
+    outputs: [
+      {
+        name: 'pieces',
+        internalType: 'struct Cids.Cid[]',
+        type: 'tuple[]',
+        components: [{ name: 'data', internalType: 'bytes', type: 'bytes' }],
+      },
+      { name: 'pieceIds', internalType: 'uint256[]', type: 'uint256[]' },
+      { name: 'hasMore', internalType: 'bool', type: 'bool' },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'setId', internalType: 'uint256', type: 'uint256' },
+      { name: 'startPieceId', internalType: 'uint256', type: 'uint256' },
+      { name: 'limit', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'getActivePiecesByCursor',
     outputs: [
       {
         name: 'pieces',
@@ -3832,6 +3930,16 @@ export const pdpVerifierAbi = [
     name: 'nextProvingPeriod',
     outputs: [],
     stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [],
+    name: 'nextUpgrade',
+    outputs: [
+      { name: 'nextImplementation', internalType: 'address', type: 'address' },
+      { name: 'afterEpoch', internalType: 'uint96', type: 'uint96' },
+    ],
+    stateMutability: 'view',
   },
   {
     type: 'function',
@@ -4210,6 +4318,27 @@ export const pdpVerifierAbi = [
     anonymous: false,
     inputs: [
       {
+        name: 'plannedUpgrade',
+        internalType: 'struct PDPVerifier.PlannedUpgrade',
+        type: 'tuple',
+        components: [
+          {
+            name: 'nextImplementation',
+            internalType: 'address',
+            type: 'address',
+          },
+          { name: 'afterEpoch', internalType: 'uint96', type: 'uint96' },
+        ],
+        indexed: false,
+      },
+    ],
+    name: 'UpgradeAnnounced',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
         name: 'implementation',
         internalType: 'address',
         type: 'address',
@@ -4232,6 +4361,7 @@ export const pdpVerifierAbi = [
   },
   { type: 'error', inputs: [], name: 'ERC1967NonPayable' },
   { type: 'error', inputs: [], name: 'FailedCall' },
+  { type: 'error', inputs: [], name: 'FilRefundFailed' },
   {
     type: 'error',
     inputs: [
@@ -4258,6 +4388,7 @@ export const pdpVerifierAbi = [
     inputs: [{ name: 'slot', internalType: 'bytes32', type: 'bytes32' }],
     name: 'UUPSUnsupportedProxiableUUID',
   },
+  { type: 'error', inputs: [], name: 'UsdfcSybilFeeNotMet' },
 ] as const
 
 /**
@@ -4405,7 +4536,17 @@ export const providerIdSetConfig = {
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x839e5c9988e4e9977d40708d0094103c0839Ac9D)
  */
 export const serviceProviderRegistryAbi = [
-  { type: 'constructor', inputs: [], stateMutability: 'nonpayable' },
+  {
+    type: 'constructor',
+    inputs: [
+      {
+        name: '_reinitializer_version',
+        internalType: 'uint64',
+        type: 'uint64',
+      },
+    ],
+    stateMutability: 'nonpayable',
+  },
   {
     type: 'function',
     inputs: [],

--- a/packages/synapse-core/src/utils/constants.ts
+++ b/packages/synapse-core/src/utils/constants.ts
@@ -123,6 +123,13 @@ export const CDN_FIXED_LOCKUP = {
   total: 1_000_000_000_000_000_000n,
 } as const
 
+/**
+ * USDFC sybil fee charged on new dataset creation.
+ * Extracted from client funds into the payments auction pool to prevent state-growth spam.
+ * Matches PDPVerifier.USDFC_SYBIL_FEE (immutable, only changes with contract upgrade).
+ */
+export const USDFC_SYBIL_FEE = 100_000_000_000_000_000n // 0.1 USDFC
+
 export const RETRY_CONSTANTS = {
   RETRIES: Infinity,
   FACTOR: 1,

--- a/packages/synapse-core/src/warm-storage/calculate-additional-lockup-required.ts
+++ b/packages/synapse-core/src/warm-storage/calculate-additional-lockup-required.ts
@@ -1,4 +1,4 @@
-import { CDN_FIXED_LOCKUP, LOCKUP_PERIOD, TIME_CONSTANTS } from '../utils/constants.ts'
+import { CDN_FIXED_LOCKUP, LOCKUP_PERIOD, TIME_CONSTANTS, USDFC_SYBIL_FEE } from '../utils/constants.ts'
 import { calculateEffectiveRate } from './calculate-effective-rate.ts'
 
 export namespace calculateAdditionalLockupRequired {
@@ -28,7 +28,9 @@ export namespace calculateAdditionalLockupRequired {
     rateLockupDelta: bigint
     /** Fixed CDN lockup (only for new CDN datasets), 0 otherwise. */
     cdnFixedLockup: bigint
-    /** rateLockupDelta + cdnFixedLockup */
+    /** USDFC sybil fee (only for new datasets), 0 otherwise. */
+    sybilFee: bigint
+    /** rateLockupDelta + cdnFixedLockup + sybilFee */
     total: bigint
   }
 }
@@ -87,10 +89,14 @@ export function calculateAdditionalLockupRequired(
   // CDN fixed lockup only applies to new CDN datasets
   const cdnFixedLockup = isNewDataSet && withCDN ? CDN_FIXED_LOCKUP.total : 0n
 
+  // Sybil fee applies to all new dataset creations
+  const sybilFee = isNewDataSet ? USDFC_SYBIL_FEE : 0n
+
   return {
     rateDeltaPerEpoch,
     rateLockupDelta,
     cdnFixedLockup,
-    total: rateLockupDelta + cdnFixedLockup,
+    sybilFee,
+    total: rateLockupDelta + cdnFixedLockup + sybilFee,
   }
 }

--- a/packages/synapse-core/test/calculate-additional-lockup-required.test.ts
+++ b/packages/synapse-core/test/calculate-additional-lockup-required.test.ts
@@ -1,6 +1,7 @@
 /* globals describe it */
 
 import assert from 'assert'
+import { USDFC_SYBIL_FEE } from '../src/utils/constants.ts'
 import { calculateAdditionalLockupRequired } from '../src/warm-storage/calculate-additional-lockup-required.ts'
 
 const pricing = {
@@ -23,11 +24,12 @@ describe('calculateAdditionalLockupRequired', () => {
     })
 
     assert.equal(result.cdnFixedLockup, 0n)
+    assert.equal(result.sybilFee, USDFC_SYBIL_FEE)
     // For a small file, should use floor rate
     const minimumPerEpoch = pricing.minimumPricePerMonth / pricing.epochsPerMonth
     assert.equal(result.rateDeltaPerEpoch, minimumPerEpoch)
     assert.equal(result.rateLockupDelta, minimumPerEpoch * lockupEpochs)
-    assert.equal(result.total, result.rateLockupDelta)
+    assert.equal(result.total, result.rateLockupDelta + result.sybilFee)
   })
 
   it('new dataset with CDN: includes CDN fixed lockup of 1 USDFC', () => {
@@ -42,7 +44,8 @@ describe('calculateAdditionalLockupRequired', () => {
 
     const cdnFixedLockup = 1_000_000_000_000_000_000n // 1 USDFC
     assert.equal(result.cdnFixedLockup, cdnFixedLockup)
-    assert.equal(result.total, result.rateLockupDelta + cdnFixedLockup)
+    assert.equal(result.sybilFee, USDFC_SYBIL_FEE)
+    assert.equal(result.total, result.rateLockupDelta + cdnFixedLockup + result.sybilFee)
   })
 
   it('existing dataset floor-to-floor: rate delta = 0 when both sizes are below floor', () => {
@@ -60,6 +63,7 @@ describe('calculateAdditionalLockupRequired', () => {
     assert.equal(result.rateDeltaPerEpoch, 0n)
     assert.equal(result.rateLockupDelta, 0n)
     assert.equal(result.cdnFixedLockup, 0n)
+    assert.equal(result.sybilFee, 0n)
     assert.equal(result.total, 0n)
   })
 
@@ -82,6 +86,7 @@ describe('calculateAdditionalLockupRequired', () => {
     assert.ok(result.rateDeltaPerEpoch > 0n)
     assert.equal(result.rateLockupDelta, result.rateDeltaPerEpoch * lockupEpochs)
     assert.equal(result.cdnFixedLockup, 0n)
+    assert.equal(result.sybilFee, 0n)
     assert.equal(result.total, result.rateLockupDelta)
   })
 })

--- a/packages/synapse-core/wagmi.config.ts
+++ b/packages/synapse-core/wagmi.config.ts
@@ -5,7 +5,7 @@ import { multicall } from 'viem/actions'
 import { calibration, mainnet } from './src/chains.ts'
 
 // GIT_REF can be one of: '<branch name>', '<commit>' or 'tags/<tag>'
-const GIT_REF = '3f132815997a0f6fc7b207e511b7d54205044838'
+const GIT_REF = '44ef7165f7db93e5491a27ce14460143ff9a7d13'
 const BASE_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${GIT_REF.replace(/^(?![a-f0-9]{40}$)/, 'refs/')}/service_contracts/abi`
 const FWSS_ADDRESS_CALIBRATION = '0x02925630df557F957f70E112bA06e50965417CA0' as Address
 const FWSS_ADDRESS_MAINNET = '0x8408502033C418E1bbC97cE9ac48E5528F371A9f' as Address


### PR DESCRIPTION
This pull request introduces a protocol-level "Sybil Fee" for new dataset creation to prevent state-growth spam, updates the Filecoin storage cost documentation to reflect this fee, and propagates the fee throughout the calculation logic and contract ABIs. It also enhances contract ABIs with new constructor parameters, functions, errors, and events related to upgradeability, payments, and provider management.

**Protocol & Fee Updates**

- Added a one-time "Sybil Fee" of 0.1 USDFC for new dataset creation, documented in `storage-costs.mdx` and implemented as a new constant (`USDFC_SYBIL_FEE`) in code. Calculation logic and tests now include this fee when determining lockup requirements for new datasets. [[1]](diffhunk://#diff-9bc885d267a64b325e55cd949d721969e8686f043cdcba73020cdb266b488f33R23) [[2]](diffhunk://#diff-d1b14abd75d3e45a01ede72fdbc62a6eafdfb20cbb14c7eaeae07530523aaad3R126-R132) [[3]](diffhunk://#diff-81a0e72995f29f16e5f4661db10c6cf28858ce4b8d8a3c44b13683a2daba48f9L1-R1) [[4]](diffhunk://#diff-81a0e72995f29f16e5f4661db10c6cf28858ce4b8d8a3c44b13683a2daba48f9L31-R33) [[5]](diffhunk://#diff-81a0e72995f29f16e5f4661db10c6cf28858ce4b8d8a3c44b13683a2daba48f9R92-R100) [[6]](diffhunk://#diff-3be8c1c71beee0e9cd411726f238ddf6767d3c2c6d79db99b7d6cd6de29a4189R4) [[7]](diffhunk://#diff-3be8c1c71beee0e9cd411726f238ddf6767d3c2c6d79db99b7d6cd6de29a4189R27-R32) [[8]](diffhunk://#diff-3be8c1c71beee0e9cd411726f238ddf6767d3c2c6d79db99b7d6cd6de29a4189L45-R48) [[9]](diffhunk://#diff-3be8c1c71beee0e9cd411726f238ddf6767d3c2c6d79db99b7d6cd6de29a4189R66) [[10]](diffhunk://#diff-3be8c1c71beee0e9cd411726f238ddf6767d3c2c6d79db99b7d6cd6de29a4189R89)

**Contract ABI Enhancements**

- Updated ABIs for `pdpVerifier`, `filecoinWarmStorageService`, and `serviceProviderRegistry` contracts to add new constructor parameters (e.g., initializer version, sybil fee, payment contract address), new view functions for retrieving configuration (sybil fee, token address, payment contract), and new upgradeability-related functions and events (e.g., `announcePlannedUpgrade`, `UpgradeAnnounced`, `nextUpgrade`). [[1]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711L3528-R3564) [[2]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R3593-R3620) [[3]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R3645-R3665) [[4]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R3780-R3799) [[5]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R3934-R3943) [[6]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R4316-R4336) [[7]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711L4408-R4549)

- Added new error types to ABIs for more granular contract error handling, including `ProviderIdMismatchAtIndex`, `StorageProviderChangesNotSupported`, `FilRefundFailed`, and `UsdfcSybilFeeNotMet`. [[1]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R387-R394) [[2]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R439) [[3]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R3129-R3136) [[4]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R3176) [[5]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R4364) [[6]](diffhunk://#diff-5cf1dc913a696b6cba7823e6e9a040a42376c47c3af9585a94c7f3615df3c711R4391)

**Other Maintenance**

- Updated the contract ABI reference hash in `wagmi.config.ts` to ensure the frontend uses the latest contract interfaces.

These changes ensure that the new Sybil Fee is consistently enforced and visible throughout the system, and that smart contract interfaces are up-to-date with protocol requirements.


- resolves #665 