### PR TITLE
ci(release-please): use org PAT for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,8 +19,10 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          # needs to be personal token so release PRs can run workflows
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # PAT so release PRs trigger other workflows (auto-label, add-issues-and-prs-to-fs-project-board).
+          # This PAT has the permissions outlined in https://github.com/googleapis/release-please-action?tab=readme-ov-file#workflow-permissions.
+          # Using GITHUB_TOKEN suppresses follow-on workflow runs, which would mean release please PRs wouldn't get properly labeled and added to the project board.
+          token: ${{ secrets.FILOZZY_RELEASE_PLEASE_PAT }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
   npm:


### PR DESCRIPTION
## Summary

Configure `googleapis/release-please-action` with the organization secret `FILOZZY_RELEASE_PLEASE_PAT` instead of `GITHUB_TOKEN`. GitHub does not start new workflow runs for events caused by the default `GITHUB_TOKEN`, so release PRs otherwise skip the same automation as human-opened PRs.

Comments match [`filecoin-pin`](https://github.com/filecoin-project/filecoin-pin).

## Note

This change was **not strictly required for the project board**: synapse-sdk already has a board workflow that auto-adds PRs. We still want the PAT so other PR-triggered CI (checks, labeling, etc.) behaves consistently with normal PRs, per [release-please-action](https://github.com/googleapis/release-please-action#other-actions-on-release-please-prs) and [GitHub’s docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow).

**Prerequisite:** Org secret `FILOZZY_RELEASE_PLEASE_PAT` must be available to this repository.

Made with [Cursor](https://cursor.com)