### PR TITLE
feat(core): preserve non-standard SP registry capabilities in PDPOffering

### DIFF
--- a/packages/synapse-core/src/sp-registry/types.ts
+++ b/packages/synapse-core/src/sp-registry/types.ts
@@ -71,4 +71,10 @@ export interface PDPOffering {
    * The IPNI peer ID.
    */
   ipniPeerId?: string
+  /**
+   * Additional non-standard capabilities declared by the provider.
+   * Keys are capability names as registered on-chain (plain strings),
+   * values are the raw hex-encoded bytes from the contract.
+   */
+  extraCapabilities?: Record<string, Hex>
 }

--- a/packages/synapse-core/src/utils/pdp-capabilities.ts
+++ b/packages/synapse-core/src/utils/pdp-capabilities.ts
@@ -12,18 +12,20 @@ import { zHex } from './schemas.ts'
  *
  * @see https://github.com/FilOzone/filecoin-services/blob/a86e4a5018133f17a25b4bb6b5b99da4d34fe664/service_contracts/src/ServiceProviderRegistry.sol#L14
  */
-export const PDPOfferingSchema = z.object({
-  serviceURL: zHex,
-  minPieceSizeInBytes: zHex,
-  maxPieceSizeInBytes: zHex,
-  storagePricePerTibPerDay: zHex,
-  minProvingPeriodInEpochs: zHex,
-  location: zHex,
-  paymentTokenAddress: zHex,
-  ipniPiece: zHex.optional(),
-  ipniIpfs: zHex.optional(),
-  ipniPeerId: zHex.optional(),
-})
+export const PDPOfferingSchema = z
+  .object({
+    serviceURL: zHex,
+    minPieceSizeInBytes: zHex,
+    maxPieceSizeInBytes: zHex,
+    storagePricePerTibPerDay: zHex,
+    minProvingPeriodInEpochs: zHex,
+    location: zHex,
+    paymentTokenAddress: zHex,
+    ipniPiece: zHex.optional(),
+    ipniIpfs: zHex.optional(),
+    ipniPeerId: zHex.optional(),
+  })
+  .catchall(zHex)
 // Standard capability keys for PDP product type (must match ServiceProviderRegistry.sol REQUIRED_PDP_KEYS)
 export const CAP_SERVICE_URL = 'serviceURL'
 export const CAP_MIN_PIECE_SIZE = 'minPieceSizeInBytes'
@@ -46,6 +48,9 @@ export function decodePDPOffering(provider: ProviderWithProduct): PDPOffering {
   }
   return decodePDPCapabilities(parsed.data)
 }
+
+/** Capability keys that are decoded into typed PDPOffering fields, derived from the schema */
+const KNOWN_CAPABILITY_KEYS = new Set([...Object.keys(PDPOfferingSchema.shape), CAP_IPNI_PEER_ID_LEGACY])
 
 /**
  * Decode PDP capabilities from keys/values arrays into a PDPOffering object.
@@ -71,7 +76,15 @@ export function decodePDPCapabilities(capabilities: Record<string, Hex>): PDPOff
           ? base58btc.encode(fromHex(capabilities[CAP_IPNI_PEER_ID_LEGACY], 'bytes'))
           : undefined,
   }
-  return { ...required, ...optional }
+
+  const extraCapabilities: Record<string, Hex> = Object.create(null)
+  for (const key of Object.keys(capabilities)) {
+    if (!KNOWN_CAPABILITY_KEYS.has(key)) {
+      extraCapabilities[key] = capabilities[key]
+    }
+  }
+
+  return { ...required, ...optional, extraCapabilities }
 }
 
 /**

--- a/packages/synapse-core/test/pdp-capabilities.test.ts
+++ b/packages/synapse-core/test/pdp-capabilities.test.ts
@@ -27,6 +27,43 @@ describe('decodePDPCapabilities', () => {
       assert.strictEqual(result.ipniPeerId, undefined)
     })
   })
+
+  describe('extraCapabilities', () => {
+    it('preserves non-standard capabilities in extraCapabilities', () => {
+      const capabilities = createMinimalCapabilities({
+        serviceStatus: toHex('dev'),
+        customFlag: '0x01',
+      })
+
+      const result = decodePDPCapabilities(capabilities)
+
+      assert.ok(result.extraCapabilities)
+      assert.strictEqual(result.extraCapabilities.serviceStatus, toHex('dev'))
+      assert.strictEqual(result.extraCapabilities.customFlag, '0x01')
+    })
+
+    it('returns empty extraCapabilities when no non-standard capabilities exist', () => {
+      const capabilities = createMinimalCapabilities()
+
+      const result = decodePDPCapabilities(capabilities)
+
+      assert.ok(result.extraCapabilities)
+      assert.strictEqual(Object.keys(result.extraCapabilities).length, 0)
+    })
+
+    it('does not include standard capabilities in extraCapabilities', () => {
+      const capabilities = createMinimalCapabilities({
+        serviceStatus: toHex('dev'),
+      })
+
+      const result = decodePDPCapabilities(capabilities)
+
+      assert.ok(result.extraCapabilities)
+      assert.strictEqual(Object.keys(result.extraCapabilities).length, 1)
+      assert.strictEqual(result.extraCapabilities.serviceURL, undefined)
+      assert.strictEqual(result.extraCapabilities.location, undefined)
+    })
+  })
 })
 
 // Minimal valid capabilities for testing (all required fields)

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -1270,6 +1270,7 @@ describe('StorageService', () => {
           minProvingPeriodInEpochs: 30n,
           location: 'us-east',
           paymentTokenAddress: '0xb3042734b608a1b16e9e86b374a3f3e389b4cdf0',
+          extraCapabilities: {},
         },
       })
     })


### PR DESCRIPTION
We shouldn't have been stripping theses, there's potentially useful signals in here downstream from our consumption of the capabilities providers publish. One example is https://github.com/FilOzone/dealbot/issues/364 where the "serviceStatus" capability still has some use, but there's plenty more where clients have needs that align with what service providers want to dump in their capabilities field that we don't know or care about.