### PR TITLE
feat: use PDPVerifier.findPieceIdsByCid for efficient CID→ID lookups

### DIFF
--- a/packages/synapse-core/src/mocks/jsonrpc/index.ts
+++ b/packages/synapse-core/src/mocks/jsonrpc/index.ts
@@ -526,6 +526,7 @@ export const presets = {
       getDataSetLeafCount: () => [0n],
       getScheduledRemovals: () => [[]],
       getNextChallengeEpoch: () => [5000n],
+      findPieceIdsByCid: () => [[0n]],
     },
     serviceRegistry: {
       registerProvider: () => [1n],

--- a/packages/synapse-core/src/mocks/jsonrpc/pdp.ts
+++ b/packages/synapse-core/src/mocks/jsonrpc/pdp.ts
@@ -14,6 +14,7 @@ export type getDataSetStorageProvider = ExtractAbiFunction<typeof Abis.pdp, 'get
 export type getDataSetLeafCount = ExtractAbiFunction<typeof Abis.pdp, 'getDataSetLeafCount'>
 export type getScheduledRemovals = ExtractAbiFunction<typeof Abis.pdp, 'getScheduledRemovals'>
 export type getNextChallengeEpoch = ExtractAbiFunction<typeof Abis.pdp, 'getNextChallengeEpoch'>
+export type findPieceIdsByCid = ExtractAbiFunction<typeof Abis.pdp, 'findPieceIdsByCid'>
 
 export interface PDPVerifierOptions {
   dataSetLive?: (args: AbiToType<dataSetLive['inputs']>) => AbiToType<dataSetLive['outputs']>
@@ -29,6 +30,7 @@ export interface PDPVerifierOptions {
   getNextChallengeEpoch?: (
     args: AbiToType<getNextChallengeEpoch['inputs']>
   ) => AbiToType<getNextChallengeEpoch['outputs']>
+  findPieceIdsByCid?: (args: AbiToType<findPieceIdsByCid['inputs']>) => AbiToType<findPieceIdsByCid['outputs']>
 }
 
 /**
@@ -122,6 +124,15 @@ export function pdpVerifierCallHandler(data: Hex, options: JSONRPCOptions): Hex 
       return encodeAbiParameters(
         Abis.pdp.find((abi) => abi.type === 'function' && abi.name === 'getNextChallengeEpoch')!.outputs,
         options.pdpVerifier.getNextChallengeEpoch(args)
+      )
+    }
+    case 'findPieceIdsByCid': {
+      if (!options.pdpVerifier?.findPieceIdsByCid) {
+        throw new Error('PDP Verifier: findPieceIdsByCid is not defined')
+      }
+      return encodeAbiParameters(
+        Abis.pdp.find((abi) => abi.type === 'function' && abi.name === 'findPieceIdsByCid')!.outputs,
+        options.pdpVerifier.findPieceIdsByCid(args)
       )
     }
     default: {

--- a/packages/synapse-core/src/pdp-verifier/find-piece-ids-by-cid.ts
+++ b/packages/synapse-core/src/pdp-verifier/find-piece-ids-by-cid.ts
@@ -1,0 +1,135 @@
+import type { Simplify } from 'type-fest'
+import {
+  type Address,
+  type Chain,
+  type Client,
+  type ContractFunctionParameters,
+  type ContractFunctionReturnType,
+  type ReadContractErrorType,
+  type Transport,
+  toHex,
+} from 'viem'
+import { readContract } from 'viem/actions'
+import type { pdpVerifierAbi } from '../abis/generated.ts'
+import { asChain } from '../chains.ts'
+import type { PieceCID } from '../piece/piece.ts'
+import type { ActionCallChain } from '../types.ts'
+
+export namespace findPieceIdsByCid {
+  export type OptionsType = {
+    /** The ID of the data set to search in. */
+    dataSetId: bigint
+    /** The PieceCID to search for. */
+    pieceCid: PieceCID
+    /** The starting piece ID for the search. @default 0n */
+    startPieceId?: bigint
+    /** The maximum number of results to return. @default 1n */
+    limit?: bigint
+    /** PDP Verifier contract address. If not provided, the default is the PDP Verifier contract address for the chain. */
+    contractAddress?: Address
+  }
+
+  export type OutputType = readonly bigint[]
+
+  /**
+   * `uint256[]` - Array of piece IDs matching the given CID
+   */
+  export type ContractOutputType = ContractFunctionReturnType<
+    typeof pdpVerifierAbi,
+    'pure' | 'view',
+    'findPieceIdsByCid'
+  >
+
+  export type ErrorType = asChain.ErrorType | ReadContractErrorType
+}
+
+/**
+ * Find piece IDs for a given PieceCID in a data set.
+ *
+ * Uses the on-chain `findPieceIdsByCid` function for efficient CID→ID lookup.
+ *
+ * @example
+ * ```ts
+ * import { findPieceIdsByCid } from '@filoz/synapse-core/pdp-verifier'
+ * import { calibration } from '@filoz/synapse-core/chains'
+ * import { createPublicClient, http } from 'viem'
+ * import * as Piece from '@filoz/synapse-core/piece'
+ *
+ * const client = createPublicClient({
+ *   chain: calibration,
+ *   transport: http(),
+ * })
+ *
+ * const pieceCid = Piece.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+ * const pieceIds = await findPieceIdsByCid(client, {
+ *   dataSetId: 1n,
+ *   pieceCid,
+ * })
+ * // pieceIds is an array of bigint IDs matching the CID
+ * ```
+ *
+ * @param client - The client to use to find piece IDs.
+ * @param options - {@link findPieceIdsByCid.OptionsType}
+ * @returns Array of piece IDs matching the CID {@link findPieceIdsByCid.OutputType}
+ * @throws Errors {@link findPieceIdsByCid.ErrorType}
+ */
+export async function findPieceIdsByCid(
+  client: Client<Transport, Chain>,
+  options: findPieceIdsByCid.OptionsType
+): Promise<findPieceIdsByCid.OutputType> {
+  return await readContract(
+    client,
+    findPieceIdsByCidCall({
+      chain: client.chain,
+      dataSetId: options.dataSetId,
+      pieceCid: options.pieceCid,
+      startPieceId: options.startPieceId,
+      limit: options.limit,
+      contractAddress: options.contractAddress,
+    })
+  )
+}
+
+export namespace findPieceIdsByCidCall {
+  export type OptionsType = Simplify<findPieceIdsByCid.OptionsType & ActionCallChain>
+  export type ErrorType = asChain.ErrorType
+  export type OutputType = ContractFunctionParameters<typeof pdpVerifierAbi, 'pure' | 'view', 'findPieceIdsByCid'>
+}
+
+/**
+ * Create a call to the {@link findPieceIdsByCid} function for use with the multicall or readContract function.
+ *
+ * @example
+ * ```ts
+ * import { findPieceIdsByCidCall } from '@filoz/synapse-core/pdp-verifier'
+ * import { calibration } from '@filoz/synapse-core/chains'
+ * import { createPublicClient, http } from 'viem'
+ * import { readContract } from 'viem/actions'
+ * import * as Piece from '@filoz/synapse-core/piece'
+ *
+ * const client = createPublicClient({
+ *   chain: calibration,
+ *   transport: http(),
+ * })
+ *
+ * const pieceCid = Piece.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+ * const result = await readContract(client, findPieceIdsByCidCall({
+ *   chain: calibration,
+ *   dataSetId: 1n,
+ *   pieceCid,
+ * }))
+ * ```
+ *
+ * @param options - {@link findPieceIdsByCidCall.OptionsType}
+ * @returns The call to the findPieceIdsByCid function {@link findPieceIdsByCidCall.OutputType}
+ * @throws Errors {@link findPieceIdsByCidCall.ErrorType}
+ */
+export function findPieceIdsByCidCall(options: findPieceIdsByCidCall.OptionsType) {
+  const chain = asChain(options.chain)
+  return {
+    abi: chain.contracts.pdp.abi,
+    address: options.contractAddress ?? chain.contracts.pdp.address,
+    functionName: 'findPieceIdsByCid',
+    args: [options.dataSetId, { data: toHex(options.pieceCid.bytes) }, options.startPieceId ?? 0n, options.limit ?? 1n],
+  } satisfies findPieceIdsByCidCall.OutputType
+}

--- a/packages/synapse-core/src/pdp-verifier/index.ts
+++ b/packages/synapse-core/src/pdp-verifier/index.ts
@@ -10,6 +10,7 @@ import {
 import { asChain } from '../chains.ts'
 
 export * from './data-set-live.ts'
+export * from './find-piece-ids-by-cid.ts'
 export * from './get-active-piece-count.ts'
 export * from './get-active-pieces.ts'
 export * from './get-data-set-leaf-count.ts'

--- a/packages/synapse-core/test/find-piece-ids-by-cid.test.ts
+++ b/packages/synapse-core/test/find-piece-ids-by-cid.test.ts
@@ -1,0 +1,143 @@
+import assert from 'assert'
+import { setup } from 'iso-web/msw'
+import { createPublicClient, http, toHex } from 'viem'
+import { calibration, mainnet } from '../src/chains.ts'
+import { JSONRPC, presets } from '../src/mocks/jsonrpc/index.ts'
+import { findPieceIdsByCid, findPieceIdsByCidCall } from '../src/pdp-verifier/find-piece-ids-by-cid.ts'
+import * as Piece from '../src/piece/piece.ts'
+
+describe('findPieceIdsByCid', () => {
+  const server = setup()
+
+  before(async () => {
+    await server.start()
+  })
+
+  after(() => {
+    server.stop()
+  })
+
+  beforeEach(() => {
+    server.resetHandlers()
+  })
+
+  describe('findPieceIdsByCidCall', () => {
+    const pieceCid = Piece.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+
+    it('should create call with calibration chain defaults', () => {
+      const call = findPieceIdsByCidCall({
+        chain: calibration,
+        dataSetId: 1n,
+        pieceCid,
+      })
+
+      assert.equal(call.functionName, 'findPieceIdsByCid')
+      assert.deepEqual(call.args, [1n, { data: toHex(pieceCid.bytes) }, 0n, 1n])
+      assert.equal(call.address, calibration.contracts.pdp.address)
+      assert.equal(call.abi, calibration.contracts.pdp.abi)
+    })
+
+    it('should create call with mainnet chain defaults', () => {
+      const call = findPieceIdsByCidCall({
+        chain: mainnet,
+        dataSetId: 1n,
+        pieceCid,
+      })
+
+      assert.equal(call.functionName, 'findPieceIdsByCid')
+      assert.deepEqual(call.args, [1n, { data: toHex(pieceCid.bytes) }, 0n, 1n])
+      assert.equal(call.address, mainnet.contracts.pdp.address)
+      assert.equal(call.abi, mainnet.contracts.pdp.abi)
+    })
+
+    it('should use provided startPieceId and limit', () => {
+      const call = findPieceIdsByCidCall({
+        chain: calibration,
+        dataSetId: 1n,
+        pieceCid,
+        startPieceId: 10n,
+        limit: 5n,
+      })
+
+      assert.deepEqual(call.args, [1n, { data: toHex(pieceCid.bytes) }, 10n, 5n])
+    })
+
+    it('should use custom address when provided', () => {
+      const customAddress = '0x1234567890123456789012345678901234567890'
+      const call = findPieceIdsByCidCall({
+        chain: calibration,
+        dataSetId: 1n,
+        pieceCid,
+        contractAddress: customAddress,
+      })
+
+      assert.equal(call.address, customAddress)
+    })
+  })
+
+  describe('findPieceIdsByCid (with mocked RPC)', () => {
+    it('should find piece IDs by CID', async () => {
+      server.use(JSONRPC(presets.basic))
+
+      const client = createPublicClient({
+        chain: calibration,
+        transport: http(),
+      })
+
+      const pieceCid = Piece.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+      const result = await findPieceIdsByCid(client, { dataSetId: 1n, pieceCid })
+
+      assert.ok(Array.isArray(result))
+      assert.equal(result.length, 1)
+      assert.equal(result[0], 0n)
+    })
+
+    it('should return empty array when piece not found', async () => {
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          pdpVerifier: {
+            ...presets.basic.pdpVerifier,
+            findPieceIdsByCid: () => [[]],
+          },
+        })
+      )
+
+      const client = createPublicClient({
+        chain: calibration,
+        transport: http(),
+      })
+
+      const pieceCid = Piece.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+      const result = await findPieceIdsByCid(client, { dataSetId: 1n, pieceCid })
+
+      assert.ok(Array.isArray(result))
+      assert.equal(result.length, 0)
+    })
+
+    it('should return multiple piece IDs', async () => {
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          pdpVerifier: {
+            ...presets.basic.pdpVerifier,
+            findPieceIdsByCid: () => [[42n, 99n]],
+          },
+        })
+      )
+
+      const client = createPublicClient({
+        chain: calibration,
+        transport: http(),
+      })
+
+      const pieceCid = Piece.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+      const result = await findPieceIdsByCid(client, { dataSetId: 1n, pieceCid, limit: 10n })
+
+      assert.ok(Array.isArray(result))
+      assert.equal(result.length, 2)
+      assert.equal(result[0], 42n)
+      assert.equal(result[1], 99n)
+    })
+  })
+})

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -1048,15 +1048,16 @@ export class StorageContext {
       throw createError('StorageContext', 'deletePiece', 'Invalid PieceCID provided')
     }
 
-    const dataSetData = await SP.getDataSet({
-      serviceURL: this._pdpEndpoint,
+    const pieceIds = await PDPVerifier.findPieceIdsByCid(this._client, {
       dataSetId: this.dataSetId,
+      pieceCid: parsedPieceCID,
+      startPieceId: 0n,
+      limit: 1n,
     })
-    const pieceData = dataSetData.pieces.find((piece) => piece.pieceCid.toString() === parsedPieceCID.toString())
-    if (pieceData == null) {
+    if (pieceIds.length === 0) {
       throw createError('StorageContext', 'deletePiece', 'Piece not found in data set')
     }
-    return pieceData.pieceId
+    return pieceIds[0]
   }
 
   /**
@@ -1108,9 +1109,12 @@ export class StorageContext {
     }
 
     // Run multiple operations in parallel for better performance
-    const [activePieces, nextChallengeEpoch, currentEpoch, pdpConfig, providerInfo] = await Promise.all([
-      PDPVerifier.getActivePieces(this._client, {
+    const [pieceIds, nextChallengeEpoch, currentEpoch, pdpConfig, providerInfo] = await Promise.all([
+      PDPVerifier.findPieceIdsByCid(this._client, {
         dataSetId: this.dataSetId,
+        pieceCid: parsedPieceCID,
+        startPieceId: 0n,
+        limit: 1n,
       }),
       PDPVerifier.getNextChallengeEpoch(this._client, {
         dataSetId: this.dataSetId,
@@ -1123,14 +1127,13 @@ export class StorageContext {
       this.getProviderInfo().catch(() => null),
     ])
 
-    const pieceData = activePieces.pieces.find((piece) => piece.cid.equals(parsedPieceCID))
-    if (pieceData === undefined) {
+    if (pieceIds.length === 0) {
       return null
     }
+    const pieceId = pieceIds[0]
 
     // Initialize return values
     let retrievalUrl: string | null = null
-    let pieceId: bigint | undefined
     let lastProven: Date | null = null
     let nextProofDue: Date | null = null
     let inChallengeWindow = false
@@ -1147,8 +1150,6 @@ export class StorageContext {
 
     // Process proof timing data if we have data set data and PDP config
     if (pdpConfig != null) {
-      pieceId = pieceData.id
-
       // Calculate timing based on nextChallengeEpoch
       if (nextChallengeEpoch > 0n) {
         // nextChallengeEpoch is when the challenge window STARTS, not ends!

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -1415,6 +1415,10 @@ describe('StorageService', () => {
       server.use(
         Mocks.JSONRPC({
           ...Mocks.presets.basic,
+          pdpVerifier: {
+            ...Mocks.presets.basic.pdpVerifier,
+            findPieceIdsByCid: () => [[]],
+          },
         })
       )
       const synapse = new Synapse({ client, source: null })


### PR DESCRIPTION
Closes #667

## Summary

Replaces expensive full-piece-list fetches with the new `PDPVerifier.findPieceIdsByCid` contract method for direct CID→ID lookups.

## Changes

### synapse-core
- **New**: `findPieceIdsByCid` + `findPieceIdsByCidCall` in `pdp-verifier/`
- **Mocks**: Added `findPieceIdsByCid` handler and default preset

### synapse-sdk
- **`pieceStatus()`**: Replaced `getActivePieces()` + `.find()` with single `findPieceIdsByCid()` call
- **`_getPieceIdByCID()`**: Replaced SP API `getDataSet()` + `.find()` with `findPieceIdsByCid()` call

### Tests
- New unit tests for `findPieceIdsByCid` call builder and mocked RPC
- Updated `pieceStatus` test for "piece not found" scenario

## Why

Previously `pieceStatus()` fetched **all** active pieces then searched linearly — O(n) and potentially fails on large datasets. Now it's a single targeted contract call.
