### PR TITLE
docs(filbeam): add disclaimer about limited support

### DIFF
--- a/packages/synapse-sdk/src/filbeam/index.ts
+++ b/packages/synapse-sdk/src/filbeam/index.ts
@@ -5,7 +5,7 @@
  *
  * ## Disclaimer
  *
- * FilBeam is not currently fully supported -- use with caution. If you have a
+ * FilBeam is not currently a priority for active support and development, use with caution. If you have a
  * use case for FilBeam, please open an issue at
  * {@link https://github.com/filbeam/roadmap/issues} describing it, so we can
  * prioritize the work accordingly.

--- a/packages/synapse-sdk/src/filbeam/index.ts
+++ b/packages/synapse-sdk/src/filbeam/index.ts
@@ -3,6 +3,13 @@
  *
  * Client for the FilBeam stats API.
  *
+ * ## Disclaimer
+ *
+ * FilBeam is not currently fully supported -- use with caution. If you have a
+ * use case for FilBeam, please open an issue at
+ * {@link https://github.com/filbeam/roadmap/issues} describing it, so we can
+ * prioritize the work accordingly.
+ *
  * ## Overview
  *
  * FilBeam enables retrieval incentives for Filecoin PDP (Proof of Data Possession)


### PR DESCRIPTION
For https://github.com/filbeam/roadmap/issues/105#issuecomment-4464181349

## Summary
- Adds a Disclaimer section to the FilBeam module JSDoc noting that FilBeam isn't currently fully supported and should be used with caution.
- Links users to the [filbeam/roadmap issue tracker](https://github.com/filbeam/roadmap/issues) so they can submit their use cases.

## Test plan
- [ ] JSDoc renders correctly in the generated docs
- [ ] No lint or build regressions (`pnpm run lint:fix`, `pnpm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)