### PR TITLE
feat(synapse-core)!: drop fundedUntilEpoch, add grossCoverageInEpochs

### DIFF
--- a/docs/src/content/docs/cookbooks/payments-and-storage.mdx
+++ b/docs/src/content/docs/cookbooks/payments-and-storage.mdx
@@ -93,17 +93,17 @@ If you're building custom integrations outside the SDK, FWSS approval uses the F
 
 ## Running Low on Funds
 
-Your account has a **runway**: how many epochs until your account enters deficit and the standard payment flow to providers halts. The SDK's account queries return this as `runwayInEpochs` alongside `grossCoverageInEpochs` (the total horizon of your deposit at the current spend rate, including the reserve held against future settlement). See [Storage Costs: Account Queries](/developer-guides/storage/storage-costs/#account-queries) and [Payment Operations: Account Health Monitoring](/developer-guides/payments/payment-operations/#account-health-monitoring) for examples.
+Your account has a **runway**: how many epochs until your account enters deficit and the standard payment flow to providers halts. The SDK exposes this as `runwayInEpochs` alongside `grossCoverageInEpochs` (the full horizon your deposit covers at the current rate, including the lockup reserve). See [Storage Costs: Account Queries](/developer-guides/storage/storage-costs/#account-queries) and [Payment Operations: Account Health Monitoring](/developer-guides/payments/payment-operations/#account-health-monitoring) for examples.
 
-When your runway hits zero, the account becomes **underfunded** (in deficit). This has real consequences:
+When your runway hits zero, the account is **in deficit** and several things change:
 
-- **Uploads fail**: new storage operations require the account to be current on payments, and an underfunded account can't settle to the current epoch
-- **Existing data is at risk**: after the 30-day lockup grace period, providers may remove your data
-- **Deposits must cover the shortfall first**: when you deposit into an underfunded account, part of the deposit goes toward settling outstanding obligations before it can fund new storage
+- **Uploads fail**: new storage operations require the account to be current on payments
+- **Existing rails are at risk**: providers can terminate rails and claim against the lockup for up to one lockup period of payment. Termination is one-way; once a rail has an `endEpoch`, topping up your account won't bring it back. Pieces remain at the provider until they're garbage-collected, so a fresh rail can re-reference them.
+- **Deposits must cover the shortfall first**: depositing into a deficit account first settles outstanding obligations before funding new storage
 
-The SDK handles this automatically: `getUploadCosts()` and `prepare()` account for any outstanding debt when calculating the deposit amount. If your account is underfunded, the deposit will include the shortfall so your upload can proceed.
+The SDK handles the deposit math automatically: `getUploadCosts()` and `prepare()` include any outstanding debt in the deposit amount, so a fresh upload can proceed.
 
-**To avoid interruptions**, keep your account funded well beyond the 30-day lockup window. You can request extra runway when preparing uploads via the `extraRunwayEpochs` parameter.
+**To avoid interruptions**, keep your account funded with headroom beyond the lockup reserve. Use `extraRunwayEpochs` when preparing uploads to add additional buffer.
 
 ## Advanced Details
 

--- a/docs/src/content/docs/cookbooks/payments-and-storage.mdx
+++ b/docs/src/content/docs/cookbooks/payments-and-storage.mdx
@@ -93,9 +93,9 @@ If you're building custom integrations outside the SDK, FWSS approval uses the F
 
 ## Running Low on Funds
 
-Your account has a **funded-until epoch**: the point in time when your balance runs out at the current rate. You can check this via the SDK's account queries (see [Storage Costs: Account Queries](/developer-guides/storage/storage-costs/#account-queries)).
+Your account has a **runway**: how many epochs until your account enters deficit and the standard payment flow to providers halts. The SDK's account queries return this as `runwayInEpochs` alongside `grossCoverageInEpochs` (the total horizon of your deposit at the current spend rate, including the reserve held against future settlement). See [Storage Costs: Account Queries](/developer-guides/storage/storage-costs/#account-queries) and [Payment Operations: Account Health Monitoring](/developer-guides/payments/payment-operations/#account-health-monitoring) for examples.
 
-When your balance runs out, the account becomes **underfunded**. This has real consequences:
+When your runway hits zero, the account becomes **underfunded** (in deficit). This has real consequences:
 
 - **Uploads fail**: new storage operations require the account to be current on payments, and an underfunded account can't settle to the current epoch
 - **Existing data is at risk**: after the 30-day lockup grace period, providers may remove your data

--- a/docs/src/content/docs/developer-guides/payments/payment-operations.mdx
+++ b/docs/src/content/docs/developer-guides/payments/payment-operations.mdx
@@ -80,7 +80,7 @@ This requires two transactions and higher gas costs. Use `depositWithPermit` ins
 
 ### Account Summary
 
-Get a comprehensive snapshot of your account's payment state in a single call. This is the recommended way to check account health — it returns derived values like debt, lockup breakdown, and funded-until epoch.
+Get a comprehensive snapshot of your account's payment state in a single call. This is the recommended way to check account health: it returns derived values like debt, lockup breakdown, and runway.
 
 ```ts twoslash
 // @lib: esnext,dom
@@ -98,8 +98,16 @@ console.log("Rate per month:", formatUnits(summary.lockupRatePerMonth));
 console.log("Total lockup:", formatUnits(summary.totalLockup));
 console.log("  Fixed lockup:", formatUnits(summary.totalFixedLockup));
 console.log("  Rate-based lockup:", formatUnits(summary.totalRateBasedLockup));
-console.log("Funded until epoch:", summary.fundedUntilEpoch);
+console.log("Runway (epochs):", summary.runwayInEpochs);
+console.log("Gross coverage (epochs):", summary.grossCoverageInEpochs);
 ```
+
+`runwayInEpochs` and `grossCoverageInEpochs` answer different questions and generally diverge by roughly the size of the safety reserve:
+
+- **`runwayInEpochs`**: how long until your account enters deficit and the standard payment flow to providers halts. The operational "when must I act?" number. After this point the safety reserve is not automatically spent: it can only be claimed by a provider terminating their rail (which gives them up to one lockup period of guaranteed payment from the deficit point). Providers may keep serving for a while in deficit, but the relationship is at risk.
+- **`grossCoverageInEpochs`**: total spend your deposit covers at the current rate (`funds / lockupRate`). The explanatory "how much have I prepaid?" number. Treats `funds` as a single bucket: it uses the *whole* deposit, including the portion held in reserve, without modeling whether the reserve is actually flowing as ongoing payment.
+
+In a healthy account the gap between them is roughly the lockup period of spend; when in deficit `runwayInEpochs` clamps to `0n` while `grossCoverageInEpochs` still reflects the funds sitting in the account.
 
 ### Account Health Monitoring
 
@@ -111,16 +119,24 @@ import { Synapse } from "@filoz/synapse-sdk";
 import { privateKeyToAccount } from 'viem/accounts'
 const synapse = Synapse.create({ account: privateKeyToAccount('0x...'), source: 'my-app' });
 // ---cut---
-import { TIME_CONSTANTS } from "@filoz/synapse-sdk";
+import { epochsToDays } from "@filoz/synapse-core/utils";
 
 const summary = await synapse.payments.accountSummary();
-const epochsRemaining = summary.availableFunds / summary.lockupRatePerEpoch;
-const daysRemaining =
-  Number(epochsRemaining) / Number(TIME_CONSTANTS.EPOCHS_PER_DAY);
 
-console.log(`Days remaining: ${daysRemaining.toFixed(1)}`);
-if (daysRemaining < 7) console.warn("Low balance!");
+const runwayDays = epochsToDays(summary.runwayInEpochs);
+const totalDays = epochsToDays(summary.grossCoverageInEpochs);
+
+console.log(`Runway: ${runwayDays} days`);
+console.log(`Gross coverage: ${totalDays} days`);
+
+if (runwayDays === 0n && summary.funds > 0n) {
+  console.warn("Account in deficit: standard settlement to providers has halted. Deposit to resume.");
+} else if (runwayDays < 7n) {
+  console.warn("Low runway, top up soon to avoid service interruption.");
+}
 ```
+
+`epochsToDays` floors to whole days and passes `maxUint256` through unchanged (use that as the "infinite" sentinel when the account has no spend rate).
 
 ### Withdrawing Unlocked Funds
 

--- a/docs/src/content/docs/developer-guides/payments/payment-operations.mdx
+++ b/docs/src/content/docs/developer-guides/payments/payment-operations.mdx
@@ -102,12 +102,12 @@ console.log("Runway (epochs):", summary.runwayInEpochs);
 console.log("Gross coverage (epochs):", summary.grossCoverageInEpochs);
 ```
 
-`runwayInEpochs` and `grossCoverageInEpochs` answer different questions and generally diverge by roughly the size of the safety reserve:
+Two runway numbers, differing by the safety reserve:
 
-- **`runwayInEpochs`**: how long until your account enters deficit and the standard payment flow to providers halts. The operational "when must I act?" number. After this point the safety reserve is not automatically spent: it can only be claimed by a provider terminating their rail (which gives them up to one lockup period of guaranteed payment from the deficit point). Providers may keep serving for a while in deficit, but the relationship is at risk.
-- **`grossCoverageInEpochs`**: total spend your deposit covers at the current rate (`funds / lockupRate`). The explanatory "how much have I prepaid?" number. Treats `funds` as a single bucket: it uses the *whole* deposit, including the portion held in reserve, without modeling whether the reserve is actually flowing as ongoing payment.
+- **`runwayInEpochs`**: runway *excluding* the safety reserve. How long until your account enters deficit and the standard payment flow halts. Use for "when must I act?".
+- **`grossCoverageInEpochs`**: runway *including* the safety reserve (`funds / lockupRate`). The full prepaid horizon, treating `funds` as a single bucket. Use for "how much storage have I prepaid in total?".
 
-In a healthy account the gap between them is roughly the lockup period of spend; when in deficit `runwayInEpochs` clamps to `0n` while `grossCoverageInEpochs` still reflects the funds sitting in the account.
+The **safety reserve** (`totalLockup`) is held in your account as a payment guarantee for providers. While you're funded, payments draw from the unreserved portion of `funds` and the reserve sits as a floor. Once you enter deficit (runway hits zero), the reserve is no longer ongoing-payment material: a provider can terminate the rail to claim it as a final settlement window. Termination is one-way: once a rail has an `endEpoch` it's heading to finalization and topping up your account won't revive it. Top up before deficit to keep your existing rails alive.
 
 ### Account Health Monitoring
 

--- a/docs/src/content/docs/developer-guides/payments/payment-operations.mdx
+++ b/docs/src/content/docs/developer-guides/payments/payment-operations.mdx
@@ -102,12 +102,12 @@ console.log("Runway (epochs):", summary.runwayInEpochs);
 console.log("Gross coverage (epochs):", summary.grossCoverageInEpochs);
 ```
 
-Two runway numbers, differing by the safety reserve:
+Two runway numbers, differing by the lockup reserve:
 
-- **`runwayInEpochs`**: runway *excluding* the safety reserve. How long until your account enters deficit and the standard payment flow halts. Use for "when must I act?".
-- **`grossCoverageInEpochs`**: runway *including* the safety reserve (`funds / lockupRate`). The full prepaid horizon, treating `funds` as a single bucket. Use for "how much storage have I prepaid in total?".
+- **`runwayInEpochs`**: runway *excluding* the lockup reserve. How long until your account enters deficit and the standard payment flow halts. Use for "when must I act?".
+- **`grossCoverageInEpochs`**: runway *including* the lockup reserve (`funds / lockupRate`). The full horizon your deposit covers at the current rate. Use for "how much have I prepaid in total?".
 
-The **safety reserve** (`totalLockup`) is held in your account as a payment guarantee for providers. While you're funded, payments draw from the unreserved portion of `funds` and the reserve sits as a floor. Once you enter deficit (runway hits zero), the reserve is no longer ongoing-payment material: a provider can terminate the rail to claim it as a final settlement window. Termination is one-way: once a rail has an `endEpoch` it's heading to finalization and topping up your account won't revive it. Top up before deficit to keep your existing rails alive.
+The **lockup reserve** (`totalLockup`) is the portion of `funds` each rail has set aside under its terms. The funds are locked at the contract level while the rail is active, they can't be withdrawn. Active payments draw from the unreserved portion of `funds`; the reserve sits as a floor. Once you enter deficit, standard settlement halts. A provider can then terminate the rail to claim against the reserve for up to one lockup period. Termination is one-way: once a rail has an `endEpoch` it's heading to finalization and topping up your account won't revive it. Top up before deficit to keep existing rails open.
 
 ### Account Health Monitoring
 

--- a/packages/synapse-core/src/pay/get-account-summary.ts
+++ b/packages/synapse-core/src/pay/get-account-summary.ts
@@ -56,21 +56,17 @@ export namespace getAccountSummary {
      * Epochs from `epoch` until this account enters deficit and the standard
      * payment flow to providers halts. Treat as "when must the user act?".
      *
-     * The account holds a reserve in `totalLockup`, set aside as a payment
-     * guarantee for the providers this account is paying. Each rail
-     * contributes its own piece of the reserve under its own terms (typically
-     * a streaming guarantee tied to that rail's payment period). Active
-     * payments draw from `availableFunds` (`funds - totalLockup`). Once
+     * The account holds a reserve in `totalLockup` that each rail has set
+     * aside under its terms. The funds are locked at the contract level: the
+     * user can't withdraw them while the rail is active. Active payments
+     * draw from `availableFunds` (`funds - totalLockup`). Once
      * `availableFunds` reaches zero, the account is in deficit: standard
-     * settlement of active rails halts and providers stop being paid for
-     * new epochs even though `funds` is still positive. The reserve is not
-     * automatically spent. It becomes claimable only after a provider
-     * terminates the rail (settlement then proceeds up to one `lockupPeriod`
-     * from the last solvent epoch, drawing from the reserve). Termination
-     * is one-way: once a rail has an `endEpoch` it's heading to
-     * finalization and topping up the account won't revive it. Providers
-     * may keep serving briefly in deficit, but the user should top up
-     * before reaching this point to keep existing rails alive.
+     * settlement of active rails halts even though `funds` is still
+     * positive. A provider can then terminate the rail to claim against the
+     * reserve for a final payment window of up to one `lockupPeriod`.
+     * Termination is one-way: once a rail has an `endEpoch` it's heading to
+     * finalization and topping up the account won't revive it. Top up
+     * before deficit to keep existing rails open.
      *
      * - `maxUint256` when `lockupRatePerEpoch` is 0n (nothing is being spent).
      * - `0n` when the account is already past this point (in deficit).

--- a/packages/synapse-core/src/pay/get-account-summary.ts
+++ b/packages/synapse-core/src/pay/get-account-summary.ts
@@ -66,9 +66,11 @@ export namespace getAccountSummary {
      * new epochs even though `funds` is still positive. The reserve is not
      * automatically spent. It becomes claimable only after a provider
      * terminates the rail (settlement then proceeds up to one `lockupPeriod`
-     * from the last solvent epoch, drawing from the reserve). Providers may
-     * keep serving for a while in deficit (their choice), but the
-     * relationship is now at risk and the user should top up promptly.
+     * from the last solvent epoch, drawing from the reserve). Termination
+     * is one-way: once a rail has an `endEpoch` it's heading to
+     * finalization and topping up the account won't revive it. Providers
+     * may keep serving briefly in deficit, but the user should top up
+     * before reaching this point to keep existing rails alive.
      *
      * - `maxUint256` when `lockupRatePerEpoch` is 0n (nothing is being spent).
      * - `0n` when the account is already past this point (in deficit).
@@ -90,7 +92,7 @@ export namespace getAccountSummary {
      *
      * Useful as a complement to `runwayInEpochs` in user-facing displays,
      * e.g. "your deposit covers ~X days of storage in total; you have ~Y
-     * days before you need to top up to keep paying".
+     * days of runway before your account enters deficit".
      *
      * - `maxUint256` when `lockupRatePerEpoch` is 0n (nothing is being
      *   spent; takes precedence over `funds === 0n`).

--- a/packages/synapse-core/src/pay/get-account-summary.ts
+++ b/packages/synapse-core/src/pay/get-account-summary.ts
@@ -19,38 +19,91 @@ export namespace getAccountSummary {
   }
 
   export type OutputType = {
-    /** Total deposited funds in the contract */
+    /** Total deposited funds in the contract. */
     funds: bigint
-    /** Funds available for withdrawal or new commitments */
+    /**
+     * Funds available for withdrawal or new rail commitments at `epoch`.
+     * Equal to `funds - totalLockup`, the *unreserved* portion described on
+     * {@link runwayInEpochs}. Active payments draw from this; once it reaches
+     * zero, settlement halts.
+     */
     availableFunds: bigint
-    /** Outstanding debt (0n if healthy) */
+    /**
+     * Outstanding payment obligation that couldn't be moved into
+     * `lockupCurrent` because `funds` was insufficient. `0n` when the account
+     * is healthy; positive when in deficit. Effectively the gap between the
+     * lockup the account should be holding and what it actually holds.
+     */
     debt: bigint
 
-    /** Per-epoch lockup rate (aggregate across all rails) */
+    /** Per-epoch lockup rate (aggregate across all rails). */
     lockupRatePerEpoch: bigint
-    /** Per-month lockup rate (lockupRatePerEpoch * EPOCHS_PER_MONTH) */
+    /** Per-month lockup rate (`lockupRatePerEpoch * EPOCHS_PER_MONTH`). */
     lockupRatePerMonth: bigint
 
-    /** Total effective lockup at the given epoch (fixed + rate-based) */
+    /** Total effective lockup at `epoch` (fixed + rate-based). */
     totalLockup: bigint
-    /** Sum of lockupFixed across all rails (CDN deposits, etc.) */
+    /**
+     * Sum of `lockupFixed` across all rails. Reserved for one-time payments
+     * rather than streaming rate (e.g. FWSS CDN egress and cache miss
+     * credits).
+     */
     totalFixedLockup: bigint
-    /** Rate-based portion of lockup (totalLockup - totalFixedLockup) */
+    /** Rate-based portion of lockup (`totalLockup - totalFixedLockup`). */
     totalRateBasedLockup: bigint
 
     /**
-     * Absolute epoch at which funds run out at the current lockup rate.
-     * `maxUint256` when `lockupRate` is 0n.
-     */
-    fundedUntilEpoch: bigint
-    /**
-     * Number of epochs that can pass from `epoch` before the account runs out
-     * of funds at the current lockup rate — i.e. how long until the user needs
-     * to deposit more funds. `maxUint256` when `lockupRatePerEpoch` is 0n
-     * (no drain), `0n` when the account is already insolvent.
+     * Epochs from `epoch` until this account enters deficit and the standard
+     * payment flow to providers halts. Treat as "when must the user act?".
+     *
+     * The account holds a reserve in `totalLockup`, set aside as a payment
+     * guarantee for the providers this account is paying. Each rail
+     * contributes its own piece of the reserve under its own terms (typically
+     * a streaming guarantee tied to that rail's payment period). Active
+     * payments draw from `availableFunds` (`funds - totalLockup`). Once
+     * `availableFunds` reaches zero, the account is in deficit: standard
+     * settlement of active rails halts and providers stop being paid for
+     * new epochs even though `funds` is still positive. The reserve is not
+     * automatically spent. It becomes claimable only after a provider
+     * terminates the rail (settlement then proceeds up to one `lockupPeriod`
+     * from the last solvent epoch, drawing from the reserve). Providers may
+     * keep serving for a while in deficit (their choice), but the
+     * relationship is now at risk and the user should top up promptly.
+     *
+     * - `maxUint256` when `lockupRatePerEpoch` is 0n (nothing is being spent).
+     * - `0n` when the account is already past this point (in deficit).
+     *
+     * To get the absolute epoch form, add `epoch` (skip when this is
+     * `maxUint256`).
      */
     runwayInEpochs: bigint
-    /** The epoch used for all calculations */
+    /**
+     * Total spend the account's `funds` would cover at `lockupRatePerEpoch`,
+     * calculated as `funds / lockupRatePerEpoch`. Treat as "how much
+     * coverage has the user prepaid in total?".
+     *
+     * Always >= {@link runwayInEpochs}, typically by roughly the size of
+     * the reserve held in `totalLockup`. The two answer different
+     * questions: `runwayInEpochs` is the operational "act-by" number,
+     * accounting for the reserve as a floor that halts settlement;
+     * `grossCoverageInEpochs` treats `funds` as a single bucket without
+     * modeling whether the reserve is actually flowing as ongoing payment.
+     * They converge in degenerate cases (e.g. `totalLockup == 0` at
+     * `lockupLastSettledAt == epoch`, or trivially at zero `funds`), but
+     * generally diverge.
+     *
+     * The reserve portion of `funds` is real money in the account but can
+     * only flow to providers via rail termination, not as ongoing coverage.
+     * Useful as a complement to `runwayInEpochs` in user-facing displays,
+     * e.g. "your deposit covers ~X days of storage in total; you have ~Y
+     * days before you need to top up to keep paying".
+     *
+     * - `maxUint256` when `lockupRatePerEpoch` is 0n (nothing is being
+     *   spent; takes precedence over `funds === 0n`).
+     * - `0n` when `funds` is 0n and `lockupRatePerEpoch` is positive.
+     */
+    grossCoverageInEpochs: bigint
+    /** The epoch used for all calculations. */
     epoch: bigint
   }
 
@@ -61,8 +114,8 @@ export namespace getAccountSummary {
  * Get a comprehensive account summary from the Payments contract.
  *
  * Fetches account state, fixed lockup totals, and (optionally) current epoch
- * in parallel, then derives debt, available funds, lockup breakdown, and
- * funded-until timeline client-side.
+ * in parallel, then derives debt, available funds, lockup breakdown, runway,
+ * and gross coverage client-side.
  *
  * @param client - The client to use for the query.
  * @param options - {@link getAccountSummary.OptionsType}
@@ -85,8 +138,8 @@ export namespace getAccountSummary {
  * })
  *
  * console.log('Available:', summary.availableFunds)
- * console.log('Funded until epoch:', summary.fundedUntilEpoch)
  * console.log('Runway in epochs:', summary.runwayInEpochs)
+ * console.log('Gross coverage in epochs:', summary.grossCoverageInEpochs)
  * ```
  */
 export async function getAccountSummary(
@@ -110,7 +163,7 @@ export async function getAccountSummary(
     currentEpoch: resolvedEpoch,
   }
 
-  const { fundedUntilEpoch, availableFunds, runwayInEpochs } = resolveAccountState(params)
+  const { availableFunds, runwayInEpochs, grossCoverageInEpochs } = resolveAccountState(params)
   const debt = calculateAccountDebt(params)
 
   const totalLockup = accountInfo.funds > availableFunds ? accountInfo.funds - availableFunds : 0n
@@ -129,8 +182,8 @@ export async function getAccountSummary(
     totalFixedLockup,
     totalRateBasedLockup,
 
-    fundedUntilEpoch,
     runwayInEpochs,
+    grossCoverageInEpochs,
     epoch: resolvedEpoch,
   }
 }

--- a/packages/synapse-core/src/pay/get-account-summary.ts
+++ b/packages/synapse-core/src/pay/get-account-summary.ts
@@ -44,9 +44,9 @@ export namespace getAccountSummary {
     /** Total effective lockup at `epoch` (fixed + rate-based). */
     totalLockup: bigint
     /**
-     * Sum of `lockupFixed` across all rails. Reserved for one-time payments
-     * rather than streaming rate (e.g. FWSS CDN egress and cache miss
-     * credits).
+     * Sum of `lockupFixed` across all rails. Reserved for one-time payments,
+     * for example, FWSS CDN egress and cache miss credits, rather than
+     * streaming rate.
      */
     totalFixedLockup: bigint
     /** Rate-based portion of lockup (`totalLockup - totalFixedLockup`). */
@@ -83,17 +83,11 @@ export namespace getAccountSummary {
      * coverage has the user prepaid in total?".
      *
      * Always >= {@link runwayInEpochs}, typically by roughly the size of
-     * the reserve held in `totalLockup`. The two answer different
-     * questions: `runwayInEpochs` is the operational "act-by" number,
-     * accounting for the reserve as a floor that halts settlement;
-     * `grossCoverageInEpochs` treats `funds` as a single bucket without
-     * modeling whether the reserve is actually flowing as ongoing payment.
-     * They converge in degenerate cases (e.g. `totalLockup == 0` at
-     * `lockupLastSettledAt == epoch`, or trivially at zero `funds`), but
-     * generally diverge.
+     * the reserve held in `totalLockup`. `runwayInEpochs` accounts for the
+     * reserve as a floor that halts settlement; `grossCoverageInEpochs`
+     * treats `funds` as a single bucket without modeling whether the
+     * reserve is actually flowing as ongoing payment.
      *
-     * The reserve portion of `funds` is real money in the account but can
-     * only flow to providers via rail termination, not as ongoing coverage.
      * Useful as a complement to `runwayInEpochs` in user-facing displays,
      * e.g. "your deposit covers ~X days of storage in total; you have ~Y
      * days before you need to top up to keep paying".

--- a/packages/synapse-core/src/pay/resolve-account-state.ts
+++ b/packages/synapse-core/src/pay/resolve-account-state.ts
@@ -28,9 +28,11 @@ export namespace resolveAccountState {
      * still positive. The reserve is not automatically spent. It becomes
      * claimable only after a provider terminates the rail (settlement then
      * proceeds up to one `lockupPeriod` from the last solvent epoch,
-     * drawing from the reserve). Providers may keep serving for a while in
-     * deficit (their choice), but reaching this point means service is at
-     * risk and the user should top up promptly.
+     * drawing from the reserve). Termination is one-way: once a rail has
+     * an `endEpoch` it's heading to finalization and topping up the
+     * account won't revive it. Providers may keep serving briefly in
+     * deficit, but the user should top up before reaching this point to
+     * keep existing rails alive.
      *
      * - `maxUint256` when `lockupRate` is 0n (nothing is being spent).
      * - `0n` when the account is already past this point (in deficit).
@@ -52,7 +54,7 @@ export namespace resolveAccountState {
      *
      * Useful as a complement to `runwayInEpochs` in user-facing displays,
      * e.g. "your deposit covers ~X days of storage in total; you have ~Y
-     * days before you need to top up to keep paying".
+     * days of runway before your account enters deficit".
      *
      * - `maxUint256` when `lockupRate` is 0n (nothing is being spent;
      *   takes precedence over `funds === 0n`).

--- a/packages/synapse-core/src/pay/resolve-account-state.ts
+++ b/packages/synapse-core/src/pay/resolve-account-state.ts
@@ -6,41 +6,101 @@ export namespace resolveAccountState {
 
   export type OutputType = {
     /**
-     * Absolute epoch at which funds run out at the current lockup rate.
-     * `maxUint256` when `lockupRate` is 0n.
+     * Funds available for withdrawal or new rail commitments at
+     * `currentEpoch`. Equal to `funds - lockupCurrent` once lockup is
+     * simulated forward to `currentEpoch`. The "unreserved" portion of
+     * `funds` described on {@link runwayInEpochs}.
      */
-    fundedUntilEpoch: bigint
-    /** Funds available after accounting for all lockup (fixed + rate) at `currentEpoch`. */
     availableFunds: bigint
     /**
-     * Number of epochs that can pass from `currentEpoch` (on the input params) before the account
-     * runs out of funds at the current lockup rate — i.e. how long until the
-     * user needs to deposit more funds.
+     * Epochs from `currentEpoch` until this account enters deficit and the
+     * standard payment flow to providers halts. Treat as "when must the user
+     * act?".
      *
-     * `maxUint256` when `lockupRate` is 0n (no drain), `0n` when the account
-     * is already insolvent.
+     * The account holds a reserve in `lockupCurrent`, set aside as a payment
+     * guarantee for the providers this account is paying. Each rail
+     * contributes its own piece of the reserve under its own terms (typically
+     * a streaming guarantee tied to that rail's payment period). Active
+     * payments draw from the *unreserved* portion of `funds`
+     * (`funds - lockupCurrent`). Once the unreserved portion is exhausted,
+     * the account is in deficit: standard settlement of active rails halts
+     * and providers stop being paid for new epochs even though `funds` is
+     * still positive. The reserve is not automatically spent. It becomes
+     * claimable only after a provider terminates the rail (settlement then
+     * proceeds up to one `lockupPeriod` from the last solvent epoch,
+     * drawing from the reserve). Providers may keep serving for a while in
+     * deficit (their choice), but reaching this point means service is at
+     * risk and the user should top up promptly.
+     *
+     * - `maxUint256` when `lockupRate` is 0n (nothing is being spent).
+     * - `0n` when the account is already past this point (in deficit).
+     *
+     * To get the absolute epoch form, add `currentEpoch` (skip when this is
+     * `maxUint256`).
      */
     runwayInEpochs: bigint
+    /**
+     * Total spend the account's `funds` would cover at `lockupRate`,
+     * calculated as `funds / lockupRate`. Treat as "how much coverage has
+     * the user prepaid in total?".
+     *
+     * Always >= {@link runwayInEpochs}, typically by roughly the size of
+     * the reserve held in `lockupCurrent`. The two answer different
+     * questions: `runwayInEpochs` is the operational "act-by" number,
+     * accounting for the reserve as a floor that halts settlement;
+     * `grossCoverageInEpochs` treats `funds` as a single bucket without
+     * modeling whether the reserve is actually flowing as ongoing payment.
+     * They converge in degenerate cases (e.g. `lockupCurrent == 0` at
+     * `currentEpoch == lockupLastSettledAt`, or trivially at zero `funds`),
+     * but generally diverge.
+     *
+     * The reserve portion of `funds` is real money in the account but can
+     * only flow to providers via rail termination, not as ongoing coverage.
+     * Useful as a complement to `runwayInEpochs` in user-facing displays,
+     * e.g. "your deposit covers ~X days of storage in total; you have ~Y
+     * days before you need to top up to keep paying".
+     *
+     * - `maxUint256` when `lockupRate` is 0n (nothing is being spent;
+     *   takes precedence over `funds === 0n`).
+     * - `0n` when `funds` is 0n and `lockupRate` is positive.
+     */
+    grossCoverageInEpochs: bigint
   }
 }
 
 /**
  * Project account state forward to `currentEpoch` by simulating settlement locally.
  *
- * Pure function — no RPC call. Takes raw account fields from `accounts()` +
- * currentEpoch and computes:
+ * Pure function, no RPC call. Takes raw account fields from `accounts()` plus
+ * `currentEpoch` and returns:
  *
- * - `fundedUntilEpoch` — the absolute epoch at which
- *   `lockupCurrent + lockupRate × elapsed === funds`. Past this point,
- *   settlement stops advancing and the payer must deposit more funds (or
- *   have rails terminated) to keep services running.
- * - `availableFunds` — funds minus all lockup (fixed + rate) at `currentEpoch`.
- * - `runwayInEpochs` — `fundedUntilEpoch - currentEpoch`, clamped to `0n`
- *   when insolvent and `maxUint256` when `lockupRate` is 0n.
+ * - `availableFunds`: `funds - lockupCurrent` simulated forward to
+ *   `currentEpoch`. Withdrawable, available to back new rail commitments.
+ * - `runwayInEpochs`: how long until the account enters deficit and
+ *   settlement of active rails halts. Use for "when must the user act?".
+ * - `grossCoverageInEpochs`: `funds / lockupRate`, the total horizon the
+ *   deposit covers at the current rate. Use for "how much coverage has the
+ *   user prepaid in total?".
  *
- * Note: `funds` already includes fixed lockup from rails (it's reflected in
- * `lockupCurrent`), so runway accounts for both fixed lockup and rate-based
- * lockup automatically.
+ * `runwayInEpochs` and `grossCoverageInEpochs` answer different questions
+ * and generally diverge by roughly the reserve held in `lockupCurrent`,
+ * even for a healthy account. They only converge in degenerate cases
+ * (`lockupCurrent == 0` at `currentEpoch == lockupLastSettledAt`, or
+ * trivially at zero `funds`). Worked examples (in token units, with
+ * `lockupRate = 1 token / day`):
+ *
+ *   Healthy account: funds=100, lockupCurrent=30
+ *     runwayInEpochs           ~= 70 days  (unreserved 70 / 1)
+ *     grossCoverageInEpochs   = 100 days (100 / 1)
+ *
+ *   In deficit: funds=10, lockupCurrent=30
+ *     runwayInEpochs            = 0 days   (already past the trigger)
+ *     grossCoverageInEpochs   = 10 days  (10 / 1)
+ *
+ * The reserve in `lockupCurrent` is the sum of each rail's contribution; its
+ * size depends on the operators and rails configured for this account.
+ * `funds` already includes fixed lockup (it's reflected in `lockupCurrent`),
+ * so both numbers account for fixed and rate-based lockup automatically.
  *
  * @param params - Raw account fields + current epoch
  * @returns The projected account state {@link resolveAccountState.OutputType}
@@ -61,8 +121,8 @@ export function resolveAccountState(params: resolveAccountState.ParamsType): res
   const availableFunds = rawAvailable > 0n ? rawAvailable : 0n
 
   // runwayInEpochs = fundedUntilEpoch - currentEpoch, with edge cases:
-  // - lockupRate === 0n → maxUint256 (already the value of fundedUntilEpoch)
-  // - insolvent (fundedUntilEpoch <= currentEpoch) → 0n
+  // - lockupRate === 0n -> maxUint256 (already the value of fundedUntilEpoch)
+  // - in deficit (fundedUntilEpoch <= currentEpoch) -> 0n
   const runwayInEpochs =
     fundedUntilEpoch === maxUint256
       ? maxUint256
@@ -70,9 +130,14 @@ export function resolveAccountState(params: resolveAccountState.ParamsType): res
         ? fundedUntilEpoch - currentEpoch
         : 0n
 
+  // grossCoverageInEpochs = funds / lockupRate. Total horizon the deposit
+  // covers at the current rate, treating funds as a single bucket. Always
+  // >= runwayInEpochs.
+  const grossCoverageInEpochs = lockupRate === 0n ? maxUint256 : funds / lockupRate
+
   return {
-    fundedUntilEpoch,
     availableFunds,
     runwayInEpochs,
+    grossCoverageInEpochs,
   }
 }

--- a/packages/synapse-core/src/pay/resolve-account-state.ts
+++ b/packages/synapse-core/src/pay/resolve-account-state.ts
@@ -45,17 +45,11 @@ export namespace resolveAccountState {
      * the user prepaid in total?".
      *
      * Always >= {@link runwayInEpochs}, typically by roughly the size of
-     * the reserve held in `lockupCurrent`. The two answer different
-     * questions: `runwayInEpochs` is the operational "act-by" number,
-     * accounting for the reserve as a floor that halts settlement;
-     * `grossCoverageInEpochs` treats `funds` as a single bucket without
-     * modeling whether the reserve is actually flowing as ongoing payment.
-     * They converge in degenerate cases (e.g. `lockupCurrent == 0` at
-     * `currentEpoch == lockupLastSettledAt`, or trivially at zero `funds`),
-     * but generally diverge.
+     * the reserve held in `lockupCurrent`. `runwayInEpochs` accounts for
+     * the reserve as a floor that halts settlement; `grossCoverageInEpochs`
+     * treats `funds` as a single bucket without modeling whether the
+     * reserve is actually flowing as ongoing payment.
      *
-     * The reserve portion of `funds` is real money in the account but can
-     * only flow to providers via rail termination, not as ongoing coverage.
      * Useful as a complement to `runwayInEpochs` in user-facing displays,
      * e.g. "your deposit covers ~X days of storage in total; you have ~Y
      * days before you need to top up to keep paying".
@@ -72,30 +66,19 @@ export namespace resolveAccountState {
  * Project account state forward to `currentEpoch` by simulating settlement locally.
  *
  * Pure function, no RPC call. Takes raw account fields from `accounts()` plus
- * `currentEpoch` and returns:
+ * `currentEpoch` and returns `availableFunds`, `runwayInEpochs`, and
+ * `grossCoverageInEpochs`. See {@link resolveAccountState.OutputType} for
+ * each field's full semantics.
  *
- * - `availableFunds`: `funds - lockupCurrent` simulated forward to
- *   `currentEpoch`. Withdrawable, available to back new rail commitments.
- * - `runwayInEpochs`: how long until the account enters deficit and
- *   settlement of active rails halts. Use for "when must the user act?".
- * - `grossCoverageInEpochs`: `funds / lockupRate`, the total horizon the
- *   deposit covers at the current rate. Use for "how much coverage has the
- *   user prepaid in total?".
- *
- * `runwayInEpochs` and `grossCoverageInEpochs` answer different questions
- * and generally diverge by roughly the reserve held in `lockupCurrent`,
- * even for a healthy account. They only converge in degenerate cases
- * (`lockupCurrent == 0` at `currentEpoch == lockupLastSettledAt`, or
- * trivially at zero `funds`). Worked examples (in token units, with
- * `lockupRate = 1 token / day`):
+ * Worked examples (in token units, with `lockupRate = 1 token / day`):
  *
  *   Healthy account: funds=100, lockupCurrent=30
- *     runwayInEpochs           ~= 70 days  (unreserved 70 / 1)
- *     grossCoverageInEpochs   = 100 days (100 / 1)
+ *     runwayInEpochs        ~= 70 days  (unreserved 70 / 1)
+ *     grossCoverageInEpochs  = 100 days (100 / 1)
  *
  *   In deficit: funds=10, lockupCurrent=30
- *     runwayInEpochs            = 0 days   (already past the trigger)
- *     grossCoverageInEpochs   = 10 days  (10 / 1)
+ *     runwayInEpochs         = 0 days   (already past the trigger)
+ *     grossCoverageInEpochs  = 10 days  (10 / 1)
  *
  * The reserve in `lockupCurrent` is the sum of each rail's contribution; its
  * size depends on the operators and rails configured for this account.

--- a/packages/synapse-core/src/pay/resolve-account-state.ts
+++ b/packages/synapse-core/src/pay/resolve-account-state.ts
@@ -17,22 +17,17 @@ export namespace resolveAccountState {
      * standard payment flow to providers halts. Treat as "when must the user
      * act?".
      *
-     * The account holds a reserve in `lockupCurrent`, set aside as a payment
-     * guarantee for the providers this account is paying. Each rail
-     * contributes its own piece of the reserve under its own terms (typically
-     * a streaming guarantee tied to that rail's payment period). Active
-     * payments draw from the *unreserved* portion of `funds`
-     * (`funds - lockupCurrent`). Once the unreserved portion is exhausted,
-     * the account is in deficit: standard settlement of active rails halts
-     * and providers stop being paid for new epochs even though `funds` is
-     * still positive. The reserve is not automatically spent. It becomes
-     * claimable only after a provider terminates the rail (settlement then
-     * proceeds up to one `lockupPeriod` from the last solvent epoch,
-     * drawing from the reserve). Termination is one-way: once a rail has
-     * an `endEpoch` it's heading to finalization and topping up the
-     * account won't revive it. Providers may keep serving briefly in
-     * deficit, but the user should top up before reaching this point to
-     * keep existing rails alive.
+     * The account holds a reserve in `lockupCurrent` that each rail has set
+     * aside under its terms. The funds are locked at the contract level: the
+     * user can't withdraw them while the rail is active. Active payments
+     * draw from the *unreserved* portion of `funds` (`funds - lockupCurrent`).
+     * Once the unreserved portion is exhausted, the account is in deficit:
+     * standard settlement of active rails halts even though `funds` is still
+     * positive. A provider can then terminate the rail to claim against the
+     * reserve for a final payment window of up to one `lockupPeriod`.
+     * Termination is one-way: once a rail has an `endEpoch` it's heading to
+     * finalization and topping up the account won't revive it. Top up
+     * before deficit to keep existing rails open.
      *
      * - `maxUint256` when `lockupRate` is 0n (nothing is being spent).
      * - `0n` when the account is already past this point (in deficit).

--- a/packages/synapse-core/src/warm-storage/calculate-deposit-needed.ts
+++ b/packages/synapse-core/src/warm-storage/calculate-deposit-needed.ts
@@ -29,10 +29,8 @@ export namespace calculateBufferAmount {
     rawDepositNeeded: bigint
     /** Projected account rate after this upload: currentLockupRate + rateDeltaPerEpoch. */
     netRateAfterUpload: bigint
-    /** From resolveAccountState().fundedUntilEpoch. */
-    fundedUntilEpoch: bigint
-    /** Current epoch (block number). */
-    currentEpoch: bigint
+    /** From resolveAccountState().runwayInEpochs. */
+    runwayInEpochs: bigint
     /** From resolveAccountState().availableFunds. */
     availableFunds: bigint
     /** Safety margin in epochs. */
@@ -50,21 +48,23 @@ export namespace calculateBufferAmount {
  * @returns The buffer amount in token base units
  */
 export function calculateBufferAmount(params: calculateBufferAmount.ParamsType): bigint {
-  const { rawDepositNeeded, netRateAfterUpload, fundedUntilEpoch, currentEpoch, availableFunds, bufferEpochs } = params
+  const { rawDepositNeeded, netRateAfterUpload, runwayInEpochs, availableFunds, bufferEpochs } = params
 
   if (rawDepositNeeded > 0n) {
-    // Deposit is needed — add buffer so it's sufficient at T_exec
+    // Deposit is needed, add buffer so it's sufficient at T_exec
     return netRateAfterUpload * bufferEpochs
   }
 
-  if (fundedUntilEpoch <= currentEpoch + bufferEpochs) {
-    // No new lockup needed, but account expires within buffer window
+  if (runwayInEpochs <= bufferEpochs) {
+    // No new lockup needed, but account expires within buffer window.
+    // (runwayInEpochs is maxUint256 when lockupRate is 0n, so this branch
+    // is only entered for actively-draining accounts.)
     const bufferCost = netRateAfterUpload * bufferEpochs
     const needed = bufferCost - availableFunds
     return needed > 0n ? needed : 0n
   }
 
-  // Account has sufficient runway — no buffer needed
+  // Account has sufficient runway, no buffer needed
   return 0n
 }
 
@@ -90,10 +90,9 @@ export namespace calculateDepositNeeded {
     // Account debt + resolved state
     debt: bigint
     availableFunds: bigint
-    fundedUntilEpoch: bigint
+    runwayInEpochs: bigint
 
     // Buffer parameters
-    currentEpoch: bigint
     /** Safety margin in epochs for tx execution delay. Defaults to DEFAULT_BUFFER_EPOCHS (5). */
     bufferEpochs?: bigint
   }
@@ -138,8 +137,7 @@ export function calculateDepositNeeded(params: calculateDepositNeeded.ParamsType
     : calculateBufferAmount({
         rawDepositNeeded,
         netRateAfterUpload,
-        fundedUntilEpoch: params.fundedUntilEpoch,
-        currentEpoch: params.currentEpoch,
+        runwayInEpochs: params.runwayInEpochs,
         availableFunds: params.availableFunds,
         bufferEpochs,
       })

--- a/packages/synapse-core/src/warm-storage/get-upload-costs.ts
+++ b/packages/synapse-core/src/warm-storage/get-upload-costs.ts
@@ -92,7 +92,7 @@ export async function getUploadCosts(
     currentEpoch,
   }
   const debt = calculateAccountDebt(accountParams)
-  const { availableFunds, fundedUntilEpoch } = resolveAccountState(accountParams)
+  const { availableFunds, runwayInEpochs } = resolveAccountState(accountParams)
 
   // Calculate deposit needed
   const depositNeeded = calculateDepositNeeded({
@@ -108,8 +108,7 @@ export async function getUploadCosts(
     extraRunwayEpochs,
     debt,
     availableFunds,
-    fundedUntilEpoch,
-    currentEpoch,
+    runwayInEpochs,
     bufferEpochs,
   })
 

--- a/packages/synapse-core/test/account-debt.test.ts
+++ b/packages/synapse-core/test/account-debt.test.ts
@@ -6,7 +6,7 @@ import { calculateAccountDebt } from '../src/pay/account-debt.ts'
 import { resolveAccountState } from '../src/pay/resolve-account-state.ts'
 
 describe('resolveAccountState', () => {
-  it('healthy account: funds > lockup → correct availableFunds, fundedUntilEpoch, runwayInEpochs', () => {
+  it('healthy account: funds > lockup, correct availableFunds and runwayInEpochs', () => {
     const result = resolveAccountState({
       funds: 1000n,
       lockupCurrent: 100n,
@@ -15,19 +15,20 @@ describe('resolveAccountState', () => {
       currentEpoch: 100n,
     })
 
-    // fundedUntilEpoch = 0 + (1000 - 100) / 1 = 900
-    assert.equal(result.fundedUntilEpoch, 900n)
-
     // simulatedSettledAt = min(900, 100) = 100
     // simulatedLockupCurrent = 100 + 1 * (100 - 0) = 200
     // availableFunds = max(0, 1000 - 200) = 800
     assert.equal(result.availableFunds, 800n)
 
-    // runwayInEpochs = fundedUntilEpoch - currentEpoch = 900 - 100 = 800
+    // runwayInEpochs = (funds - lockupCurrent) / lockupRate - elapsed
+    //                = (1000 - 100) / 1 - 100 = 800
     assert.equal(result.runwayInEpochs, 800n)
+
+    // grossCoverageInEpochs = 1000 / 1 = 1000
+    assert.equal(result.grossCoverageInEpochs, 1000n)
   })
 
-  it('underfunded account: lockup > funds → availableFunds = 0, fundedUntilEpoch < currentEpoch, runway = 0', () => {
+  it('underfunded account: lockup > funds, availableFunds = 0, runway = 0', () => {
     const result = resolveAccountState({
       funds: 100n,
       lockupCurrent: 200n,
@@ -36,17 +37,16 @@ describe('resolveAccountState', () => {
       currentEpoch: 1200n,
     })
 
-    // fundedUntilEpoch = 1000 + (100 - 200) / 2 = 1000 + (-50) = 950
-    assert.equal(result.fundedUntilEpoch, 950n)
-    assert.ok(result.fundedUntilEpoch < 1200n)
-
-    // simulatedSettledAt = min(950, 1200) = 950
-    // simulatedLockupCurrent = 200 + 2 * (950 - 1000) = 200 + (-100) = 100
+    // simulatedLockupCurrent = 200 + 2 * (950 - 1000) = 100
     // availableFunds = max(0, 100 - 100) = 0
     assert.equal(result.availableFunds, 0n)
 
-    // fundedUntilEpoch < currentEpoch → runway clamped to 0n
+    // funds < lockupCurrent already at lockupLastSettledAt, account is in
+    // deficit, runway clamped to 0n
     assert.equal(result.runwayInEpochs, 0n)
+
+    // funds remain even after settlement halts: 100 / 2 = 50
+    assert.equal(result.grossCoverageInEpochs, 50n)
   })
 
   it('partially funded account: funds > lockupCurrent but runs out before currentEpoch', () => {
@@ -58,20 +58,19 @@ describe('resolveAccountState', () => {
       currentEpoch: 200n,
     })
 
-    // fundedUntilEpoch = 0 + (100 - 50) / 1 = 50
-    assert.equal(result.fundedUntilEpoch, 50n)
-    assert.ok(result.fundedUntilEpoch < 200n)
-
     // simulatedSettledAt = min(50, 200) = 50
     // simulatedLockupCurrent = 50 + 1 * (50 - 0) = 100
     // availableFunds = max(0, 100 - 100) = 0
     assert.equal(result.availableFunds, 0n)
 
-    // ran out 150 epochs ago → runway = 0n
+    // ran out 150 epochs ago, runway = 0n
     assert.equal(result.runwayInEpochs, 0n)
+
+    // 100 / 1 = 100
+    assert.equal(result.grossCoverageInEpochs, 100n)
   })
 
-  it('zero lockupRate → fundedUntilEpoch = maxUint256, runway = maxUint256', () => {
+  it('zero lockupRate, runway and gross coverage = maxUint256', () => {
     const result = resolveAccountState({
       funds: 1000n,
       lockupCurrent: 100n,
@@ -80,18 +79,15 @@ describe('resolveAccountState', () => {
       currentEpoch: 100n,
     })
 
-    assert.equal(result.fundedUntilEpoch, maxUint256)
-
-    // simulatedSettledAt = min(maxUint256, 100) = 100
-    // simulatedLockupCurrent = 100 + 0 * (100 - 0) = 100
     // availableFunds = max(0, 1000 - 100) = 900
     assert.equal(result.availableFunds, 900n)
-
-    // zero rate → infinite runway
+    // zero rate: nothing draining, infinite for both numbers
     assert.equal(result.runwayInEpochs, maxUint256)
+    assert.equal(result.grossCoverageInEpochs, maxUint256)
   })
 
-  it('zero lockupRate with zero funds → runway = maxUint256 (no drain)', () => {
+  it('zero lockupRate with zero funds, runway = maxUint256 (no drain)', () => {
+    // Zero rate takes precedence over zero funds: nothing is draining.
     const result = resolveAccountState({
       funds: 0n,
       lockupCurrent: 0n,
@@ -100,14 +96,64 @@ describe('resolveAccountState', () => {
       currentEpoch: 1_000_000n,
     })
 
-    assert.equal(result.fundedUntilEpoch, maxUint256)
     assert.equal(result.availableFunds, 0n)
     assert.equal(result.runwayInEpochs, maxUint256)
+    assert.equal(result.grossCoverageInEpochs, maxUint256)
   })
 
-  it('fundedUntilEpoch exactly equals currentEpoch → runway = 0n', () => {
-    // fundedUntilEpoch = 0 + (1000 - 0) / 10 = 100
-    // currentEpoch = 100 → just hit the funded epoch, no more runway
+  it('zero funds with positive lockupRate, runway and gross coverage = 0n', () => {
+    const result = resolveAccountState({
+      funds: 0n,
+      lockupCurrent: 0n,
+      lockupRate: 1n,
+      lockupLastSettledAt: 1_000_000n,
+      currentEpoch: 1_000_000n,
+    })
+
+    assert.equal(result.availableFunds, 0n)
+    assert.equal(result.runwayInEpochs, 0n)
+    assert.equal(result.grossCoverageInEpochs, 0n)
+  })
+
+  it('in-deficit user retains a positive grossCoverageInEpochs (filecoin-pin issue #385)', () => {
+    // Reproduces the user-reported scenario: ~10.52 USDFC deposit, ~0.467
+    // USDFC/day spend across many rails. With multiple datasets the operator
+    // commits enough lockup that lockupCurrent grows past the deposit, so
+    // settlement halts and runwayInEpochs clamps to 0n. The user is right
+    // that money still sits in the account though, so grossCoverageInEpochs
+    // must stay positive to support a meaningful "X days prepaid" display
+    // even though no further payment will flow until they top up.
+    const oneUsdfc = 1_000_000_000_000_000_000n
+    const epochsPerDay = 2880n
+    const ratePerDay = 467_000_000_000_000_000n // 0.467 USDFC/day
+    const ratePerEpoch = ratePerDay / epochsPerDay
+    const funds = (oneUsdfc * 10_5225n) / 10_000n // 10.5225 USDFC
+    // lockupCurrent past funds simulates the delinquent state
+    const lockupCurrent = ratePerDay * 30n
+
+    const result = resolveAccountState({
+      funds,
+      lockupCurrent,
+      lockupRate: ratePerEpoch,
+      lockupLastSettledAt: 1_000_000n,
+      currentEpoch: 1_000_000n,
+    })
+
+    // Settlement-halt runway is zero: the user must act
+    assert.equal(result.runwayInEpochs, 0n)
+    // But the deposit still represents real days of coverage
+    const expectedExhaustion = funds / ratePerEpoch
+    assert.equal(result.grossCoverageInEpochs, expectedExhaustion)
+    // ~22 days at 0.467 USDFC/day
+    assert.ok(
+      result.grossCoverageInEpochs > 60_000n && result.grossCoverageInEpochs < 70_000n,
+      `expected ~22 days (~63360 epochs), got ${result.grossCoverageInEpochs}`
+    )
+  })
+
+  it('boundary: just hit deficit at currentEpoch, runway = 0n', () => {
+    // (funds - lockupCurrent) / lockupRate = (1000 - 0) / 10 = 100 epochs
+    // currentEpoch = 100, exactly hit the deficit point, no more runway
     const result = resolveAccountState({
       funds: 1000n,
       lockupCurrent: 0n,
@@ -116,17 +162,16 @@ describe('resolveAccountState', () => {
       currentEpoch: 100n,
     })
 
-    assert.equal(result.fundedUntilEpoch, 100n)
     assert.equal(result.runwayInEpochs, 0n)
+    // total funds horizon still positive: 1000 / 10 = 100
+    assert.equal(result.grossCoverageInEpochs, 100n)
   })
 
   it('fixed lockup implicit in lockupCurrent: held but does not drain', () => {
     // funds=500, lockupCurrent=100 (all fixed lockup), rate=1, settledAt=1000, currentEpoch=1200
-    // fundedUntilEpoch = 1000 + (500 - 100) / 1 = 1400
-    // simulatedSettledAt = min(1400, 1200) = 1200
-    // simulatedLockupCurrent = 100 + 1 * (1200 - 1000) = 300
-    // availableFunds = max(0, 500 - 300) = 200
-    // runway = 1400 - 1200 = 200
+    // simulatedSettledAt = 1200; simulatedLockupCurrent = 100 + 1 * 200 = 300
+    // availableFunds = 500 - 300 = 200
+    // runway = (500 - 100) / 1 - (1200 - 1000) = 400 - 200 = 200
     const result = resolveAccountState({
       funds: 500n,
       lockupCurrent: 100n,
@@ -135,15 +180,16 @@ describe('resolveAccountState', () => {
       currentEpoch: 1200n,
     })
 
-    assert.equal(result.fundedUntilEpoch, 1400n)
     assert.equal(result.availableFunds, 200n)
     assert.equal(result.runwayInEpochs, 200n)
+    // 500 / 1 = 500
+    assert.equal(result.grossCoverageInEpochs, 500n)
   })
 
   it('realistic USDFC numbers: 100 USDFC funds, 1 USDFC/day rate', () => {
     const oneUsdfc = 1_000_000_000_000_000_000n
     const epochsPerDay = 2880n
-    const ratePerEpoch = oneUsdfc / epochsPerDay
+    const ratePerEpoch = oneUsdfc / epochsPerDay // truncated
 
     const result = resolveAccountState({
       funds: 100n * oneUsdfc,
@@ -153,16 +199,15 @@ describe('resolveAccountState', () => {
       currentEpoch: 1_000_000n,
     })
 
-    // ~100 days of runway = 100 * 2880 epochs, with rounding from integer div
-    assert.ok(
-      result.runwayInEpochs > 287_000n && result.runwayInEpochs <= 300_000n,
-      `expected ~288000, got ${result.runwayInEpochs}`
-    )
+    // ~100 days runway, exact value derives from the truncated rate
+    const expected = (100n * oneUsdfc) / ratePerEpoch
+    assert.equal(result.runwayInEpochs, expected)
+    assert.equal(result.grossCoverageInEpochs, expected)
   })
 
   it('truncation: (funds - lockupCurrent) divisible by lockupRate', () => {
     // funds=10, lockupCurrent=1, lockupRate=3, settledAt=0, currentEpoch=0
-    // fundedUntilEpoch = 0 + (10 - 1) / 3 = 3 (exact)
+    // runway = (10 - 1) / 3 = 3 (exact)
     const result = resolveAccountState({
       funds: 10n,
       lockupCurrent: 1n,
@@ -171,13 +216,14 @@ describe('resolveAccountState', () => {
       currentEpoch: 0n,
     })
 
-    assert.equal(result.fundedUntilEpoch, 3n)
     assert.equal(result.runwayInEpochs, 3n)
+    // 10 / 3 = 3 (truncated)
+    assert.equal(result.grossCoverageInEpochs, 3n)
   })
 
   it('truncation with remainder: (funds - lockupCurrent) not divisible by lockupRate', () => {
     // funds=10, lockupCurrent=0, lockupRate=3, settledAt=0, currentEpoch=0
-    // fundedUntilEpoch = 0 + 10 / 3 = 3 (remainder discarded)
+    // runway = 10 / 3 = 3 (remainder discarded)
     const result = resolveAccountState({
       funds: 10n,
       lockupCurrent: 0n,
@@ -186,8 +232,8 @@ describe('resolveAccountState', () => {
       currentEpoch: 0n,
     })
 
-    assert.equal(result.fundedUntilEpoch, 3n)
     assert.equal(result.runwayInEpochs, 3n)
+    assert.equal(result.grossCoverageInEpochs, 3n)
   })
 })
 

--- a/packages/synapse-core/test/calculate-deposit-needed.test.ts
+++ b/packages/synapse-core/test/calculate-deposit-needed.test.ts
@@ -25,8 +25,7 @@ describe('calculateBufferAmount', () => {
     const result = calculateBufferAmount({
       rawDepositNeeded: 100n,
       netRateAfterUpload: 15n, // e.g. currentLockupRate(10) + rateDelta(5)
-      fundedUntilEpoch: 500n,
-      currentEpoch: 100n,
+      runwayInEpochs: 400n,
       availableFunds: 200n,
       bufferEpochs: 20n,
     })
@@ -39,9 +38,8 @@ describe('calculateBufferAmount', () => {
   it('rawDepositNeeded > 0, zero delta: returns netRateAfterUpload * bufferEpochs', () => {
     const result = calculateBufferAmount({
       rawDepositNeeded: 100n,
-      netRateAfterUpload: 10n, // no delta — just currentLockupRate
-      fundedUntilEpoch: 500n,
-      currentEpoch: 100n,
+      netRateAfterUpload: 10n, // no delta, just currentLockupRate
+      runwayInEpochs: 400n,
       availableFunds: 200n,
       bufferEpochs: 20n,
     })
@@ -50,14 +48,12 @@ describe('calculateBufferAmount', () => {
     assert.equal(result, 200n)
   })
 
-  it('rawDepositNeeded <= 0, fundedUntilEpoch within buffer window: returns max(0, netRateAfterUpload*buffer - available)', () => {
-    // fundedUntilEpoch = 110, currentEpoch = 100, bufferEpochs = 20
-    // 110 <= 100 + 20 = 120, so within buffer window
+  it('rawDepositNeeded <= 0, runway within buffer window: returns max(0, netRateAfterUpload*buffer - available)', () => {
+    // runwayInEpochs (10) <= bufferEpochs (20), within buffer window
     const result = calculateBufferAmount({
       rawDepositNeeded: -50n,
       netRateAfterUpload: 15n, // e.g. currentLockupRate(10) + rateDelta(5)
-      fundedUntilEpoch: 110n,
-      currentEpoch: 100n,
+      runwayInEpochs: 10n,
       availableFunds: 50n,
       bufferEpochs: 20n,
     })
@@ -66,15 +62,26 @@ describe('calculateBufferAmount', () => {
     assert.equal(result, 250n)
   })
 
-  it('rawDepositNeeded <= 0, fundedUntilEpoch beyond buffer window: returns 0', () => {
-    // fundedUntilEpoch = 500, currentEpoch = 100, bufferEpochs = 20
-    // 500 > 100 + 20 = 120, so beyond buffer window
+  it('rawDepositNeeded <= 0, runway beyond buffer window: returns 0', () => {
+    // runwayInEpochs (400) > bufferEpochs (20), beyond buffer window
     const result = calculateBufferAmount({
       rawDepositNeeded: -50n,
       netRateAfterUpload: 15n,
-      fundedUntilEpoch: 500n,
-      currentEpoch: 100n,
+      runwayInEpochs: 400n,
       availableFunds: 200n,
+      bufferEpochs: 20n,
+    })
+
+    assert.equal(result, 0n)
+  })
+
+  it('rawDepositNeeded <= 0, infinite runway (lockupRate 0n): returns 0', () => {
+    // runwayInEpochs is maxUint256 when nothing is draining
+    const result = calculateBufferAmount({
+      rawDepositNeeded: -50n,
+      netRateAfterUpload: 0n,
+      runwayInEpochs: maxUint256,
+      availableFunds: 1000n,
       bufferEpochs: 20n,
     })
 
@@ -100,9 +107,8 @@ describe('calculateDepositNeeded', () => {
       currentLockupRate: 0n,
       extraRunwayEpochs: 0n,
       debt: 0n,
-      availableFunds: 100_000_000_000_000_000_000n, // 100 USDFC - way more than needed
-      fundedUntilEpoch: maxUint256,
-      currentEpoch: 1000n,
+      availableFunds: 100_000_000_000_000_000_000n, // 100 USDFC, way more than needed
+      runwayInEpochs: maxUint256,
       bufferEpochs: 10n,
     })
 
@@ -121,14 +127,13 @@ describe('calculateDepositNeeded', () => {
       extraRunwayEpochs: 0n,
       debt: 0n,
       availableFunds: 0n,
-      fundedUntilEpoch: 0n,
-      currentEpoch: 1000n,
+      runwayInEpochs: 0n,
     }
 
     const withBuffer = calculateDepositNeeded({ ...base, bufferEpochs: 100n })
     const withoutBuffer = calculateDepositNeeded({ ...base, bufferEpochs: 0n })
 
-    // No existing rails (currentLockupRate=0) + new dataset → buffer skipped
+    // No existing rails (currentLockupRate=0) + new dataset, buffer skipped
     assert.equal(withBuffer, withoutBuffer)
     assert.ok(withBuffer > 0n) // still requires the lockup deposit
   })
@@ -145,14 +150,13 @@ describe('calculateDepositNeeded', () => {
       extraRunwayEpochs: 0n,
       debt: 0n,
       availableFunds: 0n,
-      fundedUntilEpoch: 0n,
-      currentEpoch: 1000n,
+      runwayInEpochs: 0n,
     }
 
     const withBuffer = calculateDepositNeeded({ ...base, bufferEpochs: 100n })
     const withoutBuffer = calculateDepositNeeded({ ...base, bufferEpochs: 0n })
 
-    // Existing rails draining → buffer must apply even for new dataset
+    // Existing rails draining, buffer must apply even for new dataset
     assert.ok(withBuffer > withoutBuffer)
   })
 
@@ -169,8 +173,7 @@ describe('calculateDepositNeeded', () => {
       extraRunwayEpochs: 0n,
       debt,
       availableFunds: 0n,
-      fundedUntilEpoch: 50n,
-      currentEpoch: 1000n,
+      runwayInEpochs: 0n,
       bufferEpochs: 10n,
     })
 

--- a/packages/synapse-core/test/get-account-summary.test.ts
+++ b/packages/synapse-core/test/get-account-summary.test.ts
@@ -60,8 +60,8 @@ describe('getAccountSummary', () => {
     assert.equal(result.totalLockup, 0n)
     assert.equal(result.totalFixedLockup, 0n)
     assert.equal(result.totalRateBasedLockup, 0n)
-    assert.equal(result.fundedUntilEpoch, maxUint256)
     assert.equal(result.runwayInEpochs, maxUint256)
+    assert.equal(result.grossCoverageInEpochs, maxUint256)
     assert.equal(result.epoch, 1000000n)
   })
 
@@ -126,8 +126,11 @@ describe('getAccountSummary', () => {
     assert.equal(result.totalLockup, funds - result.availableFunds)
     // totalRateBasedLockup = totalLockup - totalFixedLockup
     assert.equal(result.totalRateBasedLockup, result.totalLockup - result.totalFixedLockup)
-    // runwayInEpochs = fundedUntilEpoch - epoch
-    assert.equal(result.runwayInEpochs, result.fundedUntilEpoch - epoch)
+    // runwayInEpochs > 0 because account is healthy
+    assert.ok(result.runwayInEpochs > 0n)
+    // grossCoverageInEpochs = funds / lockupRate, always >= runwayInEpochs
+    assert.equal(result.grossCoverageInEpochs, funds / lockupRate)
+    assert.ok(result.grossCoverageInEpochs >= result.runwayInEpochs)
   })
 
   it('should show debt when funds are insufficient', async () => {
@@ -159,10 +162,11 @@ describe('getAccountSummary', () => {
 
     assert.equal(result.availableFunds, 0n)
     assert.ok(result.debt > 0n, 'should have debt')
-    // fundedUntilEpoch should be before current epoch
-    assert.ok(result.fundedUntilEpoch < epoch, 'funded until should be in the past')
-    // runway is exhausted when account is insolvent
+    // runway is exhausted when account is in deficit
     assert.equal(result.runwayInEpochs, 0n)
+    // grossCoverageInEpochs reflects the total horizon: funds remain even
+    // after settlement halts
+    assert.equal(result.grossCoverageInEpochs, funds / lockupRate)
   })
 
   it('should use provided epoch parameter', async () => {

--- a/packages/synapse-sdk/src/storage/manager.ts
+++ b/packages/synapse-sdk/src/storage/manager.ts
@@ -773,7 +773,7 @@ export class StorageManager {
       currentEpoch,
     }
     const debt = calculateAccountDebt(accountParams)
-    const { availableFunds, fundedUntilEpoch } = resolveAccountState(accountParams)
+    const { availableFunds, runwayInEpochs } = resolveAccountState(accountParams)
 
     const netRateAfterUpload = accountInfo.lockupRate + totalRateDeltaPerEpoch
 
@@ -797,8 +797,7 @@ export class StorageManager {
       : calculateBufferAmount({
           rawDepositNeeded,
           netRateAfterUpload,
-          fundedUntilEpoch,
-          currentEpoch,
+          runwayInEpochs,
           availableFunds,
           bufferEpochs,
         })


### PR DESCRIPTION
`resolveAccountState` and `getAccountSummary` now return `runwayInEpochs` and `grossCoverageInEpochs`; `fundedUntilEpoch` is no longer exposed. Buffer and deposit-needed helpers take `runwayInEpochs` directly. Account state docs reframed around deficit semantics.

Ref: https://github.com/filecoin-project/filecoin-pin/pull/412

---

I spent some time noodling this problem because in https://github.com/filecoin-project/filecoin-pin/pull/412 we're proposing "runway" as something different to what we mean by "runway" here; we'd have two divergent calculations. _But_ both are valid, just with a different framing, and 412 has a real user complaint behind it. So,  this proposal is to introduce both concepts here, and while we're doing it drop the absolute "Until" number because both of these runway variants could have an "Until" and we don't really need it here anyway.

* `runwayInEpochs` tells you how much you have at current rate _discounting_ your lockup
* `grossCoverageInEpochs` tells you how much you have at the current rate _including_ your lockup

The latter would solve for the complaint in 412 but what we should be doing is displaying both, unfortunately, we just need to express it clearly.

Lots of doc effort going on in here to try and express the concepts as clearly as possible, but it's not easy. Suggested here as:

> "your deposit covers ~X days of storage in total; you have ~Y days before you need to top up to keep paying"