### PR TITLE
chore(synapse-core): update filecoin-services ref to v1.3.0

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -5,8 +5,6 @@
   "last-release-sha": "b28d3724f79407d3194613e762609ef5c841013c",
   "packages": {
     "packages/synapse-sdk": {
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
       "include-v-in-tag": true,
       "pull-request-header": "📦 Release Preparation",
       "pull-request-footer": "\n\n## 🚀 How to Release\n\n1. **Review** the changelog and version bump in this PR\n2. **Merge this PR** to trigger the release\n3. After merging, the workflow will:\n   - Create a GitHub release with tag ${version}\n   - Publish to npm automatically\n4. Wait until the workflow is complete before merging another release PR\n\n⚠️ **Note**: The release has NOT been created yet. It will only be created after you merge this PR.",

--- a/docs/src/content/docs/core-concepts/retrieval.mdx
+++ b/docs/src/content/docs/core-concepts/retrieval.mdx
@@ -26,7 +26,7 @@ FOC offers three ways to retrieve a piece. They share the same PieceCID and can 
 | ----- | ------- | ------- | ----------- |
 | **Direct SP `/piece` retrieval** | Storage provider `/piece` HTTP API | Seconds | Default. No extra setup or egress charges. |
 | **FilBeam (CDN) `/piece` retrieval** | Filecoin Beam cache, backed by SPs | Milliseconds | Hot data, frequent reads, latency-sensitive apps. |
-| **IPFS retrieval** | Storage provider `/ipfs` HTTP API, with potential IPFS HTTP gateway as an intermediary  | Varies | IPFS-native applications and gateways. |
+| **IPFS retrieval** | Storage provider `/ipfs` HTTP API, with potential IPFS HTTP gateway as an intermediary | Varies | IPFS-native applications and gateways. |
 
 ```mermaid
 graph TD
@@ -94,6 +94,7 @@ Note: FilBeam currently only supports `/piece` retrieval. `/ipfs` retrieval is c
 Service providers also expose an `/ipfs` endpoint, which serves as an [IPFS trustless gateway](https://specs.ipfs.tech/http-gateways/trustless-gateway/), the same protocol that [public IPFS gateways](https://docs.ipfs.tech/concepts/public-utilities/#public-ipfs-gateways) use.
 
 Data Sets that include `withIPFSIndexing` metadata index and announce their content to [IPNI](https://github.com/filecoin-project/filecoin-pin/blob/master/documentation/glossary.md#ipni), so it resolves through standard IPFS gateways and tooling including:
+
 - `https://inbrowser.link/ipfs/<ipfsCid>`: a verifiable Service Worker Gateway that fetches blocks and verifies them against the CID inside your browser using Helia's [`verified-fetch`](https://www.npmjs.com/package/@helia/verified-fetch) before rendering.
 - `https://dweb.link/ipfs/<ipfsCid>`: public gateways, which are [rate-limited and best-effort](https://about.ipfs.io/#public-utility).
 - [Helia](https://helia.io/)

--- a/packages/synapse-core/src/abis/generated.ts
+++ b/packages/synapse-core/src/abis/generated.ts
@@ -59,6 +59,19 @@ export const errorsAbi = [
     type: 'error',
     inputs: [
       { name: 'dataSetId', internalType: 'uint256', type: 'uint256' },
+      {
+        name: 'expectedServiceProvider',
+        internalType: 'address',
+        type: 'address',
+      },
+      { name: 'caller', internalType: 'address', type: 'address' },
+    ],
+    name: 'CallerNotServiceProvider',
+  },
+  {
+    type: 'error',
+    inputs: [
+      { name: 'dataSetId', internalType: 'uint256', type: 'uint256' },
       { name: 'windowStart', internalType: 'uint256', type: 'uint256' },
       { name: 'nowBlock', internalType: 'uint256', type: 'uint256' },
     ],
@@ -2684,6 +2697,19 @@ export const filecoinWarmStorageServiceAbi = [
     type: 'error',
     inputs: [
       { name: 'dataSetId', internalType: 'uint256', type: 'uint256' },
+      {
+        name: 'expectedServiceProvider',
+        internalType: 'address',
+        type: 'address',
+      },
+      { name: 'caller', internalType: 'address', type: 'address' },
+    ],
+    name: 'CallerNotServiceProvider',
+  },
+  {
+    type: 'error',
+    inputs: [
+      { name: 'dataSetId', internalType: 'uint256', type: 'uint256' },
       { name: 'windowStart', internalType: 'uint256', type: 'uint256' },
       { name: 'nowBlock', internalType: 'uint256', type: 'uint256' },
     ],
@@ -3004,7 +3030,7 @@ export const filecoinWarmStorageServiceConfig = {
 
 /**
  * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xB1B3A3d979c1f233c1021EF98dff9c0932FF1bb9)
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x537320bd004a7FDd3c1932ca64BD88268301322A)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xF4B446171b3677fD2B9b183a9fB76d517365700a)
  */
 export const filecoinWarmStorageServiceStateViewAbi = [
   {
@@ -3494,16 +3520,16 @@ export const filecoinWarmStorageServiceStateViewAbi = [
 
 /**
  * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xB1B3A3d979c1f233c1021EF98dff9c0932FF1bb9)
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x537320bd004a7FDd3c1932ca64BD88268301322A)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xF4B446171b3677fD2B9b183a9fB76d517365700a)
  */
 export const filecoinWarmStorageServiceStateViewAddress = {
   314: '0xB1B3A3d979c1f233c1021EF98dff9c0932FF1bb9',
-  314159: '0x537320bd004a7FDd3c1932ca64BD88268301322A',
+  314159: '0xF4B446171b3677fD2B9b183a9fB76d517365700a',
 } as const
 
 /**
  * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xB1B3A3d979c1f233c1021EF98dff9c0932FF1bb9)
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x537320bd004a7FDd3c1932ca64BD88268301322A)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xF4B446171b3677fD2B9b183a9fB76d517365700a)
  */
 export const filecoinWarmStorageServiceStateViewConfig = {
   address: filecoinWarmStorageServiceStateViewAddress,

--- a/packages/synapse-core/wagmi.config.ts
+++ b/packages/synapse-core/wagmi.config.ts
@@ -7,7 +7,7 @@ import { ZodValidationError } from './src/errors/base.ts'
 import { zAddress, zAddressLoose } from './src/utils/schemas.ts'
 
 // GIT_REF can be one of: '<branch name>', '<commit>' or 'tags/<tag>'
-const FILECOIN_SERVICES_GIT_REF = '02de64a17847f59262b535ab548cae6be307917f' // main
+const FILECOIN_SERVICES_GIT_REF = 'a592db5edfaf8557666097b4638ccbc826d55a9d' // v1.3.0
 const FILECOIN_SERVICES_REF = FILECOIN_SERVICES_GIT_REF.replace(/^(?![a-f0-9]{40}$)/, 'refs/')
 const BASE_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/abi`
 const DEPLOYMENTS_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/deployments.json`

--- a/packages/synapse-core/wagmi.config.ts
+++ b/packages/synapse-core/wagmi.config.ts
@@ -7,7 +7,7 @@ import { ZodValidationError } from './src/errors/base.ts'
 import { zAddress, zAddressLoose } from './src/utils/schemas.ts'
 
 // GIT_REF can be one of: '<branch name>', '<commit>' or 'tags/<tag>'
-const FILECOIN_SERVICES_GIT_REF = 'a592db5edfaf8557666097b4638ccbc826d55a9d' // v1.3.0
+const FILECOIN_SERVICES_GIT_REF = '7946bfec6a6d38e2cfaa8036b2f34146a4333cde' // v1.3.0
 const FILECOIN_SERVICES_REF = FILECOIN_SERVICES_GIT_REF.replace(/^(?![a-f0-9]{40}$)/, 'refs/')
 const BASE_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/abi`
 const DEPLOYMENTS_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/deployments.json`
@@ -25,6 +25,7 @@ const DeploymentSchema = z
     SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS: zAddress,
     SERVICE_PROVIDER_REGISTRY_IMPLEMENTATION_ADDRESS: zAddress,
     SIGNATURE_VERIFICATION_LIB_ADDRESS: zAddress,
+    RAILS_LIB_ADDRESS: zAddress.optional(),
     FWSS_PROXY_ADDRESS: zAddress,
     FWSS_IMPLEMENTATION_ADDRESS: zAddress,
     FWSS_VIEW_ADDRESS: zAddress,

--- a/packages/synapse-sdk/src/test/terminate-service.test.ts
+++ b/packages/synapse-sdk/src/test/terminate-service.test.ts
@@ -194,7 +194,7 @@ describe('StorageManager.terminateService', () => {
     const serviceTerminatedTopics = encodeEventTopics({
       abi: fwss,
       eventName: 'ServiceTerminated',
-      args: { caller: Mocks.ADDRESSES.client1, dataSetId },
+      args: { approver: Mocks.ADDRESSES.client1, dataSetId },
     })
     const serviceTerminatedData = encodeAbiParameters(
       [


### PR DESCRIPTION
Automated update from FilOzone/filecoin-services release `v1.3.0`.

Changes:
- Updates `FILECOIN_SERVICES_GIT_REF` to `3f3eceb47ce235cdbf3fb59cd919fcb4d483b08d`
- Regenerates synapse-core ABIs and contract addresses

Source:
- Release tag: https://github.com/FilOzone/filecoin-services/releases/tag/v1.3.0
- Workflow run: https://github.com/FilOzone/filecoin-services/actions/runs/27367127348
