### PR TITLE
fix(core): fall back to Blob fetch body when ReadableStream not supported

### DIFF
--- a/packages/synapse-core/src/sp/sp.ts
+++ b/packages/synapse-core/src/sp/sp.ts
@@ -17,7 +17,7 @@ import type { PieceCID } from '../piece/piece.ts'
 import * as Piece from '../piece/piece.ts'
 import type * as TypedData from '../typed-data/index.ts'
 import { RETRY_CONSTANTS, SIZE_CONSTANTS } from '../utils/constants.ts'
-import { isUint8Array } from '../utils/streams.ts'
+import { isUint8Array, supportsStreamingFetchBody } from '../utils/streams.ts'
 
 export namespace createDataSet {
   /**
@@ -319,7 +319,7 @@ export async function uploadPieceStreaming(
     ? new Blob([options.data as Uint8Array<ArrayBuffer>]).stream()
     : (options.data as ReadableStream) // ReadableStream types dont match between browsers and Node.js
 
-  const size = isUint8Array(options.data) ? options.data.length : options.size
+  let size = isUint8Array(options.data) ? options.data.length : options.size
 
   // Add size tracking and progress reporting
   let bytesUploaded = 0
@@ -363,19 +363,48 @@ export async function uploadPieceStreaming(
     ? dataStream.pipeThrough(trackingStream).pipeThrough(pieceCidStream)
     : dataStream.pipeThrough(trackingStream)
 
-  // PUT /pdp/piece/uploads/{uuid} with streaming body
+  // Determine fetch body: stream it directly when the environment supports
+  // ReadableStream as a request body (Chrome, Node.js), otherwise drain the
+  // pipeline into a Blob first (Firefox, Safari). Draining still runs the
+  // full TransformStream chain so CommP calculation and progress tracking
+  // both execute regardless of path.
+  let fetchBody: ReadableStream | Blob
+  let fetchOptions: Record<string, string> = {}
+
+  if (supportsStreamingFetchBody()) {
+    fetchBody = bodyStream
+    fetchOptions = { duplex: 'half' }
+  } else {
+    const chunks: Uint8Array[] = []
+    let totalSize = 0
+    const reader = bodyStream.getReader()
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      chunks.push(value)
+      totalSize += value.length
+    }
+    fetchBody = new Blob(chunks as BlobPart[])
+    // Override Content-Length with the actual accumulated size since we now
+    // know it precisely, even for ReadableStream inputs without a pre-set size
+    if (size == null) {
+      size = totalSize
+    }
+  }
+
+  // PUT /pdp/piece/uploads/{uuid}
   const headers: Record<string, string> = {
     'Content-Type': 'application/octet-stream',
     ...(size != null ? { 'Content-Length': size.toString() } : {}),
   }
 
   const uploadResponse = await request.put(new URL(`pdp/piece/uploads/${uploadUuid}`, options.serviceURL), {
-    body: bodyStream,
+    body: fetchBody,
     headers,
     timeout: false, // No timeout for streaming upload
     signal: options.signal,
-    duplex: 'half', // Required for streaming request bodies
-  } as Parameters<typeof request.put>[1] & { duplex: 'half' })
+    ...fetchOptions,
+  } as Parameters<typeof request.put>[1] & { duplex?: 'half' })
 
   if (uploadResponse.error) {
     if (HttpError.is(uploadResponse.error)) {

--- a/packages/synapse-core/src/utils/streams.ts
+++ b/packages/synapse-core/src/utils/streams.ts
@@ -121,3 +121,38 @@ export async function* uint8ArrayToAsyncIterable(
 export function isUint8Array(value: unknown): value is Uint8Array {
   return value instanceof Uint8Array || (ArrayBuffer.isView(value) && value.constructor.name === 'Uint8Array')
 }
+
+let _supportsStreamBody: boolean | undefined
+
+/**
+ * Detect whether the current environment supports ReadableStream as a fetch
+ * request body. Firefox stringifies the stream to "[object ReadableStream]"
+ * instead of consuming it, and Safari silently ignores the stream body and
+ * the duplex option. This check catches both: a browser that stringifies will
+ * set Content-Type to text/plain (string body), and one that ignores duplex
+ * will fail the duplexAccessed gate. The try/catch handles any future browser
+ * that throws on the Request constructor.
+ *
+ * Result is memoized after the first call.
+ *
+ * @see https://developer.chrome.com/docs/capabilities/web-apis/fetch-streaming-requests
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1387483
+ */
+export function supportsStreamingFetchBody(): boolean {
+  if (_supportsStreamBody !== undefined) return _supportsStreamBody
+  try {
+    let duplexAccessed = false
+    const hasContentType = new Request('', {
+      body: new ReadableStream(),
+      method: 'POST',
+      get duplex() {
+        duplexAccessed = true
+        return 'half'
+      },
+    } as RequestInit).headers.has('Content-Type')
+    _supportsStreamBody = duplexAccessed && !hasContentType
+  } catch {
+    _supportsStreamBody = false
+  }
+  return _supportsStreamBody
+}


### PR DESCRIPTION
Firefox and Safari do not support `ReadableStream` as a fetch request body, causing uploads to send `"[object ReadableStream]"` (23 bytes) instead of actual data. Feature-detect support at runtime and drain the stream pipeline into a Blob before sending when necessary.

Fixes: https://github.com/FilOzone/synapse-sdk/issues/678

Notable (non-)regression here though is that we can't take advantage of parallel commp calculation in browsers that don't support `ReadableStream`, that'll end up blocking as we slurp the stream in here and then we follow up with the actual POST. This is a regression in _intended_ behaviour, but since it never worked in those browsers we're back to where we started with them. But there are a few options here (including the wasm calculator @hugomrdias made) that mainly involve farming off the work separately so it doesn't block and joining the result back when we need it. Mainly only matters for large inputs of course and the common cases (Chrome & Node.js) are fine with the status quo.