### PR TITLE
fix(storage): trim provider resolver & pass all erorrs through

### DIFF
--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -494,29 +494,20 @@ export class StorageContext {
     for (let i = 0; i < sortedDataSets.length; i += BATCH_SIZE) {
       const batchResults: (EvaluatedDataSet | null)[] = await Promise.all(
         sortedDataSets.slice(i, i + BATCH_SIZE).map(async (dataSet) => {
-          const dataSetId = dataSet.dataSetId
-          try {
-            const [dataSetMetadata, activePieceCount] = await Promise.all([
-              warmStorageService.getDataSetMetadata({ dataSetId }),
-              warmStorageService.getActivePieceCount({ dataSetId }),
-              warmStorageService.validateDataSet({ dataSetId }),
-            ])
+          const { dataSetId } = dataSet
+          const [dataSetMetadata, activePieceCount] = await Promise.all([
+            warmStorageService.getDataSetMetadata({ dataSetId }),
+            warmStorageService.getActivePieceCount({ dataSetId }),
+          ])
 
-            if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
-              return null
-            }
-
-            return {
-              dataSetId,
-              dataSetMetadata,
-              activePieceCount,
-            }
-          } catch (error) {
-            console.warn(
-              `Skipping data set ${dataSetId} for provider ${providerId}:`,
-              error instanceof Error ? error.message : String(error)
-            )
+          if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
             return null
+          }
+
+          return {
+            dataSetId,
+            dataSetMetadata,
+            activePieceCount,
           }
         })
       )


### PR DESCRIPTION
validateDataSet is mostly redundant here because getClientDataSets already applies roughly the same filters so it's primarily acting as an invariant (i.e. does PDPVerifier agree that this is still active and managed by FWSS?). So we can remove one RPC call per data set and it's the call that can throw, so all other errors that come from these RPC calls are going to be problems for the user to deal with (such as RPC rate limit errors).

validateDataSet throwing here is one of those "throw == false" situations, but of course we're not doing any sophisticated checking here and swalling any other kind of error, including RPC. The theory behind not being strict is something like: _it's not critical that we find a matching data set, it's more critical that we get the user's data uploaded._ But in the case of dealbot which is trying to be precise, that falls apart and our user in that case doesn't want any laxity.