### PR TITLE
fix: normalize network error message

### DIFF
--- a/packages/synapse-core/package.json
+++ b/packages/synapse-core/package.json
@@ -232,7 +232,7 @@
   "dependencies": {
     "@web3-storage/data-segment": "^5.3.0",
     "dnum": "^2.15.0",
-    "iso-web": "^2.2.0",
+    "iso-web": "^2.2.1",
     "multiformats": "^13.4.1",
     "ox": "catalog:",
     "p-locate": "^7.0.0",

--- a/packages/synapse-core/test/pull.test.ts
+++ b/packages/synapse-core/test/pull.test.ts
@@ -134,7 +134,10 @@ describe('Pull', () => {
         await pullPiecesApiRequest(baseOptions())
         assert.fail('Should have thrown error')
       } catch (error) {
-        assert.ok((error as Error).message.includes('Failed to fetch'), 'Error message should mention fetch failure')
+        assert.ok(
+          (error as Error).message.includes('Network request failed'),
+          'Error message should mention fetch failure'
+        )
       }
     })
 

--- a/packages/synapse-sdk/package.json
+++ b/packages/synapse-sdk/package.json
@@ -152,7 +152,7 @@
     "@types/mocha": "catalog:",
     "@types/node": "catalog:",
     "chai": "^6.2.1",
-    "iso-web": "^2.2.0",
+    "iso-web": "^2.2.1",
     "mocha": "catalog:",
     "msw": "catalog:",
     "p-defer": "^4.0.1",


### PR DESCRIPTION
iso-web always throws with `Network request failed` now

closes #737