### PR TITLE
fix: correct error method names in StorageContext._getPieceIdByCID

### DIFF
--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -1045,7 +1045,7 @@ export class StorageContext {
     }
     const parsedPieceCID = Piece.asPieceCID(pieceCid)
     if (parsedPieceCID == null) {
-      throw createError('StorageContext', 'deletePiece', 'Invalid PieceCID provided')
+      throw createError('StorageContext', 'getPieceIdByCID', 'Invalid PieceCID provided')
     }
 
     const pieceIds = await PDPVerifier.findPieceIdsByCid(this._client, {
@@ -1055,7 +1055,7 @@ export class StorageContext {
       limit: 1n,
     })
     if (pieceIds.length === 0) {
-      throw createError('StorageContext', 'deletePiece', 'Piece not found in data set')
+      throw createError('StorageContext', 'getPieceIdByCID', 'Piece not found in data set')
     }
     return pieceIds[0]
   }


### PR DESCRIPTION
## Summary

- Fix incorrect `method` argument passed to `createError` inside `StorageContext._getPieceIdByCID`: two error sites were reporting `deletePiece` even though the failure originated in `_getPieceIdByCID`, making errors misleading when this helper is called from paths other than `deletePiece` (it is also used by `download()` / non-delete flows).
- All three error sites in `_getPieceIdByCID` now consistently report `getPieceIdByCID` as the method name.

Closes #733

## Test plan

- [x] `git diff` confirms only the two affected `createError` calls are updated.
- [ ] CI lint/build/tests pass.