### PR TITLE
chore: update release configuration and improve synapse-react documentation

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -5,6 +5,7 @@
   "last-release-sha": "b28d3724f79407d3194613e762609ef5c841013c",
   "packages": {
     "packages/synapse-sdk": {
+      "release-as": "1.0.1",
       "include-v-in-tag": true,
       "pull-request-header": "📦 Release Preparation",
       "pull-request-footer": "\n\n## 🚀 How to Release\n\n1. **Review** the changelog and version bump in this PR\n2. **Merge this PR** to trigger the release\n3. After merging, the workflow will:\n   - Create a GitHub release with tag ${version}\n   - Publish to npm automatically\n4. Wait until the workflow is complete before merging another release PR\n\n⚠️ **Note**: The release has NOT been created yet. It will only be created after you merge this PR.",

--- a/packages/synapse-react/README.md
+++ b/packages/synapse-react/README.md
@@ -6,15 +6,15 @@
 
 ## Overview
 
-TODO
+Synapse React provides React hooks for building Filecoin Onchain Cloud applications with wagmi, viem, and TanStack Query. It wraps common Synapse storage and payment flows so React apps can query contract state, manage payment balances and operator approvals, discover Warm Storage providers, create data sets, and upload or delete pieces.
+
+Use this package when you want wallet-connected React components to interact with Synapse without wiring contract reads, writes, transaction receipts, and query invalidation by hand. For lower-level control outside React, use `@filoz/synapse-sdk` directly.
 
 ## Installation
 
 ```bash
-pnpm install @filoz/synapse-core viem@2.x
+pnpm install @filoz/synapse-react wagmi@3.x @tanstack/react-query@5.x viem@2.x
 ```
-
-Note: `viem` is a peer dependency and must be installed separately.
 
 ## Docs
 

--- a/packages/synapse-sdk/README.md
+++ b/packages/synapse-sdk/README.md
@@ -4,14 +4,6 @@
 
 A JavaScript/TypeScript SDK for interacting with Filecoin Synapse - a smart-contract based marketplace for storage and other services in the Filecoin ecosystem.
 
-> ⚠️ **BREAKING CHANGES in v0.24.0**: Major updates have been introduced:
->
-> - **Terminology**: **Pandora** is now **Warm Storage**, **Proof Sets** are now **Data Sets**, **Roots** are now **Pieces** and **Storage Providers** are now **Service Providers**
-> - **Storage API**: Improved with a new context-based architecture
-> - **PaymentsService**: Method signatures updated for consistency - `token` parameter is now always last and defaults to USDFC
->
-> See the [Migration Guide](#migration-guide) for detailed migration instructions.
-
 ## Overview
 
 The Synapse SDK provides an interface to Filecoin's decentralized services ecosystem:
@@ -41,10 +33,6 @@ Note: `viem` is a peer dependency and must be installed separately.
 ## Docs
 
 Check the documentation [website](https://synapse.filecoin.services/)
-
-## Telemetry
-
-See [telemetry.md](../../docs/src/content/docs/guides/telemetry.md).
 
 ## Contributing
 

--- a/packages/synapse-sdk/package.json
+++ b/packages/synapse-sdk/package.json
@@ -4,7 +4,8 @@
   "description": "JavaScript SDK for Filecoin Onchain Cloud",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FilOzone/synapse-sdk.git"
+    "url": "git+https://github.com/FilOzone/synapse-sdk.git",
+    "directory": "packages/synapse-sdk"
   },
   "keywords": [
     "filecoin",


### PR DESCRIPTION
- Set release version for synapse-sdk to 1.0.1 in release-please configuration.
- Enhance synapse-react README with a detailed overview of its functionality and installation instructions.
- Update synapse-sdk package.json to specify the directory for the repository.
- Clean up synapse-sdk README by removing outdated breaking change notes and telemetry section.