### PR TITLE
ci: add issues and PRs to project board workflow supports forks

### DIFF
--- a/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -15,7 +15,14 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
+  # pull_request_target has access to secrets even for fork PRs, which is necessary
+  # for this action to authenticate and add items to the project board.
+  # pull_request_target runs the workflow file from the base branch (main),
+  # not from the PR branch, so attackers cannot modify this workflow via PR.
+  # This action does not check out nor execute user code so we should be safe.
+  # We also hardcode to specific hash to ensure no unintended changes underneath us.
+  pull_request_target:
     types:
       - opened
 
@@ -24,7 +31,8 @@ jobs:
     name: Add all issues and prs to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        continue-on-error: true # Don't fail if item already exists in project. actions/add-to-project does not currently handle this case gracefully.
         with:
           project-url: https://github.com/orgs/FilOzone/projects/14
           github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}


### PR DESCRIPTION
Updated workflow to use pull_request_target to support forks.

This is the same that is done in https://github.com/filecoin-project/filecoin-pin/blob/master/.github/workflows/add-issues-and-prs-to-fs-project-board.yml