### PR TITLE
Add detailed FOC pricing table

### DIFF
--- a/docs/src/content/docs/introduction/about.mdx
+++ b/docs/src/content/docs/introduction/about.mdx
@@ -67,6 +67,12 @@ All payments are settled automatically through Filecoin Pay, ensuring on-chain a
 | ------- | --------- | -------------------- |
 | **Base Storage & Retrival** | **$2.5/TiB/month/copy** (minimum 2 copies) | Redundant storage ensures durability and continuous PDP verification.<br />Minimum monthly charge of **0.06 USDFC**, covering roughly **24 GiB** of total data (two copies). |
 | **Add-on Retrieval (Filecoin Beam)** | **Up to $0.014/GiB egress** | Charged for outbound data delivered via Filecoin Beam gateways or retrieval providers. |
+| **Create Data Set** | **$0.00112** to the storage provider, plus a **$0.10 Sybil fee** to the network | Provisioning a new Data Set. |
+| **Proving Service** | **$0.025 per Data Set / 30 days** | PDP proving cost per Data Set per 30-day period. |
+| **Add Piece** | **$0.002 per add operation** | Applies to each add operation. Batches support up to 61 pieces. |
+| **Delete Piece** | **$0.002 per delete operation** | Applies to deletion of a piece or batch. |
+| **Delete Data Set** | **$0.00112** | User-signed deletion; the storage provider receives gas reimbursement. |
+| **Terminate Service** | **$0.00112 per Data Set termination** | Charged when terminating service for a Data Set. |
 
 :::note[Verifiable Payment]
 All storage and retrieval charges are denominated in **USDFC** (or supported ERC-20 tokens) and settled via **Filecoin Pay**. Every transaction is on-chain, auditable, and linked to verifiable service proofs.


### PR DESCRIPTION
## Summary

- Adds detailed Filecoin Onchain Cloud operation pricing to the About page pricing table.
- Uses the finalized Proving Service price of $0.025 per Data Set / 30 days.
- Keeps unchanged operation prices from the source table.

Refs FilOzone/filecoin-cloud#290

## Testing

- pnpm dlx markdownlint-cli2 --config .github/.markdownlint-cli2.jsonc docs/src/content/docs/introduction/about.mdx
- git diff --check