### PR TITLE
feat(warm-storage): add hasActivePieces and use it in resolveByProviderId

### DIFF
--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -483,7 +483,7 @@ export class StorageContext {
     type EvaluatedDataSet = {
       dataSetId: bigint
       dataSetMetadata: Record<string, string>
-      activePieceCount: bigint
+      hasPieces: boolean
     }
 
     // Sort ascending by ID (oldest first) for deterministic selection
@@ -501,9 +501,9 @@ export class StorageContext {
       const batchResults: (EvaluatedDataSet | null)[] = await Promise.all(
         sortedDataSets.slice(i, i + BATCH_SIZE).map(async (dataSet) => {
           const { dataSetId } = dataSet
-          const [dataSetMetadata, activePieceCount] = await Promise.all([
+          const [dataSetMetadata, hasPieces] = await Promise.all([
             warmStorageService.getDataSetMetadata({ dataSetId }),
-            warmStorageService.getActivePieceCount({ dataSetId }),
+            warmStorageService.hasActivePieces({ dataSetId }),
           ])
 
           if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
@@ -513,7 +513,7 @@ export class StorageContext {
           return {
             dataSetId,
             dataSetMetadata,
-            activePieceCount,
+            hasPieces,
           }
         })
       )
@@ -521,7 +521,7 @@ export class StorageContext {
       for (const result of batchResults) {
         if (result == null) continue
 
-        if (result.activePieceCount > 0) {
+        if (result.hasPieces) {
           selectedDataSet = result
           break
         }
@@ -531,7 +531,7 @@ export class StorageContext {
         }
       }
 
-      if (selectedDataSet != null && selectedDataSet.activePieceCount > 0) {
+      if (selectedDataSet?.hasPieces) {
         break
       }
     }

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -314,13 +314,13 @@ describe('StorageService', () => {
           ...Mocks.presets.basic,
           pdpVerifier: {
             ...Mocks.presets.basic.pdpVerifier,
-            getActivePieceCount: (args) => {
+            getActivePieces: (args) => {
               const [dataSetId] = args
               if (dataSetId === 2n) {
-                return [2n]
-              } else {
-                return [0n]
+                const cid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+                return [[{ data: bytesToHex(cid.bytes) }], [101n], false]
               }
+              return [[], [], false]
             },
           },
           warmStorageView: {

--- a/packages/synapse-sdk/src/test/warm-storage-service.test.ts
+++ b/packages/synapse-sdk/src/test/warm-storage-service.test.ts
@@ -8,7 +8,8 @@ import { calibration } from '@filoz/synapse-core/chains'
 import * as Mocks from '@filoz/synapse-core/mocks'
 import { assert } from 'chai'
 import { setup } from 'iso-web/msw'
-import { type Address, createWalletClient, http as viemHttp } from 'viem'
+import { CID } from 'multiformats/cid'
+import { type Address, bytesToHex, createWalletClient, http as viemHttp } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { WarmStorageService } from '../warm-storage/index.ts'
 
@@ -44,6 +45,37 @@ describe('WarmStorageService', () => {
       const warmStorageService = await createWarmStorageService()
       assert.exists(warmStorageService)
       assert.isFunction(warmStorageService.getClientDataSets)
+    })
+  })
+
+  describe('hasActivePieces', () => {
+    it('should return true when the data set has at least one active piece', async () => {
+      const cid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          pdpVerifier: {
+            ...Mocks.presets.basic.pdpVerifier,
+            getActivePieces: () => [[{ data: bytesToHex(cid.bytes) }], [101n], false],
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+      assert.isTrue(await warmStorageService.hasActivePieces({ dataSetId: 1n }))
+    })
+
+    it('should return false when the data set has no active pieces', async () => {
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          pdpVerifier: {
+            ...Mocks.presets.basic.pdpVerifier,
+            getActivePieces: () => [[], [], false],
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+      assert.isFalse(await warmStorageService.hasActivePieces({ dataSetId: 1n }))
     })
   })
 

--- a/packages/synapse-sdk/src/warm-storage/service.ts
+++ b/packages/synapse-sdk/src/warm-storage/service.ts
@@ -292,6 +292,24 @@ export class WarmStorageService {
     return PDPVerifier.getActivePieceCount(this._client, { dataSetId: options.dataSetId })
   }
 
+  /**
+   * Report whether a data set has at least one active piece.
+   *
+   * Reads a single piece (`limit: 1`) rather than the full active-piece count, so
+   * the cost is independent of how many pieces the data set holds.
+   * @param options - Options for the data set
+   * @param options.dataSetId - The PDPVerifier data set ID
+   * @returns True when the data set has at least one active piece
+   */
+  async hasActivePieces(options: { dataSetId: bigint }): Promise<boolean> {
+    const { pieces } = await PDPVerifier.getActivePieces(this._client, {
+      dataSetId: options.dataSetId,
+      offset: 0n,
+      limit: 1n,
+    })
+    return pieces.length > 0
+  }
+
   // ========== Metadata Operations ==========
 
   /**


### PR DESCRIPTION
## What changed

`WarmStorageService.hasActivePieces({ dataSetId })` returns whether a data set has any active piece by reading one piece (`getActivePieces({ offset: 0n, limit: 1n })`), and `resolveByProviderId` uses it for the has-pieces check instead of `getActivePieceCount > 0`. `getActivePieceCount` is O(n) in piece count and reverts on large data sets (FilOzone/pdp#265); the bounded read avoids that.

## How to verify

`hasActivePieces` returns true when a piece exists and false when none (`warm-storage-service.test.ts`). `resolveByProviderId` still prefers a non-empty match (`storage.test.ts`).

Refs FilOzone/pdp#265.
