### PR TITLE
feat(synapse-core): account runway and epoch conversion utilities

### DIFF
--- a/packages/synapse-core/src/pay/account-debt.ts
+++ b/packages/synapse-core/src/pay/account-debt.ts
@@ -1,11 +1,7 @@
+import type { AccountState } from './types.ts'
+
 export namespace calculateAccountDebt {
-  export type ParamsType = {
-    funds: bigint
-    lockupCurrent: bigint
-    lockupRate: bigint
-    lockupLastSettledAt: bigint
-    currentEpoch: bigint
-  }
+  export type ParamsType = AccountState
 }
 
 /**

--- a/packages/synapse-core/src/pay/get-account-summary.ts
+++ b/packages/synapse-core/src/pay/get-account-summary.ts
@@ -38,8 +38,18 @@ export namespace getAccountSummary {
     /** Rate-based portion of lockup (totalLockup - totalFixedLockup) */
     totalRateBasedLockup: bigint
 
-    /** Epoch at which funds run out at current rate */
+    /**
+     * Absolute epoch at which funds run out at the current lockup rate.
+     * `maxUint256` when `lockupRate` is 0n.
+     */
     fundedUntilEpoch: bigint
+    /**
+     * Number of epochs that can pass from `epoch` before the account runs out
+     * of funds at the current lockup rate — i.e. how long until the user needs
+     * to deposit more funds. `maxUint256` when `lockupRatePerEpoch` is 0n
+     * (no drain), `0n` when the account is already insolvent.
+     */
+    runwayInEpochs: bigint
     /** The epoch used for all calculations */
     epoch: bigint
   }
@@ -76,6 +86,7 @@ export namespace getAccountSummary {
  *
  * console.log('Available:', summary.availableFunds)
  * console.log('Funded until epoch:', summary.fundedUntilEpoch)
+ * console.log('Runway in epochs:', summary.runwayInEpochs)
  * ```
  */
 export async function getAccountSummary(
@@ -99,7 +110,7 @@ export async function getAccountSummary(
     currentEpoch: resolvedEpoch,
   }
 
-  const { fundedUntilEpoch, availableFunds } = resolveAccountState(params)
+  const { fundedUntilEpoch, availableFunds, runwayInEpochs } = resolveAccountState(params)
   const debt = calculateAccountDebt(params)
 
   const totalLockup = accountInfo.funds > availableFunds ? accountInfo.funds - availableFunds : 0n
@@ -119,6 +130,7 @@ export async function getAccountSummary(
     totalRateBasedLockup,
 
     fundedUntilEpoch,
+    runwayInEpochs,
     epoch: resolvedEpoch,
   }
 }

--- a/packages/synapse-core/src/pay/resolve-account-state.ts
+++ b/packages/synapse-core/src/pay/resolve-account-state.ts
@@ -1,28 +1,49 @@
 import { maxUint256 } from 'viem'
+import type { AccountState } from './types.ts'
 
 export namespace resolveAccountState {
-  export type ParamsType = {
-    funds: bigint
-    lockupCurrent: bigint
-    lockupRate: bigint
-    lockupLastSettledAt: bigint
-    currentEpoch: bigint
-  }
+  export type ParamsType = AccountState
 
   export type OutputType = {
+    /**
+     * Absolute epoch at which funds run out at the current lockup rate.
+     * `maxUint256` when `lockupRate` is 0n.
+     */
     fundedUntilEpoch: bigint
+    /** Funds available after accounting for all lockup (fixed + rate) at `currentEpoch`. */
     availableFunds: bigint
+    /**
+     * Number of epochs that can pass from `currentEpoch` before the account
+     * runs out of funds at the current lockup rate — i.e. how long until the
+     * user needs to deposit more funds.
+     *
+     * `maxUint256` when `lockupRate` is 0n (no drain), `0n` when the account
+     * is already insolvent.
+     */
+    runwayInEpochs: bigint
   }
 }
 
 /**
  * Project account state forward to `currentEpoch` by simulating settlement locally.
  *
- * Pure function — no RPC call. Takes raw account fields from `accounts()` + currentEpoch
- * and computes what the account state would be if settlement happened now.
+ * Pure function — no RPC call. Takes raw account fields from `accounts()` +
+ * currentEpoch and computes:
+ *
+ * - `fundedUntilEpoch` — the absolute epoch at which
+ *   `lockupCurrent + lockupRate × elapsed === funds`. Past this point,
+ *   settlement stops advancing and the payer must deposit more funds (or
+ *   have rails terminated) to keep services running.
+ * - `availableFunds` — funds minus all lockup (fixed + rate) at `currentEpoch`.
+ * - `runwayInEpochs` — `fundedUntilEpoch - currentEpoch`, clamped to `0n`
+ *   when insolvent and `maxUint256` when `lockupRate` is 0n.
+ *
+ * Note: `funds` already includes fixed lockup from rails (it's reflected in
+ * `lockupCurrent`), so runway accounts for both fixed lockup and rate-based
+ * lockup automatically.
  *
  * @param params - Raw account fields + current epoch
- * @returns fundedUntilEpoch and availableFunds after simulated settlement
+ * @returns The projected account state {@link resolveAccountState.OutputType}
  */
 export function resolveAccountState(params: resolveAccountState.ParamsType): resolveAccountState.OutputType {
   const { funds, lockupCurrent, lockupRate, lockupLastSettledAt, currentEpoch } = params
@@ -39,8 +60,19 @@ export function resolveAccountState(params: resolveAccountState.ParamsType): res
   const rawAvailable = funds - simulatedLockupCurrent
   const availableFunds = rawAvailable > 0n ? rawAvailable : 0n
 
+  // runwayInEpochs = fundedUntilEpoch - currentEpoch, with edge cases:
+  // - lockupRate === 0n → maxUint256 (already the value of fundedUntilEpoch)
+  // - insolvent (fundedUntilEpoch <= currentEpoch) → 0n
+  const runwayInEpochs =
+    fundedUntilEpoch === maxUint256
+      ? maxUint256
+      : fundedUntilEpoch > currentEpoch
+        ? fundedUntilEpoch - currentEpoch
+        : 0n
+
   return {
     fundedUntilEpoch,
     availableFunds,
+    runwayInEpochs,
   }
 }

--- a/packages/synapse-core/src/pay/resolve-account-state.ts
+++ b/packages/synapse-core/src/pay/resolve-account-state.ts
@@ -13,7 +13,7 @@ export namespace resolveAccountState {
     /** Funds available after accounting for all lockup (fixed + rate) at `currentEpoch`. */
     availableFunds: bigint
     /**
-     * Number of epochs that can pass from `currentEpoch` before the account
+     * Number of epochs that can pass from `currentEpoch` (on the input params) before the account
      * runs out of funds at the current lockup rate — i.e. how long until the
      * user needs to deposit more funds.
      *

--- a/packages/synapse-core/src/pay/types.ts
+++ b/packages/synapse-core/src/pay/types.ts
@@ -9,3 +9,22 @@ export type RailInfo = {
   /** End epoch (0 for active rails, > 0 for terminated rails) */
   endEpoch: bigint
 }
+
+/**
+ * Raw account fields (from `accounts()`) + the current epoch.
+ *
+ * Shared input shape for pure account-state helpers like
+ * {@link resolveAccountState} and {@link calculateAccountDebt}.
+ */
+export type AccountState = {
+  /** Total funds deposited by the account (from `accounts()`). */
+  funds: bigint
+  /** Lockup amount at `lockupLastSettledAt` (fixed lockup + rate lockup accrued so far). */
+  lockupCurrent: bigint
+  /** Aggregate per-epoch lockup rate across all active rails. */
+  lockupRate: bigint
+  /** Epoch when lockup was last settled. */
+  lockupLastSettledAt: bigint
+  /** Current epoch (block number on Filecoin). */
+  currentEpoch: bigint
+}

--- a/packages/synapse-core/src/utils/constants.ts
+++ b/packages/synapse-core/src/utils/constants.ts
@@ -8,6 +8,11 @@ export const TIME_CONSTANTS = {
   EPOCH_DURATION: 30,
 
   /**
+   * Number of epochs in an hour (60 minutes * 2 epochs per minute)
+   */
+  EPOCHS_PER_HOUR: 120n,
+
+  /**
    * Number of epochs in a day (24 hours * 60 minutes * 2 epochs per minute)
    */
   EPOCHS_PER_DAY: 2880n,

--- a/packages/synapse-core/src/utils/epoch.ts
+++ b/packages/synapse-core/src/utils/epoch.ts
@@ -2,6 +2,7 @@
  * Epoch to date conversion utilities for Filecoin networks
  */
 
+import { maxUint256 } from 'viem'
 import { TIME_CONSTANTS } from './constants.ts'
 
 /**
@@ -55,6 +56,56 @@ export function timeUntilEpoch(
     hours: seconds / 3600,
     days: seconds / 86400,
   }
+}
+
+/**
+ * Convert a number of epochs to whole hours (floor division).
+ *
+ * Each Filecoin epoch is 30 seconds, so 120 epochs = 1 hour.
+ *
+ * Passes `maxUint256` through unchanged so callers can use it as an
+ * "infinite" sentinel (e.g. `resolveAccountState().runwayInEpochs` when
+ * `lockupRate` is 0n).
+ *
+ * @param epochs - The number of epochs to convert
+ * @returns The number of whole hours
+ *
+ * @example
+ * ```ts
+ * import { epochsToHours } from '@filoz/synapse-core/utils'
+ *
+ * epochsToHours(240n)   // 2n
+ * epochsToHours(2880n)  // 24n
+ * ```
+ */
+export function epochsToHours(epochs: bigint): bigint {
+  if (epochs === maxUint256) return maxUint256
+  return epochs / TIME_CONSTANTS.EPOCHS_PER_HOUR
+}
+
+/**
+ * Convert a number of epochs to whole days (floor division).
+ *
+ * Each Filecoin epoch is 30 seconds, so 2880 epochs = 1 day.
+ *
+ * Passes `maxUint256` through unchanged so callers can use it as an
+ * "infinite" sentinel (e.g. `resolveAccountState().runwayInEpochs` when
+ * `lockupRate` is 0n).
+ *
+ * @param epochs - The number of epochs to convert
+ * @returns The number of whole days
+ *
+ * @example
+ * ```ts
+ * import { epochsToDays } from '@filoz/synapse-core/utils'
+ *
+ * epochsToDays(2880n)  // 1n
+ * epochsToDays(8640n)  // 3n
+ * ```
+ */
+export function epochsToDays(epochs: bigint): bigint {
+  if (epochs === maxUint256) return maxUint256
+  return epochs / TIME_CONSTANTS.EPOCHS_PER_DAY
 }
 
 /**

--- a/packages/synapse-core/test/account-debt.test.ts
+++ b/packages/synapse-core/test/account-debt.test.ts
@@ -6,7 +6,7 @@ import { calculateAccountDebt } from '../src/pay/account-debt.ts'
 import { resolveAccountState } from '../src/pay/resolve-account-state.ts'
 
 describe('resolveAccountState', () => {
-  it('healthy account: funds > lockup → correct availableFunds and fundedUntilEpoch', () => {
+  it('healthy account: funds > lockup → correct availableFunds, fundedUntilEpoch, runwayInEpochs', () => {
     const result = resolveAccountState({
       funds: 1000n,
       lockupCurrent: 100n,
@@ -22,9 +22,12 @@ describe('resolveAccountState', () => {
     // simulatedLockupCurrent = 100 + 1 * (100 - 0) = 200
     // availableFunds = max(0, 1000 - 200) = 800
     assert.equal(result.availableFunds, 800n)
+
+    // runwayInEpochs = fundedUntilEpoch - currentEpoch = 900 - 100 = 800
+    assert.equal(result.runwayInEpochs, 800n)
   })
 
-  it('underfunded account: lockup > funds → availableFunds = 0, fundedUntilEpoch < currentEpoch', () => {
+  it('underfunded account: lockup > funds → availableFunds = 0, fundedUntilEpoch < currentEpoch, runway = 0', () => {
     const result = resolveAccountState({
       funds: 100n,
       lockupCurrent: 200n,
@@ -41,6 +44,9 @@ describe('resolveAccountState', () => {
     // simulatedLockupCurrent = 200 + 2 * (950 - 1000) = 200 + (-100) = 100
     // availableFunds = max(0, 100 - 100) = 0
     assert.equal(result.availableFunds, 0n)
+
+    // fundedUntilEpoch < currentEpoch → runway clamped to 0n
+    assert.equal(result.runwayInEpochs, 0n)
   })
 
   it('partially funded account: funds > lockupCurrent but runs out before currentEpoch', () => {
@@ -60,9 +66,12 @@ describe('resolveAccountState', () => {
     // simulatedLockupCurrent = 50 + 1 * (50 - 0) = 100
     // availableFunds = max(0, 100 - 100) = 0
     assert.equal(result.availableFunds, 0n)
+
+    // ran out 150 epochs ago → runway = 0n
+    assert.equal(result.runwayInEpochs, 0n)
   })
 
-  it('zero lockupRate → fundedUntilEpoch = maxUint256', () => {
+  it('zero lockupRate → fundedUntilEpoch = maxUint256, runway = maxUint256', () => {
     const result = resolveAccountState({
       funds: 1000n,
       lockupCurrent: 100n,
@@ -77,6 +86,108 @@ describe('resolveAccountState', () => {
     // simulatedLockupCurrent = 100 + 0 * (100 - 0) = 100
     // availableFunds = max(0, 1000 - 100) = 900
     assert.equal(result.availableFunds, 900n)
+
+    // zero rate → infinite runway
+    assert.equal(result.runwayInEpochs, maxUint256)
+  })
+
+  it('zero lockupRate with zero funds → runway = maxUint256 (no drain)', () => {
+    const result = resolveAccountState({
+      funds: 0n,
+      lockupCurrent: 0n,
+      lockupRate: 0n,
+      lockupLastSettledAt: 1_000_000n,
+      currentEpoch: 1_000_000n,
+    })
+
+    assert.equal(result.fundedUntilEpoch, maxUint256)
+    assert.equal(result.availableFunds, 0n)
+    assert.equal(result.runwayInEpochs, maxUint256)
+  })
+
+  it('fundedUntilEpoch exactly equals currentEpoch → runway = 0n', () => {
+    // fundedUntilEpoch = 0 + (1000 - 0) / 10 = 100
+    // currentEpoch = 100 → just hit the funded epoch, no more runway
+    const result = resolveAccountState({
+      funds: 1000n,
+      lockupCurrent: 0n,
+      lockupRate: 10n,
+      lockupLastSettledAt: 0n,
+      currentEpoch: 100n,
+    })
+
+    assert.equal(result.fundedUntilEpoch, 100n)
+    assert.equal(result.runwayInEpochs, 0n)
+  })
+
+  it('fixed lockup implicit in lockupCurrent: held but does not drain', () => {
+    // funds=500, lockupCurrent=100 (all fixed lockup), rate=1, settledAt=1000, currentEpoch=1200
+    // fundedUntilEpoch = 1000 + (500 - 100) / 1 = 1400
+    // simulatedSettledAt = min(1400, 1200) = 1200
+    // simulatedLockupCurrent = 100 + 1 * (1200 - 1000) = 300
+    // availableFunds = max(0, 500 - 300) = 200
+    // runway = 1400 - 1200 = 200
+    const result = resolveAccountState({
+      funds: 500n,
+      lockupCurrent: 100n,
+      lockupRate: 1n,
+      lockupLastSettledAt: 1000n,
+      currentEpoch: 1200n,
+    })
+
+    assert.equal(result.fundedUntilEpoch, 1400n)
+    assert.equal(result.availableFunds, 200n)
+    assert.equal(result.runwayInEpochs, 200n)
+  })
+
+  it('realistic USDFC numbers: 100 USDFC funds, 1 USDFC/day rate', () => {
+    const oneUsdfc = 1_000_000_000_000_000_000n
+    const epochsPerDay = 2880n
+    const ratePerEpoch = oneUsdfc / epochsPerDay
+
+    const result = resolveAccountState({
+      funds: 100n * oneUsdfc,
+      lockupCurrent: 0n,
+      lockupRate: ratePerEpoch,
+      lockupLastSettledAt: 1_000_000n,
+      currentEpoch: 1_000_000n,
+    })
+
+    // ~100 days of runway = 100 * 2880 epochs, with rounding from integer div
+    assert.ok(
+      result.runwayInEpochs > 287_000n && result.runwayInEpochs <= 300_000n,
+      `expected ~288000, got ${result.runwayInEpochs}`
+    )
+  })
+
+  it('truncation: (funds - lockupCurrent) divisible by lockupRate', () => {
+    // funds=10, lockupCurrent=1, lockupRate=3, settledAt=0, currentEpoch=0
+    // fundedUntilEpoch = 0 + (10 - 1) / 3 = 3 (exact)
+    const result = resolveAccountState({
+      funds: 10n,
+      lockupCurrent: 1n,
+      lockupRate: 3n,
+      lockupLastSettledAt: 0n,
+      currentEpoch: 0n,
+    })
+
+    assert.equal(result.fundedUntilEpoch, 3n)
+    assert.equal(result.runwayInEpochs, 3n)
+  })
+
+  it('truncation with remainder: (funds - lockupCurrent) not divisible by lockupRate', () => {
+    // funds=10, lockupCurrent=0, lockupRate=3, settledAt=0, currentEpoch=0
+    // fundedUntilEpoch = 0 + 10 / 3 = 3 (remainder discarded)
+    const result = resolveAccountState({
+      funds: 10n,
+      lockupCurrent: 0n,
+      lockupRate: 3n,
+      lockupLastSettledAt: 0n,
+      currentEpoch: 0n,
+    })
+
+    assert.equal(result.fundedUntilEpoch, 3n)
+    assert.equal(result.runwayInEpochs, 3n)
   })
 })
 

--- a/packages/synapse-core/test/epoch.test.ts
+++ b/packages/synapse-core/test/epoch.test.ts
@@ -1,9 +1,17 @@
 /* globals describe it */
 
 import { assert } from 'chai'
+import { maxUint256 } from 'viem'
 import { calibration, mainnet } from '../src/chains.ts'
 import { TIME_CONSTANTS } from '../src/utils/constants.ts'
-import { calculateLastProofDate, dateToEpoch, epochToDate, timeUntilEpoch } from '../src/utils/epoch.ts'
+import {
+  calculateLastProofDate,
+  dateToEpoch,
+  epochsToDays,
+  epochsToHours,
+  epochToDate,
+  timeUntilEpoch,
+} from '../src/utils/epoch.ts'
 
 describe('Epoch Utilities', () => {
   describe('epochToDate', () => {
@@ -89,6 +97,46 @@ describe('Epoch Utilities', () => {
       assert.equal(result.minutes, -60)
       assert.equal(result.hours, -1)
       assert.equal(result.days, -1 / 24)
+    })
+  })
+
+  describe('epochsToHours', () => {
+    it('should convert exact multiples of EPOCHS_PER_HOUR', () => {
+      assert.equal(epochsToHours(0n), 0n)
+      assert.equal(epochsToHours(TIME_CONSTANTS.EPOCHS_PER_HOUR), 1n)
+      assert.equal(epochsToHours(240n), 2n)
+      assert.equal(epochsToHours(TIME_CONSTANTS.EPOCHS_PER_DAY), 24n)
+    })
+
+    it('should floor non-exact values', () => {
+      // 119 epochs is less than 1 hour
+      assert.equal(epochsToHours(119n), 0n)
+      // 121 epochs is 1 hour + 1 epoch
+      assert.equal(epochsToHours(121n), 1n)
+    })
+
+    it('should pass maxUint256 through unchanged', () => {
+      assert.equal(epochsToHours(maxUint256), maxUint256)
+    })
+  })
+
+  describe('epochsToDays', () => {
+    it('should convert exact multiples of EPOCHS_PER_DAY', () => {
+      assert.equal(epochsToDays(0n), 0n)
+      assert.equal(epochsToDays(TIME_CONSTANTS.EPOCHS_PER_DAY), 1n)
+      assert.equal(epochsToDays(8640n), 3n)
+      assert.equal(epochsToDays(TIME_CONSTANTS.EPOCHS_PER_MONTH), 30n)
+    })
+
+    it('should floor non-exact values', () => {
+      // 2879 epochs is less than 1 day
+      assert.equal(epochsToDays(2879n), 0n)
+      // 2881 epochs is 1 day + 1 epoch
+      assert.equal(epochsToDays(2881n), 1n)
+    })
+
+    it('should pass maxUint256 through unchanged', () => {
+      assert.equal(epochsToDays(maxUint256), maxUint256)
     })
   })
 

--- a/packages/synapse-core/test/get-account-summary.test.ts
+++ b/packages/synapse-core/test/get-account-summary.test.ts
@@ -61,6 +61,7 @@ describe('getAccountSummary', () => {
     assert.equal(result.totalFixedLockup, 0n)
     assert.equal(result.totalRateBasedLockup, 0n)
     assert.equal(result.fundedUntilEpoch, maxUint256)
+    assert.equal(result.runwayInEpochs, maxUint256)
     assert.equal(result.epoch, 1000000n)
   })
 
@@ -125,6 +126,8 @@ describe('getAccountSummary', () => {
     assert.equal(result.totalLockup, funds - result.availableFunds)
     // totalRateBasedLockup = totalLockup - totalFixedLockup
     assert.equal(result.totalRateBasedLockup, result.totalLockup - result.totalFixedLockup)
+    // runwayInEpochs = fundedUntilEpoch - epoch
+    assert.equal(result.runwayInEpochs, result.fundedUntilEpoch - epoch)
   })
 
   it('should show debt when funds are insufficient', async () => {
@@ -158,6 +161,8 @@ describe('getAccountSummary', () => {
     assert.ok(result.debt > 0n, 'should have debt')
     // fundedUntilEpoch should be before current epoch
     assert.ok(result.fundedUntilEpoch < epoch, 'funded until should be in the past')
+    // runway is exhausted when account is insolvent
+    assert.equal(result.runwayInEpochs, 0n)
   })
 
   it('should use provided epoch parameter', async () => {


### PR DESCRIPTION
## Summary

- Surface how long an account can sustain current spending by adding `runwayInEpochs` to `resolveAccountState` and threading it through `getAccountSummary`. Computed from the existing `fundedUntilEpoch`, with `maxUint256` when `lockupRate === 0n` (infinite runway) and `0n` when the account is already insolvent.
- Consolidate the repeated raw-account + current-epoch parameter shape used by the pure helpers into a shared `AccountState` type in `pay/types.ts`, reused by `resolveAccountState` and `calculateAccountDebt`.
- Add `epochsToHours` / `epochsToDays` bigint utilities (floor division) plus `TIME_CONSTANTS.EPOCHS_PER_HOUR` so callers can convert `runwayInEpochs` to human units. Both pass `maxUint256` through unchanged to preserve the infinite-runway sentinel.

## Test plan

- [x] `resolveAccountState` unit tests cover `runwayInEpochs` across healthy, insolvent, zero-rate, fixed-lockup, and truncation cases (migrated from the removed `calculate-account-runway.test.ts`).
- [x] `getAccountSummary` tests assert `runwayInEpochs` in healthy / draining / insolvent scenarios.
- [x] New `epochsToHours` / `epochsToDays` tests cover exact multiples, floor behavior, and `maxUint256` passthrough.
- [x] `biome check` clean on the touched files.