### PR TITLE
feat(storage): add 'source' and 'withCDN' getters on StorageManager

### DIFF
--- a/packages/synapse-sdk/src/storage/manager.ts
+++ b/packages/synapse-sdk/src/storage/manager.ts
@@ -159,6 +159,23 @@ export class StorageManager {
   }
 
   /**
+   * The application source identifier used for dataset namespace isolation.
+   * Set via `Synapse.create({ source })`. Used by `combineMetadata` to tag
+   * datasets so that different applications sharing a wallet don't collide.
+   */
+  get source(): string | null {
+    return this._source
+  }
+
+  /**
+   * Whether CDN rails are enabled for new datasets by default.
+   * Set via `Synapse.create({ withCDN })`.
+   */
+  get withCDN(): boolean {
+    return this._withCDN
+  }
+
+  /**
    * Upload data to Filecoin Onchain Cloud using a store->pull->commit flow across
    * multiple providers.
    *


### PR DESCRIPTION
To help with the case where you have a `Synapse` or a `StorageManeger` instance and want to do some metadata inspection before you hit combineMetadata. Currently with these two as private, we don't know whether one will show up or not.
e.g. in filecoin-pin we don't want to override an existing 'source' parameter with the 'filecoin-pin' default if the user supplied a `Synapse` instance with a 'source' but we have no way of knowing that currently.