### PR TITLE
fix(synapse-core): keep findPiece polling through transient 404s

### DIFF
--- a/packages/synapse-core/src/sp/find-piece.ts
+++ b/packages/synapse-core/src/sp/find-piece.ts
@@ -14,9 +14,9 @@ export namespace findPiece {
     signal?: AbortSignal
     /** The timeout in milliseconds. Defaults to 5 minutes. */
     timeout?: number
-    /** The number of retries. Defaults to 2. */
+    /** The number of retries. Defaults to polling until timeout when poll is true. */
     retryCount?: number
-    /** The delay with exponential backoff between retries in milliseconds. Defaults to {@link RETRY_CONSTANTS.RETRY_DELAY}. */
+    /** The delay between retries in milliseconds. Defaults to pollInterval when poll is true. */
     retryDelay?: number
     /** Whether to poll the request. Defaults to false. */
     poll?: boolean
@@ -38,12 +38,15 @@ export namespace findPiece {
 export async function findPiece(options: findPiece.OptionsType): Promise<findPiece.OutputType> {
   const { pieceCid, serviceURL } = options
   const params = new URLSearchParams({ pieceCid: pieceCid.toString() })
+  const retryCount = options.retryCount ?? (options.poll ? RETRY_CONSTANTS.POLL_LIMIT : undefined)
+  const retryDelay = options.retryDelay ?? (options.poll ? (options.pollInterval ?? 1000) : RETRY_CONSTANTS.RETRY_DELAY)
   const response = await request.json.get<{ pieceCid: string }>(new URL(`pdp/piece?${params.toString()}`, serviceURL), {
     signal: options.signal,
     timeout: options.timeout ?? RETRY_CONSTANTS.TIMEOUT,
     retry: {
-      retries: options.retryCount,
-      minTimeout: options.retryDelay ?? RETRY_CONSTANTS.RETRY_DELAY,
+      retries: retryCount,
+      factor: options.poll ? 1 : undefined,
+      minTimeout: retryDelay,
       shouldRetry: (ctx) => HttpError.is(ctx.error) && ctx.error.code === 404,
     },
     poll: options.poll

--- a/packages/synapse-core/test/sp.test.ts
+++ b/packages/synapse-core/test/sp.test.ts
@@ -1023,6 +1023,32 @@ InvalidSignature(address expected, address actual)
       assert.strictEqual(result.toString(), mockPieceCidStr)
       assert.isAtLeast(attemptCount, 3, 'Should have retried at least 3 times')
     })
+
+    it('should wait through 404 status until an uploaded piece becomes visible', async () => {
+      const pieceCid = Piece.from(mockPieceCidStr)
+      let attemptCount = 0
+
+      server.use(
+        http.get('http://pdp.local/pdp/piece', () => {
+          attemptCount++
+          if (attemptCount <= 12) {
+            return HttpResponse.text(null, { status: 404 })
+          }
+          return HttpResponse.json({ pieceCid: mockPieceCidStr }, { status: 200 })
+        })
+      )
+
+      const result = await findPiece({
+        serviceURL: 'http://pdp.local',
+        pieceCid,
+        poll: true,
+        pollInterval: 1,
+        timeout: 1000,
+      })
+
+      assert.strictEqual(result.toString(), mockPieceCidStr)
+      assert.strictEqual(attemptCount, 13)
+    })
   })
 
   describe('uploadPiece', () => {


### PR DESCRIPTION
When retryCount was omitted, iso-web 3.x defaulted 404 handling to only two retries, causing upload confirmation to fail before Curio promoted the piece. Use the polling timeout/cadence for 404s during findPiece polling and add a regression test for repeated 404s before success.