### PR TITLE
fix(permissions): remove DeleteDataSet

### DIFF
--- a/docs/src/content/docs/developer-guides/session-keys.mdx
+++ b/docs/src/content/docs/developer-guides/session-keys.mdx
@@ -27,7 +27,6 @@ The SessionKeyRegistry stores arbitrary `bytes32` hashes as permissions and is a
 | `CreateDataSetPermission` | Create new datasets |
 | `AddPiecesPermission` | Add pieces to datasets |
 | `SchedulePieceRemovalsPermission` | Schedule piece removals |
-| `DeleteDataSetPermission` | Delete datasets |
 
 These are the constants currently supported by FWSS. The `Permission` type also accepts any `Hex` value, allowing registration of custom permission hashes for non-FWSS operations (e.g., authenticated Curio HTTP endpoints).
 

--- a/packages/synapse-core/src/session-key/permissions.ts
+++ b/packages/synapse-core/src/session-key/permissions.ts
@@ -7,7 +7,6 @@ import { EIP712Types } from '../typed-data/type-definitions.ts'
 export type CreateDataSetPermission = Tagged<Hex, 'CreateDataSetPermission'>
 export type AddPiecesPermission = Tagged<Hex, 'AddPiecesPermission'>
 export type SchedulePieceRemovalsPermission = Tagged<Hex, 'SchedulePieceRemovalsPermission'>
-export type DeleteDataSetPermission = Tagged<Hex, 'DeleteDataSetPermission'>
 
 function typeHash(type: TypedData.encodeType.Value) {
   return keccak256(stringToHex(TypedData.encodeType(type)))
@@ -28,24 +27,9 @@ export const SchedulePieceRemovalsPermission = typeHash({
   primaryType: 'SchedulePieceRemovals',
 }) as SchedulePieceRemovalsPermission
 
-export const DeleteDataSetPermission = typeHash({
-  types: EIP712Types,
-  primaryType: 'DeleteDataSet',
-}) as DeleteDataSetPermission
+export const DefaultFwssPermissions = [CreateDataSetPermission, AddPiecesPermission, SchedulePieceRemovalsPermission]
 
-export const DefaultFwssPermissions = [
-  CreateDataSetPermission,
-  AddPiecesPermission,
-  SchedulePieceRemovalsPermission,
-  DeleteDataSetPermission,
-]
-
-export type Permission =
-  | CreateDataSetPermission
-  | AddPiecesPermission
-  | SchedulePieceRemovalsPermission
-  | DeleteDataSetPermission
-  | Hex
+export type Permission = CreateDataSetPermission | AddPiecesPermission | SchedulePieceRemovalsPermission | Hex
 
 export type Expirations = {
   [key in Permission]: bigint
@@ -55,5 +39,4 @@ export const DefaultEmptyExpirations: Expirations = {
   [CreateDataSetPermission]: 0n,
   [AddPiecesPermission]: 0n,
   [SchedulePieceRemovalsPermission]: 0n,
-  [DeleteDataSetPermission]: 0n,
 }

--- a/packages/synapse-core/src/typed-data/type-definitions.ts
+++ b/packages/synapse-core/src/typed-data/type-definitions.ts
@@ -28,8 +28,6 @@ export const EIP712Types = {
     { name: 'clientDataSetId', type: 'uint256' },
     { name: 'pieceIds', type: 'uint256[]' },
   ],
-  DeleteDataSet: [{ name: 'clientDataSetId', type: 'uint256' }],
-
   /**
    * ERC-2612: Permit Extension for EIP-20 Signed Approvals
    * @see https://eips.ethereum.org/EIPS/eip-2612

--- a/packages/synapse-core/test/authorization-expiry.test.ts
+++ b/packages/synapse-core/test/authorization-expiry.test.ts
@@ -7,7 +7,6 @@ import { authorizationExpiry, authorizationExpiryCall } from '../src/session-key
 import {
   AddPiecesPermission,
   CreateDataSetPermission,
-  DeleteDataSetPermission,
   SchedulePieceRemovalsPermission,
 } from '../src/session-key/permissions.ts'
 
@@ -76,7 +75,7 @@ describe('authorizationExpiry', () => {
         chain: calibration,
         address: '0x1234567890123456789012345678901234567890',
         sessionKeyAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
-        permission: DeleteDataSetPermission,
+        permission: SchedulePieceRemovalsPermission,
       })
 
       assert.ok(typeof call.args[2] === 'string')
@@ -159,14 +158,14 @@ describe('authorizationExpiry', () => {
         permission: SchedulePieceRemovalsPermission,
       })
 
-      const expiryDelete = await authorizationExpiry(client, {
+      const expiryCreate = await authorizationExpiry(client, {
         address: '0x1234567890123456789012345678901234567890',
         sessionKeyAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
-        permission: DeleteDataSetPermission,
+        permission: CreateDataSetPermission,
       })
 
       assert.equal(expirySchedule, expiry1)
-      assert.equal(expiryDelete, expiry2)
+      assert.equal(expiryCreate, expiry2)
     })
 
     it('should return 0 when authorization does not exist', async () => {


### PR DESCRIPTION

Reviewer @hugomrdias
Closes #693
This permission was removed in https://github.com/FilOzone/filecoin-services/pull/255
Session keys can create but cannot delete data sets :(
#### Changes
* remove removed permission from SDK