### PR TITLE
chore: simplify deployment commands in workflow files and update build script in package.json

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -26,8 +26,7 @@ jobs:
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm -r --filter synapse-playground run build
-      - run: pnpm --dir apps/synapse-playground exec wrangler deploy --cwd
-          synapse-playground --env production
+      - run: pnpm --dir apps/synapse-playground exec wrangler deploy --env production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - run: pnpm run build
       - run: pnpm -r --filter docs run build
       - name: Deploy docs
-        run: pnpm --dir docs exec wrangler deploy --cwd docs --env production
+        run: pnpm --dir docs exec wrangler deploy --env production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "NODE_OPTIONS=\"--localstorage-file=.astro-localstorage.json\" astro build",
+    "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"
   },


### PR DESCRIPTION
this should fix demo app ci failing https://github.com/FilOzone/synapse-sdk/actions/workflows/demo.yml

```
A file or directory could not be found.

  
  Missing file or directory: /home/runner/work/synapse-sdk/synapse-sdk/apps/synapse-playground
  
  This is typically caused by:
    - The file or directory does not exist
    - A typo in the file path
    - The file was moved or deleted
  
  Please check the file path and try again.

```


also removes the localstorage hack `NODE_OPTIONS=\"--localstorage-file=.astro-localstorage.json\"` not needed now