### PR TITLE
chore(synapse-core): update filecoin-services ref to v1.2.1

### DIFF
--- a/packages/synapse-core/wagmi.config.ts
+++ b/packages/synapse-core/wagmi.config.ts
@@ -7,7 +7,7 @@ import { ZodValidationError } from './src/errors/base.ts'
 import { zAddress, zAddressLoose } from './src/utils/schemas.ts'
 
 // GIT_REF can be one of: '<branch name>', '<commit>' or 'tags/<tag>'
-const FILECOIN_SERVICES_GIT_REF = 'd08214e1b3d200e0bc80f0d4f2e5ea3e1e4d603e' // v1.2.0
+const FILECOIN_SERVICES_GIT_REF = '4e548903095cfb46bc35af029f2ae0f39f18b8e4' // v1.2.1
 const FILECOIN_SERVICES_REF = FILECOIN_SERVICES_GIT_REF.replace(/^(?![a-f0-9]{40}$)/, 'refs/')
 const BASE_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/abi`
 const DEPLOYMENTS_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/deployments.json`


### PR DESCRIPTION
Automated update from FilOzone/filecoin-services release `v1.2.1`.

Changes:
- Updates `FILECOIN_SERVICES_GIT_REF` to `4e548903095cfb46bc35af029f2ae0f39f18b8e4`
- Regenerates synapse-core ABIs and contract addresses

Source:
- Release tag: https://github.com/FilOzone/filecoin-services/releases/tag/v1.2.1
- Workflow run: https://github.com/FilOzone/filecoin-services/actions/runs/26805761691
