### PR TITLE
fix: fix out of gas problems with `getClientDataSets` 

### DIFF
--- a/packages/synapse-core/package.json
+++ b/packages/synapse-core/package.json
@@ -236,6 +236,7 @@
     "multiformats": "^13.4.1",
     "ox": "catalog:",
     "p-locate": "^7.0.0",
+    "p-queue": "^9.1.2",
     "p-some": "^7.0.0",
     "zod": "catalog:"
   },

--- a/packages/synapse-core/src/warm-storage/get-client-data-sets.ts
+++ b/packages/synapse-core/src/warm-storage/get-client-data-sets.ts
@@ -71,17 +71,111 @@ export async function getClientDataSets(
   client: Client<Transport, Chain>,
   options: getClientDataSets.OptionsType
 ): Promise<getClientDataSets.OutputType> {
-  const data = await readContract(
-    client,
-    getClientDataSetsCall({
-      chain: client.chain,
-      address: options.address,
-      offset: options.offset,
-      limit: options.limit,
-      contractAddress: options.contractAddress,
-    })
-  )
-  return data as getClientDataSets.OutputType
+  const limit = options.limit ?? 100n
+  let offset = options.offset ?? 0n
+  let needsMore = true
+  const dataSets: getClientDataSets.OutputType = []
+
+  while (needsMore) {
+    const data = await readContract(
+      client,
+      getClientDataSetsCall({
+        chain: client.chain,
+        address: options.address,
+        offset,
+        limit,
+        contractAddress: options.contractAddress,
+      })
+    )
+
+    for (const dataSet of data) {
+      if (dataSets.length < limit) {
+        dataSets.push(dataSet)
+      } else {
+        needsMore = false
+        break
+      }
+    }
+    if (data.length < limit) {
+      needsMore = false
+    }
+    offset += limit
+  }
+  return dataSets
+}
+
+export namespace getClientDataSetsIterable {
+  export type OptionsType = {
+    /** Client address to fetch data sets for. */
+    address: Address
+    /** Starting index (0-based). Use `0` to start from the beginning. Defaults to `0n`. */
+    offset?: bigint
+    /** Batch size for each pagination call. Defaults to `100n`. */
+    batchSize?: bigint
+    /** Warm storage contract address. If not provided, the default is the storage view contract address for the chain. */
+    contractAddress?: Address
+  }
+
+  export type OutputType = AsyncGenerator<DataSetInfo>
+
+  export type ErrorType = asChain.ErrorType | ReadContractErrorType
+}
+
+/**
+ * Get client data sets iterable
+ *
+ * @param client - The client to use to get data sets for a client address.
+ * @param options - {@link getClientDataSetsIterable.OptionsType}
+ * @returns Async generator of data set info entries {@link getClientDataSetsIterable.OutputType}
+ * @throws Errors {@link getClientDataSetsIterable.ErrorType}
+ *
+ * @example
+ * ```ts
+ * import { getClientDataSetsIterable } from '@filoz/synapse-core/warm-storage'
+ * import { createPublicClient, http } from 'viem'
+ * import { calibration } from '@filoz/synapse-core/chains'
+ *
+ * const client = createPublicClient({
+ *   chain: calibration,
+ *   transport: http(),
+ * })
+ *
+ * const dataSets = await getClientDataSetsIterable(client, {
+ *   address: '0x0000000000000000000000000000000000000000',
+ * })
+ *
+ * for await (const dataSet of dataSets) {
+ *   console.log(dataSet.dataSetId)
+ * }
+ * ```
+ */
+export async function* getClientDataSetsIterable(
+  client: Client<Transport, Chain>,
+  options: getClientDataSetsIterable.OptionsType
+): getClientDataSetsIterable.OutputType {
+  const batchSize = options.batchSize ?? 100n
+  let offset = options.offset ?? 0n
+  let hasMore = true
+
+  while (hasMore) {
+    const data = await readContract(
+      client,
+      getClientDataSetsCall({
+        chain: client.chain,
+        address: options.address,
+        offset,
+        limit: batchSize,
+        contractAddress: options.contractAddress,
+      })
+    )
+    for (const dataSet of data) {
+      yield dataSet
+    }
+    if (data.length < batchSize) {
+      hasMore = false
+    }
+    offset += batchSize
+  }
 }
 
 export namespace getClientDataSetsCall {

--- a/packages/synapse-core/src/warm-storage/get-pdp-data-sets.ts
+++ b/packages/synapse-core/src/warm-storage/get-pdp-data-sets.ts
@@ -1,6 +1,8 @@
+import PQueue from 'p-queue'
 import type { Chain, Client, ReadContractErrorType, Transport } from 'viem'
 import type { asChain } from '../chains.ts'
-import { getClientDataSets } from './get-client-data-sets.ts'
+
+import { type getClientDataSets, getClientDataSetsIterable } from './get-client-data-sets.ts'
 import { readPdpDataSetInfo } from './get-pdp-data-set.ts'
 import type { PdpDataSet } from './types.ts'
 
@@ -43,18 +45,41 @@ export async function getPdpDataSets(
   client: Client<Transport, Chain>,
   options: getPdpDataSets.OptionsType
 ): Promise<getPdpDataSets.OutputType> {
-  const data = await getClientDataSets(client, options)
-
-  const promises = data.map(async (dataSet) => {
-    const pdDataSetInfo = await readPdpDataSetInfo(client, {
-      dataSetInfo: dataSet,
-      providerId: dataSet.providerId,
-    })
-
-    return {
-      ...dataSet,
-      ...pdDataSetInfo,
-    }
+  const queue = new PQueue({
+    concurrency: 10,
+    interval: 1000,
+    intervalCap: 20,
+    strict: true, // sliding window
   })
-  return Promise.all(promises)
+
+  const dataSets: PdpDataSet[] = []
+
+  try {
+    for await (const dataSet of getClientDataSetsIterable(client, {
+      address: options.address,
+      offset: options.offset,
+    })) {
+      await queue.onSizeLessThan(20)
+
+      queue
+        .add(async () => {
+          const pdDataSetInfo = await readPdpDataSetInfo(client, {
+            dataSetInfo: dataSet,
+            providerId: dataSet.providerId,
+          })
+          dataSets.push({
+            ...dataSet,
+            ...pdDataSetInfo,
+          })
+        })
+        .catch(() => {
+          /* ignore */
+        })
+    }
+    await Promise.race([queue.onError(), queue.onIdle()])
+    return dataSets
+  } catch (error) {
+    queue.pause()
+    throw error
+  }
 }

--- a/packages/synapse-sdk/src/test/metadata-selection.test.ts
+++ b/packages/synapse-sdk/src/test/metadata-selection.test.ts
@@ -4,7 +4,7 @@ import { calibration } from '@filoz/synapse-core/chains'
 import * as Mocks from '@filoz/synapse-core/mocks'
 import { assert } from 'chai'
 import { setup } from 'iso-web/msw'
-import { createWalletClient, http as viemHttp, zeroAddress } from 'viem'
+import { createWalletClient, http as viemHttp } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { METADATA_KEYS } from '../utils/constants.ts'
 import { WarmStorageService } from '../warm-storage/index.ts'
@@ -31,82 +31,53 @@ describe('Metadata-based Data Set Selection', () => {
         ...Mocks.presets.basic,
         warmStorageView: {
           ...Mocks.presets.basic.warmStorageView,
-          clientDataSets: () => [[1n, 2n, 3n]],
-          // Provide base dataset info per dataset id
-          getDataSet: (args: any) => {
-            const [dataSetId] = args as [bigint]
-            if (dataSetId === 1n) {
-              return [
-                {
-                  pdpRailId: 1n,
-                  cacheMissRailId: 0n,
-                  cdnRailId: 0n,
-                  payer: Mocks.ADDRESSES.client1,
-                  payee: Mocks.ADDRESSES.serviceProvider1,
-                  serviceProvider: Mocks.ADDRESSES.serviceProvider1,
-                  commissionBps: 100n,
-                  clientDataSetId: 0n,
-                  pdpEndEpoch: 0n,
-                  providerId: 1n,
-                  cdnEndEpoch: 0n,
-                  dataSetId,
-                },
-              ]
-            }
-            if (dataSetId === 2n) {
-              return [
-                {
-                  pdpRailId: 2n,
-                  cacheMissRailId: 0n,
-                  cdnRailId: 100n,
-                  payer: Mocks.ADDRESSES.client1,
-                  payee: Mocks.ADDRESSES.serviceProvider1,
-                  serviceProvider: Mocks.ADDRESSES.serviceProvider1,
-                  commissionBps: 100n,
-                  clientDataSetId: 1n,
-                  pdpEndEpoch: 0n,
-                  providerId: 1n,
-                  cdnEndEpoch: 0n,
-                  dataSetId,
-                },
-              ]
-            }
-            if (dataSetId === 3n) {
-              return [
-                {
-                  pdpRailId: 3n,
-                  cacheMissRailId: 0n,
-                  cdnRailId: 0n,
-                  payer: Mocks.ADDRESSES.client1,
-                  payee: Mocks.ADDRESSES.serviceProvider2,
-                  serviceProvider: Mocks.ADDRESSES.serviceProvider2,
-                  commissionBps: 100n,
-                  clientDataSetId: 2n,
-                  pdpEndEpoch: 0n,
-                  providerId: 2n,
-                  cdnEndEpoch: 0n,
-                  dataSetId,
-                },
-              ]
-            }
-            // default empty/non-existent
-            return [
+          getClientDataSets: () => [
+            [
               {
-                pdpRailId: 0n,
+                pdpRailId: 1n,
                 cacheMissRailId: 0n,
                 cdnRailId: 0n,
-                payer: zeroAddress,
-                payee: zeroAddress,
-                serviceProvider: zeroAddress,
-                commissionBps: 0n,
+                payer: Mocks.ADDRESSES.client1,
+                payee: Mocks.ADDRESSES.serviceProvider1,
+                serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                commissionBps: 100n,
                 clientDataSetId: 0n,
                 pdpEndEpoch: 0n,
-                providerId: 0n,
+                providerId: 1n,
                 cdnEndEpoch: 0n,
-                dataSetId,
+                dataSetId: 1n,
               },
-            ]
-          },
+              {
+                pdpRailId: 2n,
+                cacheMissRailId: 0n,
+                cdnRailId: 100n,
+                payer: Mocks.ADDRESSES.client1,
+                payee: Mocks.ADDRESSES.serviceProvider1,
+                serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                commissionBps: 100n,
+                clientDataSetId: 1n,
+                pdpEndEpoch: 0n,
+                providerId: 1n,
+                cdnEndEpoch: 0n,
+                dataSetId: 2n,
+              },
+              {
+                pdpRailId: 3n,
+                cacheMissRailId: 0n,
+                cdnRailId: 0n,
+                payer: Mocks.ADDRESSES.client1,
+                payee: Mocks.ADDRESSES.serviceProvider2,
+                serviceProvider: Mocks.ADDRESSES.serviceProvider2,
+                commissionBps: 100n,
+                clientDataSetId: 2n,
+                pdpEndEpoch: 0n,
+                providerId: 2n,
+                cdnEndEpoch: 0n,
+                dataSetId: 3n,
+              },
+            ],
+          ],
+
           getAllDataSetMetadata: (args: any) => {
             const [dataSetId] = args
             if (dataSetId === 1n) {
@@ -122,16 +93,6 @@ describe('Metadata-based Data Set Selection', () => {
               return [[METADATA_KEYS.WITH_IPFS_INDEXING], ['']]
             }
             return [[], []]
-          },
-        },
-        pdpVerifier: {
-          ...Mocks.presets.basic.pdpVerifier,
-          getNextPieceId: (args: any) => {
-            const [dataSetId] = args
-            if (dataSetId === 1n) return [5n] as const // Has pieces
-            if (dataSetId === 2n) return [0n] as const // Empty
-            if (dataSetId === 3n) return [2n] as const // Has pieces
-            return [0n] as const
           },
         },
       }

--- a/packages/synapse-sdk/src/test/warm-storage-service.test.ts
+++ b/packages/synapse-sdk/src/test/warm-storage-service.test.ts
@@ -411,20 +411,22 @@ describe('WarmStorageService', () => {
             ...Mocks.presets.basic.warmStorageView,
             getClientDataSetsLength: () => [1n],
             clientDataSets: () => [[242n]],
-            getDataSet: () => [
-              {
-                pdpRailId: 48n,
-                cacheMissRailId: 0n,
-                cdnRailId: 0n,
-                payer: Mocks.ADDRESSES.client1,
-                payee: Mocks.ADDRESSES.payee1,
-                serviceProvider: Mocks.ADDRESSES.serviceProvider1,
-                commissionBps: 100n,
-                clientDataSetId: 0n,
-                pdpEndEpoch: 0n,
-                providerId: 1n,
-                dataSetId: 242n,
-              },
+            getClientDataSets: () => [
+              [
+                {
+                  pdpRailId: 48n,
+                  cacheMissRailId: 0n,
+                  cdnRailId: 0n,
+                  payer: Mocks.ADDRESSES.client1,
+                  payee: Mocks.ADDRESSES.payee1,
+                  serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                  commissionBps: 100n,
+                  clientDataSetId: 0n,
+                  pdpEndEpoch: 0n,
+                  providerId: 1n,
+                  dataSetId: 242n,
+                },
+              ],
             ],
           },
           pdpVerifier: {
@@ -456,10 +458,9 @@ describe('WarmStorageService', () => {
             ...Mocks.presets.basic.warmStorageView,
             getClientDataSetsLength: () => [2n],
             clientDataSets: () => [[242n, 243n]],
-            getDataSet: (args) => {
-              const [dataSetId] = args
-              if (dataSetId === 242n) {
-                return [
+            getClientDataSets: (args) => {
+              return [
+                [
                   {
                     pdpRailId: 48n,
                     cacheMissRailId: 0n,
@@ -473,9 +474,6 @@ describe('WarmStorageService', () => {
                     providerId: 1n,
                     dataSetId: 242n,
                   },
-                ]
-              } else {
-                return [
                   {
                     pdpRailId: 49n,
                     cacheMissRailId: 0n,
@@ -489,8 +487,8 @@ describe('WarmStorageService', () => {
                     providerId: 2n,
                     dataSetId: 243n,
                   },
-                ]
-              }
+                ],
+              ]
             },
           },
           pdpVerifier: {
@@ -534,20 +532,22 @@ describe('WarmStorageService', () => {
             ...Mocks.presets.basic.warmStorageView,
             getClientDataSetsLength: () => [1n],
             clientDataSets: () => [[242n]],
-            getDataSet: () => [
-              {
-                pdpRailId: 48n,
-                cacheMissRailId: 50n,
-                cdnRailId: 51n, // CDN rail exists
-                payer: Mocks.ADDRESSES.client1,
-                payee: Mocks.ADDRESSES.payee1,
-                serviceProvider: Mocks.ADDRESSES.serviceProvider1,
-                commissionBps: 100n,
-                clientDataSetId: 0n,
-                pdpEndEpoch: 0n,
-                providerId: 1n,
-                dataSetId: 242n,
-              },
+            getClientDataSets: () => [
+              [
+                {
+                  pdpRailId: 48n,
+                  cacheMissRailId: 50n,
+                  cdnRailId: 51n, // CDN rail exists
+                  payer: Mocks.ADDRESSES.client1,
+                  payee: Mocks.ADDRESSES.payee1,
+                  serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                  commissionBps: 100n,
+                  clientDataSetId: 0n,
+                  pdpEndEpoch: 0n,
+                  providerId: 1n,
+                  dataSetId: 242n,
+                },
+              ],
             ],
             getAllDataSetMetadata: () => [
               ['withCDN'], // withCDN key present
@@ -580,20 +580,22 @@ describe('WarmStorageService', () => {
             ...Mocks.presets.basic.warmStorageView,
             getClientDataSetsLength: () => [1n],
             clientDataSets: () => [[242n]],
-            getDataSet: () => [
-              {
-                pdpRailId: 48n,
-                cacheMissRailId: 50n,
-                cdnRailId: 51n, // CDN rail still exists
-                payer: Mocks.ADDRESSES.client1,
-                payee: Mocks.ADDRESSES.payee1,
-                serviceProvider: Mocks.ADDRESSES.serviceProvider1,
-                commissionBps: 100n,
-                clientDataSetId: 0n,
-                pdpEndEpoch: 0n,
-                providerId: 1n,
-                dataSetId: 242n,
-              },
+            getClientDataSets: () => [
+              [
+                {
+                  pdpRailId: 48n,
+                  cacheMissRailId: 50n,
+                  cdnRailId: 51n, // CDN rail still exists
+                  payer: Mocks.ADDRESSES.client1,
+                  payee: Mocks.ADDRESSES.payee1,
+                  serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                  commissionBps: 100n,
+                  clientDataSetId: 0n,
+                  pdpEndEpoch: 0n,
+                  providerId: 1n,
+                  dataSetId: 242n,
+                },
+              ],
             ],
             getAllDataSetMetadata: () => [
               [], // No metadata keys - CDN was terminated
@@ -626,7 +628,7 @@ describe('WarmStorageService', () => {
             ...Mocks.presets.basic.warmStorageView,
             getClientDataSetsLength: () => [1n],
             clientDataSets: () => [[242n]],
-            getDataSet: () => {
+            getClientDataSets: () => {
               throw new Error('Contract call failed')
             },
           },
@@ -638,7 +640,6 @@ describe('WarmStorageService', () => {
         await warmStorageService.getClientDataSetsWithDetails({ address: Mocks.ADDRESSES.client1 })
         assert.fail('Should have thrown error')
       } catch (error: any) {
-        assert.include(error.message, 'Failed to get details for data set')
         assert.include(error.message, 'Contract call failed')
       }
     })

--- a/packages/synapse-sdk/src/warm-storage/service.ts
+++ b/packages/synapse-sdk/src/warm-storage/service.ts
@@ -118,7 +118,11 @@ export class WarmStorageService {
     offset?: bigint
     limit?: bigint
   }): Promise<getClientDataSets.OutputType> {
-    return getClientDataSets(this._client, options)
+    return getClientDataSets(this._client, {
+      address: options.address,
+      offset: options.offset,
+      limit: options.limit,
+    })
   }
 
   /**
@@ -161,49 +165,25 @@ export class WarmStorageService {
   }): Promise<EnhancedDataSetInfo[]> {
     const { address = this._client.account.address, onlyManaged = false } = options
 
-    // Get total count first
-    const totalDataSets = await this.getClientDataSetsLength({ address })
-    if (totalDataSets === 0n) return []
-
-    // Fetch IDs in chunks to avoid unbounded response size
-    const pageSize = 100n
-    const ids: bigint[] = []
-
-    for (let offset = 0n; offset < totalDataSets; offset += pageSize) {
-      const remaining = totalDataSets - offset
-      const limit = remaining < pageSize ? remaining : pageSize
-      const pageIds = await this.getClientDataSetIds({
-        address,
-        offset,
-        limit,
-      })
-
-      if (pageIds.length === 0) break
-      ids.push(...pageIds)
-    }
-
-    if (ids.length === 0) return []
+    const dataSets = await getClientDataSets(this._client, { address })
 
     // Enhance all in parallel using dataset IDs
-    const enhancedDataSetsPromises = ids.map(async (dataSetId) => {
+    const enhancedDataSetsPromises = dataSets.map(async (dataSet) => {
       try {
-        const base = await this.getDataSet({ dataSetId })
-        if (base == null) return null
-
         const [isLive, listener, metadata] = await multicall(this._client, {
           allowFailure: false,
           contracts: [
             dataSetLiveCall({
               chain: this._client.chain,
-              dataSetId: dataSetId,
+              dataSetId: dataSet.dataSetId,
             }),
             getDataSetListenerCall({
               chain: this._client.chain,
-              dataSetId: dataSetId,
+              dataSetId: dataSet.dataSetId,
             }),
             getAllDataSetMetadataCall({
               chain: this._client.chain,
-              dataSetId: dataSetId,
+              dataSetId: dataSet.dataSetId,
             }),
           ],
         })
@@ -217,20 +197,22 @@ export class WarmStorageService {
         }
 
         // Get active piece count only if the data set is live
-        const activePieceCount = isLive ? await PDPVerifier.getActivePieceCount(this._client, { dataSetId }) : 0n
+        const activePieceCount = isLive
+          ? await PDPVerifier.getActivePieceCount(this._client, { dataSetId: dataSet.dataSetId })
+          : 0n
 
         return {
-          ...base,
-          pdpVerifierDataSetId: dataSetId,
+          ...dataSet,
+          pdpVerifierDataSetId: dataSet.dataSetId,
           activePieceCount,
           isLive,
           isManaged,
-          withCDN: base.cdnRailId > 0 && metadata[0].includes(METADATA_KEYS.WITH_CDN),
+          withCDN: dataSet.cdnRailId > 0 && metadata[0].includes(METADATA_KEYS.WITH_CDN),
           metadata: metadataArrayToObject(metadata),
         }
       } catch (error) {
         throw new Error(
-          `Failed to get details for data set ${dataSetId}: ${error instanceof Error ? error.message : String(error)}`
+          `Failed to get details for data set ${dataSet.dataSetId}: ${error instanceof Error ? error.message : String(error)}`
         )
       }
     })


### PR DESCRIPTION
Should fix https://github.com/filecoin-project/filecoin-pin/issues/362

Adds p-queue to `getPdpDataSets` its should only run into rate limits error now, `getClientDataSetsWithDetails` in the sdk many need to use something like this.


@rvagg the `hasMore` pattern from pdp-verifier would have been better for these methods