### PR TITLE
chore(synapse-core): update filecoin-services ref to final v1.3.0 deployments

### DIFF
--- a/packages/synapse-core/src/abis/generated.ts
+++ b/packages/synapse-core/src/abis/generated.ts
@@ -3029,7 +3029,7 @@ export const filecoinWarmStorageServiceConfig = {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xB1B3A3d979c1f233c1021EF98dff9c0932FF1bb9)
+ * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xAD28BBF18A72f728Ed816D07F5a1d7Ec40D68b5e)
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xF4B446171b3677fD2B9b183a9fB76d517365700a)
  */
 export const filecoinWarmStorageServiceStateViewAbi = [
@@ -3519,16 +3519,16 @@ export const filecoinWarmStorageServiceStateViewAbi = [
 ] as const
 
 /**
- * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xB1B3A3d979c1f233c1021EF98dff9c0932FF1bb9)
+ * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xAD28BBF18A72f728Ed816D07F5a1d7Ec40D68b5e)
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xF4B446171b3677fD2B9b183a9fB76d517365700a)
  */
 export const filecoinWarmStorageServiceStateViewAddress = {
-  314: '0xB1B3A3d979c1f233c1021EF98dff9c0932FF1bb9',
+  314: '0xAD28BBF18A72f728Ed816D07F5a1d7Ec40D68b5e',
   314159: '0xF4B446171b3677fD2B9b183a9fB76d517365700a',
 } as const
 
 /**
- * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xB1B3A3d979c1f233c1021EF98dff9c0932FF1bb9)
+ * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xAD28BBF18A72f728Ed816D07F5a1d7Ec40D68b5e)
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0xF4B446171b3677fD2B9b183a9fB76d517365700a)
  */
 export const filecoinWarmStorageServiceStateViewConfig = {

--- a/packages/synapse-core/wagmi.config.ts
+++ b/packages/synapse-core/wagmi.config.ts
@@ -7,7 +7,7 @@ import { ZodValidationError } from './src/errors/base.ts'
 import { zAddress, zAddressLoose } from './src/utils/schemas.ts'
 
 // GIT_REF can be one of: '<branch name>', '<commit>' or 'tags/<tag>'
-const FILECOIN_SERVICES_GIT_REF = '7946bfec6a6d38e2cfaa8036b2f34146a4333cde' // v1.3.0
+const FILECOIN_SERVICES_GIT_REF = '3f3eceb47ce235cdbf3fb59cd919fcb4d483b08d' // v1.3.0
 const FILECOIN_SERVICES_REF = FILECOIN_SERVICES_GIT_REF.replace(/^(?![a-f0-9]{40}$)/, 'refs/')
 const BASE_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/abi`
 const DEPLOYMENTS_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/deployments.json`


### PR DESCRIPTION
Automated update from FilOzone/filecoin-services release `v1.3.0` after final Mainnet deployment metadata landed.

Changes:
- Updates `FILECOIN_SERVICES_GIT_REF` to `3f3eceb47ce235cdbf3fb59cd919fcb4d483b08d`
- Regenerates synapse-core ABIs and contract addresses
- Picks up the final Mainnet FWSS v1.3.0 implementation, StateView, `SignatureVerificationLib`, and `Rails` metadata from filecoin-services #523

Context:
- The manual sync workflow succeeded, but it reused the old branch name from merged #831, so this PR carries the workflow-generated commit on a fresh branch.

Source:
- filecoin-services deployments PR: https://github.com/FilOzone/filecoin-services/pull/523
- Release tag: https://github.com/FilOzone/filecoin-services/releases/tag/v1.3.0
- Workflow run: https://github.com/FilOzone/filecoin-services/actions/runs/27367127348
