### PR TITLE
feat(synapse-sdk): expose paginated client dataset queries in WarmStorageService

### DIFF
--- a/packages/synapse-sdk/src/test/warm-storage-service.test.ts
+++ b/packages/synapse-sdk/src/test/warm-storage-service.test.ts
@@ -182,6 +182,81 @@ describe('WarmStorageService', () => {
       assert.equal(dataSets[1].cdnRailId, 100n)
     })
 
+    it('should support pagination with offset and limit', async () => {
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          warmStorageView: {
+            getClientDataSets: (args) => {
+              const [, offset, limit] = args
+              // Return first dataset when offset=0, limit=1
+              if (offset === 0n && limit === 1n) {
+                return [
+                  [
+                    {
+                      pdpRailId: 1n,
+                      cacheMissRailId: 0n,
+                      cdnRailId: 0n,
+                      payer: Mocks.ADDRESSES.client1,
+                      payee: Mocks.ADDRESSES.serviceProvider1,
+                      serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                      commissionBps: 100n,
+                      clientDataSetId: 0n,
+                      pdpEndEpoch: 0n,
+                      providerId: 1n,
+                      cdnEndEpoch: 0n,
+                      dataSetId: 1n,
+                    },
+                  ],
+                ]
+              }
+              // Return second dataset when offset=1, limit=1
+              if (offset === 1n && limit === 1n) {
+                return [
+                  [
+                    {
+                      pdpRailId: 2n,
+                      cacheMissRailId: 0n,
+                      cdnRailId: 100n,
+                      payer: Mocks.ADDRESSES.client1,
+                      payee: Mocks.ADDRESSES.serviceProvider1,
+                      serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                      commissionBps: 200n,
+                      clientDataSetId: 1n,
+                      pdpEndEpoch: 0n,
+                      providerId: 1n,
+                      cdnEndEpoch: 0n,
+                      dataSetId: 2n,
+                    },
+                  ],
+                ]
+              }
+              return [[]]
+            },
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+
+      // Get first page
+      const firstPage = await warmStorageService.getClientDataSets({
+        address: Mocks.ADDRESSES.client1,
+        offset: 0n,
+        limit: 1n,
+      })
+      assert.lengthOf(firstPage, 1)
+      assert.equal(firstPage[0].dataSetId, 1n)
+
+      // Get second page
+      const secondPage = await warmStorageService.getClientDataSets({
+        address: Mocks.ADDRESSES.client1,
+        offset: 1n,
+        limit: 1n,
+      })
+      assert.lengthOf(secondPage, 1)
+      assert.equal(secondPage[0].dataSetId, 2n)
+    })
+
     it('should handle contract call errors gracefully', async () => {
       server.use(
         Mocks.JSONRPC({
@@ -203,6 +278,130 @@ describe('WarmStorageService', () => {
     })
   })
 
+  describe('getClientDataSetsLength', () => {
+    it('should return total count of data sets for a client', async () => {
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          warmStorageView: {
+            getClientDataSetsLength: () => [5n],
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+      const count = await warmStorageService.getClientDataSetsLength({ address: Mocks.ADDRESSES.client1 })
+      assert.equal(count, 5n)
+    })
+
+    it('should return zero when client has no data sets', async () => {
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          warmStorageView: {
+            getClientDataSetsLength: () => [0n],
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+      const count = await warmStorageService.getClientDataSetsLength({ address: Mocks.ADDRESSES.client1 })
+      assert.equal(count, 0n)
+    })
+  })
+
+  describe('getClientDataSetIds', () => {
+    it('should return data set IDs for a client', async () => {
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          warmStorageView: {
+            clientDataSets: () => [[1n, 2n, 3n]],
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+      const ids = await warmStorageService.getClientDataSetIds({ address: Mocks.ADDRESSES.client1 })
+      assert.isArray(ids)
+      assert.lengthOf(ids, 3)
+      assert.equal(ids[0], 1n)
+      assert.equal(ids[1], 2n)
+      assert.equal(ids[2], 3n)
+    })
+
+    it('should return empty array when client has no data sets', async () => {
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          warmStorageView: {
+            clientDataSets: () => [[]],
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+      const ids = await warmStorageService.getClientDataSetIds({ address: Mocks.ADDRESSES.client1 })
+      assert.isArray(ids)
+      assert.lengthOf(ids, 0)
+    })
+
+    it('should support pagination with offset and limit', async () => {
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          warmStorageView: {
+            clientDataSets: (args) => {
+              const [, offset, limit] = args
+              // Return first ID when offset=0, limit=1
+              if (offset === 0n && limit === 1n) {
+                return [[1n]]
+              }
+              // Return second ID when offset=1, limit=1
+              if (offset === 1n && limit === 1n) {
+                return [[2n]]
+              }
+              return [[]]
+            },
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+
+      // Get first page
+      const firstPage = await warmStorageService.getClientDataSetIds({
+        address: Mocks.ADDRESSES.client1,
+        offset: 0n,
+        limit: 1n,
+      })
+      assert.lengthOf(firstPage, 1)
+      assert.equal(firstPage[0], 1n)
+
+      // Get second page
+      const secondPage = await warmStorageService.getClientDataSetIds({
+        address: Mocks.ADDRESSES.client1,
+        offset: 1n,
+        limit: 1n,
+      })
+      assert.lengthOf(secondPage, 1)
+      assert.equal(secondPage[0], 2n)
+    })
+
+    it('should fetch all IDs when limit is 0n', async () => {
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          warmStorageView: {
+            clientDataSets: () => [[1n, 2n, 3n, 4n, 5n]],
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+      const ids = await warmStorageService.getClientDataSetIds({
+        address: Mocks.ADDRESSES.client1,
+        offset: 0n,
+        limit: 0n,
+      })
+      assert.lengthOf(ids, 5)
+    })
+  })
+
   describe('getClientDataSetsWithDetails', () => {
     it('should enhance data sets with PDPVerifier details', async () => {
       server.use(
@@ -210,6 +409,7 @@ describe('WarmStorageService', () => {
           ...Mocks.presets.basic,
           warmStorageView: {
             ...Mocks.presets.basic.warmStorageView,
+            getClientDataSetsLength: () => [1n],
             clientDataSets: () => [[242n]],
             getDataSet: () => [
               {
@@ -254,6 +454,7 @@ describe('WarmStorageService', () => {
           ...Mocks.presets.basic,
           warmStorageView: {
             ...Mocks.presets.basic.warmStorageView,
+            getClientDataSetsLength: () => [2n],
             clientDataSets: () => [[242n, 243n]],
             getDataSet: (args) => {
               const [dataSetId] = args
@@ -331,6 +532,7 @@ describe('WarmStorageService', () => {
           ...Mocks.presets.basic,
           warmStorageView: {
             ...Mocks.presets.basic.warmStorageView,
+            getClientDataSetsLength: () => [1n],
             clientDataSets: () => [[242n]],
             getDataSet: () => [
               {
@@ -376,6 +578,7 @@ describe('WarmStorageService', () => {
           ...Mocks.presets.basic,
           warmStorageView: {
             ...Mocks.presets.basic.warmStorageView,
+            getClientDataSetsLength: () => [1n],
             clientDataSets: () => [[242n]],
             getDataSet: () => [
               {
@@ -421,6 +624,7 @@ describe('WarmStorageService', () => {
           ...Mocks.presets.basic,
           warmStorageView: {
             ...Mocks.presets.basic.warmStorageView,
+            getClientDataSetsLength: () => [1n],
             clientDataSets: () => [[242n]],
             getDataSet: () => {
               throw new Error('Contract call failed')

--- a/packages/synapse-sdk/src/warm-storage/service.ts
+++ b/packages/synapse-sdk/src/warm-storage/service.ts
@@ -28,7 +28,9 @@ import {
   getAllDataSetMetadataCall,
   getAllPieceMetadata,
   getApprovedProviderIds,
+  getClientDataSetIds,
   getClientDataSets,
+  getClientDataSetsLength,
   getDataSet,
   getServicePrice,
   removeApprovedProvider,
@@ -106,11 +108,39 @@ export class WarmStorageService {
    * Get all data sets for a specific client
    * @param options - Options for the client data sets
    * @param options.address - The client address
+   * @param options.offset - Starting index (0-based). Use 0 to start from beginning.
+   * @param options.limit - Maximum number of data sets to return. Use 0 to get all remaining.
    * @returns Array of data set information {@link getClientDataSets.OutputType}
    * @throws Errors {@link getClientDataSets.ErrorType}
    */
-  async getClientDataSets(options: { address: Address }): Promise<getClientDataSets.OutputType> {
+  async getClientDataSets(options: {
+    address: Address
+    offset?: bigint
+    limit?: bigint
+  }): Promise<getClientDataSets.OutputType> {
     return getClientDataSets(this._client, options)
+  }
+
+  /**
+   * Get total count of data sets for a specific client
+   * @param options - Options for the client data sets length
+   * @param options.address - The client address
+   * @returns Total count of data sets
+   */
+  async getClientDataSetsLength(options: { address: Address }): Promise<bigint> {
+    return getClientDataSetsLength(this._client, options)
+  }
+
+  /**
+   * Get data set IDs for a specific client with optional pagination
+   * @param options - Options for the client data set IDs
+   * @param options.address - The client address
+   * @param options.offset - Starting index (0-based). Use 0 to start from beginning.
+   * @param options.limit - Maximum number of IDs to return. Use 0 to get all remaining.
+   * @returns Array of data set IDs
+   */
+  async getClientDataSetIds(options: { address: Address; offset?: bigint; limit?: bigint }): Promise<bigint[]> {
+    return getClientDataSetIds(this._client, options)
   }
 
   /**
@@ -126,12 +156,11 @@ export class WarmStorageService {
     onlyManaged?: boolean
   }): Promise<EnhancedDataSetInfo[]> {
     const { address = this._client.account.address, onlyManaged = false } = options
-    // Query dataset IDs directly from the view contract
-    const ids = await readContract(this._client, {
-      address: this._chain.contracts.fwssView.address,
-      abi: this._chain.contracts.fwssView.abi,
-      functionName: 'clientDataSets',
-      args: [address],
+    // Query dataset IDs (offset=0, limit=0 fetches all)
+    const ids = await getClientDataSetIds(this._client, {
+      address,
+      offset: 0n,
+      limit: 0n,
     })
     if (ids.length === 0) return []
 

--- a/packages/synapse-sdk/src/warm-storage/service.ts
+++ b/packages/synapse-sdk/src/warm-storage/service.ts
@@ -108,8 +108,8 @@ export class WarmStorageService {
    * Get all data sets for a specific client
    * @param options - Options for the client data sets
    * @param options.address - The client address
-   * @param options.offset - Starting index (0-based). Use 0 to start from beginning.
-   * @param options.limit - Maximum number of data sets to return. Use 0 to get all remaining.
+   * @param options.offset - Starting index (0-based). Use `0n` to start from beginning.
+   * @param options.limit - Maximum number of data sets to return. Use `0n` to get all remaining.
    * @returns Array of data set information {@link getClientDataSets.OutputType}
    * @throws Errors {@link getClientDataSets.ErrorType}
    */
@@ -127,7 +127,7 @@ export class WarmStorageService {
    * @param options.address - The client address
    * @returns Total count of data sets
    */
-  async getClientDataSetsLength(options: { address: Address }): Promise<bigint> {
+  async getClientDataSetsLength(options: { address: Address }): Promise<getClientDataSetsLength.OutputType> {
     return getClientDataSetsLength(this._client, options)
   }
 
@@ -135,11 +135,15 @@ export class WarmStorageService {
    * Get data set IDs for a specific client with optional pagination
    * @param options - Options for the client data set IDs
    * @param options.address - The client address
-   * @param options.offset - Starting index (0-based). Use 0 to start from beginning.
-   * @param options.limit - Maximum number of IDs to return. Use 0 to get all remaining.
-   * @returns Array of data set IDs
+   * @param options.offset - Starting index (0-based). Use `0n` to start from beginning.
+   * @param options.limit - Maximum number of IDs to return. Use `0n` to get all remaining.
+   * @returns Array of data set IDs {@link getClientDataSetIds.OutputType}
    */
-  async getClientDataSetIds(options: { address: Address; offset?: bigint; limit?: bigint }): Promise<bigint[]> {
+  async getClientDataSetIds(options: {
+    address: Address
+    offset?: bigint
+    limit?: bigint
+  }): Promise<getClientDataSetIds.OutputType> {
     return getClientDataSetIds(this._client, options)
   }
 
@@ -156,12 +160,28 @@ export class WarmStorageService {
     onlyManaged?: boolean
   }): Promise<EnhancedDataSetInfo[]> {
     const { address = this._client.account.address, onlyManaged = false } = options
-    // Query dataset IDs (offset=0, limit=0 fetches all)
-    const ids = await getClientDataSetIds(this._client, {
-      address,
-      offset: 0n,
-      limit: 0n,
-    })
+
+    // Get total count first
+    const totalDataSets = await this.getClientDataSetsLength({ address })
+    if (totalDataSets === 0n) return []
+
+    // Fetch IDs in chunks to avoid unbounded response size
+    const pageSize = 100n
+    const ids: bigint[] = []
+
+    for (let offset = 0n; offset < totalDataSets; offset += pageSize) {
+      const remaining = totalDataSets - offset
+      const limit = remaining < pageSize ? remaining : pageSize
+      const pageIds = await this.getClientDataSetIds({
+        address,
+        offset,
+        limit,
+      })
+
+      if (pageIds.length === 0) break
+      ids.push(...pageIds)
+    }
+
     if (ids.length === 0) return []
 
     // Enhance all in parallel using dataset IDs


### PR DESCRIPTION
## Summary

Exposes the paginated client dataset actions from synapse-core (#698) in `WarmStorageService`, enabling consumers to use `offset`/`limit` for dataset queries.

## Changes

### `packages/synapse-sdk/src/warm-storage/service.ts`

- **`getClientDataSets`** — Added optional `offset`/`limit` parameters to support paginated queries
- **`getClientDataSetIds`** — New method wrapping `getClientDataSetIds` from synapse-core, returns dataset ID arrays with optional pagination
- **`getClientDataSetsLength`** — New method wrapping `getClientDataSetsLength` from synapse-core, returns total dataset count for a client
- **`getClientDataSetsWithDetails`** — Refactored to use `getClientDataSetIds` instead of raw `readContract` call

## Related

- Depends on #698 (synapse-core paginated dataset reads)
- Addresses filecoin-pin#362

with this in place
Closes #691 