### PR TITLE
fix: enhance pagination logic and add validation for batch size

### DIFF
--- a/packages/synapse-core/src/warm-storage/get-client-data-sets.ts
+++ b/packages/synapse-core/src/warm-storage/get-client-data-sets.ts
@@ -76,6 +76,9 @@ export async function getClientDataSets(
 ): Promise<getClientDataSets.OutputType> {
   const dataSets: getClientDataSets.OutputType = []
   const limit = options.limit ?? 0n
+  if (limit < 0n) {
+    throw new ValidationError('`limit` must be >= 0n.')
+  }
   let offset = options.offset ?? 0n
   let remaining = limit
 
@@ -184,7 +187,6 @@ export async function* getClientDataSetsIterable(
     }
     if (data.length < batchSize) {
       hasMore = false
-      continue
     }
     offset += batchSize
   }

--- a/packages/synapse-core/src/warm-storage/get-client-data-sets.ts
+++ b/packages/synapse-core/src/warm-storage/get-client-data-sets.ts
@@ -16,7 +16,7 @@ import type { ActionCallChain } from '../types.ts'
 import type { getPdpDataSets } from './get-pdp-data-sets.ts'
 import type { DataSetInfo } from './types.ts'
 
-const GET_CLIENT_DATA_SETS_PAGE_SIZE = 100n
+const DATA_SETS_PAGE_SIZE = 100n
 
 export namespace getClientDataSets {
   export type OptionsType = {
@@ -74,29 +74,13 @@ export async function getClientDataSets(
   client: Client<Transport, Chain>,
   options: getClientDataSets.OptionsType
 ): Promise<getClientDataSets.OutputType> {
-  const limit = options.limit ?? 0n
-  if (limit > 0n && limit <= GET_CLIENT_DATA_SETS_PAGE_SIZE) {
-    return [
-      ...(await readContract(
-        client,
-        getClientDataSetsCall({
-          chain: client.chain,
-          address: options.address,
-          offset: options.offset,
-          limit,
-          contractAddress: options.contractAddress,
-        })
-      )),
-    ]
-  }
-
   const dataSets: getClientDataSets.OutputType = []
+  const limit = options.limit ?? 0n
   let offset = options.offset ?? 0n
   let remaining = limit
 
   while (true) {
-    const pageLimit =
-      remaining === 0n || remaining > GET_CLIENT_DATA_SETS_PAGE_SIZE ? GET_CLIENT_DATA_SETS_PAGE_SIZE : remaining
+    const pageLimit = remaining === 0n || remaining > DATA_SETS_PAGE_SIZE ? DATA_SETS_PAGE_SIZE : remaining
 
     const data = await readContract(
       client,
@@ -177,7 +161,7 @@ export async function* getClientDataSetsIterable(
   client: Client<Transport, Chain>,
   options: getClientDataSetsIterable.OptionsType
 ): getClientDataSetsIterable.OutputType {
-  const batchSize = options.batchSize ?? GET_CLIENT_DATA_SETS_PAGE_SIZE
+  const batchSize = options.batchSize ?? DATA_SETS_PAGE_SIZE
   if (batchSize <= 0n) {
     throw new ValidationError('`batchSize` must be greater than 0n.')
   }

--- a/packages/synapse-core/src/warm-storage/get-client-data-sets.ts
+++ b/packages/synapse-core/src/warm-storage/get-client-data-sets.ts
@@ -11,9 +11,12 @@ import type {
 import { readContract } from 'viem/actions'
 import type { fwssView as storageViewAbi } from '../abis/index.ts'
 import { asChain } from '../chains.ts'
+import { ValidationError } from '../errors/base.ts'
 import type { ActionCallChain } from '../types.ts'
 import type { getPdpDataSets } from './get-pdp-data-sets.ts'
 import type { DataSetInfo } from './types.ts'
+
+const GET_CLIENT_DATA_SETS_PAGE_SIZE = 100n
 
 export namespace getClientDataSets {
   export type OptionsType = {
@@ -71,36 +74,57 @@ export async function getClientDataSets(
   client: Client<Transport, Chain>,
   options: getClientDataSets.OptionsType
 ): Promise<getClientDataSets.OutputType> {
-  const limit = options.limit ?? 100n
-  let offset = options.offset ?? 0n
-  let needsMore = true
-  const dataSets: getClientDataSets.OutputType = []
+  const limit = options.limit ?? 0n
+  if (limit > 0n && limit <= GET_CLIENT_DATA_SETS_PAGE_SIZE) {
+    return [
+      ...(await readContract(
+        client,
+        getClientDataSetsCall({
+          chain: client.chain,
+          address: options.address,
+          offset: options.offset,
+          limit,
+          contractAddress: options.contractAddress,
+        })
+      )),
+    ]
+  }
 
-  while (needsMore) {
+  const dataSets: getClientDataSets.OutputType = []
+  let offset = options.offset ?? 0n
+  let remaining = limit
+
+  while (true) {
+    const pageLimit =
+      remaining === 0n || remaining > GET_CLIENT_DATA_SETS_PAGE_SIZE ? GET_CLIENT_DATA_SETS_PAGE_SIZE : remaining
+
     const data = await readContract(
       client,
       getClientDataSetsCall({
         chain: client.chain,
         address: options.address,
         offset,
-        limit,
+        limit: pageLimit,
         contractAddress: options.contractAddress,
       })
     )
 
-    for (const dataSet of data) {
-      if (dataSets.length < limit) {
-        dataSets.push(dataSet)
-      } else {
-        needsMore = false
+    dataSets.push(...data)
+
+    const pageLength = BigInt(data.length)
+    if (pageLength < pageLimit) {
+      break
+    }
+
+    offset += pageLength
+    if (remaining > 0n) {
+      remaining -= pageLength
+      if (remaining === 0n) {
         break
       }
     }
-    if (data.length < limit) {
-      needsMore = false
-    }
-    offset += limit
   }
+
   return dataSets
 }
 
@@ -110,7 +134,7 @@ export namespace getClientDataSetsIterable {
     address: Address
     /** Starting index (0-based). Use `0` to start from the beginning. Defaults to `0n`. */
     offset?: bigint
-    /** Batch size for each pagination call. Defaults to `100n`. */
+    /** Batch size for each pagination call. Must be greater than `0n`. Defaults to `100n`. */
     batchSize?: bigint
     /** Warm storage contract address. If not provided, the default is the storage view contract address for the chain. */
     contractAddress?: Address
@@ -118,7 +142,7 @@ export namespace getClientDataSetsIterable {
 
   export type OutputType = AsyncGenerator<DataSetInfo>
 
-  export type ErrorType = asChain.ErrorType | ReadContractErrorType
+  export type ErrorType = asChain.ErrorType | ReadContractErrorType | ValidationError
 }
 
 /**
@@ -153,7 +177,10 @@ export async function* getClientDataSetsIterable(
   client: Client<Transport, Chain>,
   options: getClientDataSetsIterable.OptionsType
 ): getClientDataSetsIterable.OutputType {
-  const batchSize = options.batchSize ?? 100n
+  const batchSize = options.batchSize ?? GET_CLIENT_DATA_SETS_PAGE_SIZE
+  if (batchSize <= 0n) {
+    throw new ValidationError('`batchSize` must be greater than 0n.')
+  }
   let offset = options.offset ?? 0n
   let hasMore = true
 
@@ -173,6 +200,7 @@ export async function* getClientDataSetsIterable(
     }
     if (data.length < batchSize) {
       hasMore = false
+      continue
     }
     offset += batchSize
   }

--- a/packages/synapse-core/test/get-client-data-sets.test.ts
+++ b/packages/synapse-core/test/get-client-data-sets.test.ts
@@ -3,7 +3,11 @@ import { setup } from 'iso-web/msw'
 import { createPublicClient, http } from 'viem'
 import { calibration, mainnet } from '../src/chains.ts'
 import { ADDRESSES, JSONRPC, presets } from '../src/mocks/jsonrpc/index.ts'
-import { getClientDataSets, getClientDataSetsCall } from '../src/warm-storage/get-client-data-sets.ts'
+import {
+  getClientDataSets,
+  getClientDataSetsCall,
+  getClientDataSetsIterable,
+} from '../src/warm-storage/get-client-data-sets.ts'
 
 describe('getClientDataSets', () => {
   const server = setup()
@@ -134,5 +138,189 @@ describe('getClientDataSets', () => {
       assert.equal(typeof first.payer, 'string')
       assert.equal(typeof first.payee, 'string')
     })
+
+    it('should return all remaining data sets when limit is 0n', async () => {
+      const expectedDataSets = Array.from({ length: 150 }, (_, index) => makeDataSet(BigInt(index + 1)))
+      const calls: Array<[string, bigint, bigint]> = []
+
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          warmStorageView: {
+            ...presets.basic.warmStorageView,
+            getClientDataSets: (args) => {
+              const [address, offset = 0n, limit = 0n] = args
+              calls.push([address, offset, limit])
+              if (offset === 0n && limit === 100n) {
+                return [expectedDataSets.slice(0, 100)]
+              }
+
+              if (offset === 100n && limit === 100n) {
+                return [expectedDataSets.slice(100)]
+              }
+
+              return [[]]
+            },
+          },
+        })
+      )
+
+      const client = createPublicClient({
+        chain: calibration,
+        transport: http(),
+      })
+
+      const dataSets = await getClientDataSets(client, {
+        address: ADDRESSES.client1,
+        limit: 0n,
+      })
+
+      assert.deepEqual(dataSets, expectedDataSets)
+      assert.deepEqual(calls, [
+        [ADDRESSES.client1, 0n, 100n],
+        [ADDRESSES.client1, 100n, 100n],
+      ])
+    })
+
+    it('should paginate when limit is greater than 100n', async () => {
+      const expectedDataSets = Array.from({ length: 150 }, (_, index) => makeDataSet(BigInt(index + 1)))
+      const calls: Array<[string, bigint, bigint]> = []
+
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          warmStorageView: {
+            ...presets.basic.warmStorageView,
+            getClientDataSets: (args) => {
+              const [address, offset = 0n, limit = 0n] = args
+              calls.push([address, offset, limit])
+
+              if (offset === 0n && limit === 100n) {
+                return [expectedDataSets.slice(0, 100)]
+              }
+
+              if (offset === 100n && limit === 50n) {
+                return [expectedDataSets.slice(100)]
+              }
+
+              return [[]]
+            },
+          },
+        })
+      )
+
+      const client = createPublicClient({
+        chain: calibration,
+        transport: http(),
+      })
+
+      const dataSets = await getClientDataSets(client, {
+        address: ADDRESSES.client1,
+        limit: 150n,
+      })
+
+      assert.deepEqual(dataSets, expectedDataSets)
+      assert.deepEqual(calls, [
+        [ADDRESSES.client1, 0n, 100n],
+        [ADDRESSES.client1, 100n, 50n],
+      ])
+    })
+
+    it('should fetch all data sets with paginated iterable reads', async () => {
+      const expectedDataSets = [makeDataSet(1n), makeDataSet(2n), makeDataSet(3n)]
+      const calls: Array<[string, bigint, bigint]> = []
+
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          warmStorageView: {
+            ...presets.basic.warmStorageView,
+            getClientDataSets: (args) => {
+              const [address, offset = 0n, limit = 0n] = args
+              calls.push([address, offset, limit])
+              assert.equal(limit, 2n)
+
+              if (offset === 0n) {
+                return [expectedDataSets.slice(0, 2)]
+              }
+
+              if (offset === 2n) {
+                return [expectedDataSets.slice(2)]
+              }
+
+              return [[]]
+            },
+          },
+        })
+      )
+
+      const client = createPublicClient({
+        chain: calibration,
+        transport: http(),
+      })
+
+      const dataSets = []
+      for await (const dataSet of getClientDataSetsIterable(client, {
+        address: ADDRESSES.client1,
+        batchSize: 2n,
+      })) {
+        dataSets.push(dataSet)
+      }
+
+      assert.deepEqual(dataSets, expectedDataSets)
+      assert.deepEqual(calls, [
+        [ADDRESSES.client1, 0n, 2n],
+        [ADDRESSES.client1, 2n, 2n],
+      ])
+    })
+
+    it('should reject non-positive iterable batch sizes', async () => {
+      let calls = 0
+
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          warmStorageView: {
+            ...presets.basic.warmStorageView,
+            getClientDataSets: (args) => {
+              calls += 1
+              return presets.basic.warmStorageView?.getClientDataSets?.(args) ?? [[]]
+            },
+          },
+        })
+      )
+
+      const client = createPublicClient({
+        chain: calibration,
+        transport: http(),
+      })
+
+      await assert.rejects(async () => {
+        for await (const _dataSet of getClientDataSetsIterable(client, {
+          address: ADDRESSES.client1,
+          batchSize: 0n,
+        })) {
+          // no-op
+        }
+      }, /`batchSize` must be greater than 0n\./)
+
+      assert.equal(calls, 0)
+    })
   })
 })
+
+function makeDataSet(dataSetId: bigint) {
+  return {
+    pdpRailId: 1n,
+    cacheMissRailId: 0n,
+    cdnRailId: 0n,
+    payer: ADDRESSES.client1,
+    payee: ADDRESSES.serviceProvider1,
+    serviceProvider: ADDRESSES.serviceProvider1,
+    commissionBps: 100n,
+    clientDataSetId: 0n,
+    pdpEndEpoch: 0n,
+    providerId: 1n,
+    dataSetId,
+  }
+}


### PR DESCRIPTION
- Fix anyone not setting a limit would have been capping at 100 data sets
- Updated `getClientDataSets` to handle a limit of 0n, returning all datasets.
- Improved pagination logic to correctly manage offsets and remaining datasets.
- Added validation to ensure `batchSize` in `getClientDataSetsIterable` is greater than 0n.
- Expanded tests to cover new pagination scenarios and validation checks.