### PR TITLE
fix(docs): align contract address keys with chain definitions

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@astrojs/starlight": "^0.38.2",
-    "@hugomrdias/docs": "^0.1.10",
+    "@hugomrdias/docs": "^0.2.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "astro": "^6.0.8",

--- a/docs/src/components/contract-addresses.astro
+++ b/docs/src/components/contract-addresses.astro
@@ -11,8 +11,8 @@ const explorerUrl = chain.blockExplorers?.default?.url ?? ''
 
 const contractNames: Record<string, string> = {
   multicall3: 'Multicall3',
-  storage: 'Warm Storage Service',
-  storageView: 'Warm Storage Service StateView',
+  fwss: 'Warm Storage Service',
+  fwssView: 'Warm Storage Service StateView',
   pdp: 'PDPVerifier',
   payments: 'Filecoin Pay',
   usdfc: 'USDFC Token',
@@ -23,8 +23,8 @@ const contractNames: Record<string, string> = {
 
 const contractOrder = [
   'multicall3',
-  'storage',
-  'storageView',
+  'fwss',
+  'fwssView',
   'pdp',
   'payments',
   'usdfc',

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,3 +45,4 @@ trustPolicyExclude:
   - langium@3.3.1
   - reselect@5.1.1
   - astro-mermaid@2.0.1
+  - '@hugomrdias/docs@0.2.0'


### PR DESCRIPTION
#### Summary
- Fix contract addresses table not rendering FWSS rows due to key mismatch with chain definitions
- Bump `@hugomrdias/docs` from `^0.1.10` to `0.2.0` and add to trust policy

Closes #735 

#### Test plan
- [ ] Verify contract addresses table renders FWSS and FWSS StateView rows on calibration and mainnet pages
- [ ] Run `pnpm run build` in `docs/` to confirm no build errors