### PR TITLE
perf(storage): bound resolveByProviderId concurrency with sliding window

### DIFF
--- a/packages/synapse-core/src/mocks/jsonrpc/index.ts
+++ b/packages/synapse-core/src/mocks/jsonrpc/index.ts
@@ -77,9 +77,23 @@ function jsonrpcHandler(item: RpcRequest, options?: JSONRPCOptions): RpcResponse
 }
 
 /**
+ * Hooks for the mock JSONRPC server.
+ */
+export interface JSONRPCHooks {
+  /**
+   * Awaited before each request is answered. Return a promise to inject
+   * deterministic latency per request (e.g. to pin completion order in tests
+   * that exercise concurrent reads). Resolves immediately when omitted. Sees the
+   * top-level request only; calls nested inside a Multicall3 batch are not
+   * surfaced individually.
+   */
+  delay?: (request: RpcRequest) => Promise<void> | void
+}
+
+/**
  * Mock JSONRPC server for testing
  */
-export function JSONRPC(options?: JSONRPCOptions) {
+export function JSONRPC(options?: JSONRPCOptions, hooks?: JSONRPCHooks) {
   return http.post<Record<string, any>, RpcRequest | RpcRequest[], RpcResponse | RpcResponse[]>(
     'https://api.calibration.node.glif.io/rpc/v1',
     async ({ request }) => {
@@ -87,10 +101,12 @@ export function JSONRPC(options?: JSONRPCOptions) {
       if (Array.isArray(body)) {
         const results: RpcResponse[] = []
         for (const item of body) {
+          await hooks?.delay?.(item)
           results.push(jsonrpcHandler(item, options))
         }
         return HttpResponse.json(results)
       } else {
+        await hooks?.delay?.(body)
         return HttpResponse.json(jsonrpcHandler(body, options))
       }
     }

--- a/packages/synapse-sdk/package.json
+++ b/packages/synapse-sdk/package.json
@@ -145,8 +145,7 @@
   },
   "dependencies": {
     "@filoz/synapse-core": "workspace:^",
-    "multiformats": "^14.0.0",
-    "p-queue": "^9.1.2"
+    "multiformats": "^14.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",

--- a/packages/synapse-sdk/package.json
+++ b/packages/synapse-sdk/package.json
@@ -145,7 +145,8 @@
   },
   "dependencies": {
     "@filoz/synapse-core": "workspace:^",
-    "multiformats": "^14.0.0"
+    "multiformats": "^14.0.0",
+    "p-queue": "^9.1.2"
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -494,7 +494,7 @@ export class StorageContext {
     type EvaluatedDataSet = {
       dataSetId: bigint
       dataSetMetadata: Record<string, string>
-      hasPieces: boolean
+      activePieceCount: bigint
     }
 
     // Sort ascending by ID (oldest first) for deterministic selection
@@ -517,35 +517,44 @@ export class StorageContext {
     let firstMatchIndex = Number.POSITIVE_INFINITY
     let bestNonEmptyIndex = Number.POSITIVE_INFINITY
 
-    await Promise.all(
-      sortedDataSets.map((dataSet, index) =>
-        queue.add(async () => {
-          if (index > bestNonEmptyIndex) {
-            return
-          }
+    try {
+      await Promise.all(
+        sortedDataSets.map((dataSet, index) =>
+          queue.add(async () => {
+            if (index > bestNonEmptyIndex) {
+              return
+            }
 
-          const { dataSetId } = dataSet
-          const dataSetMetadata = await warmStorageService.getDataSetMetadata({ dataSetId })
-          if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
-            return
-          }
+            const { dataSetId } = dataSet
+            const dataSetMetadata = await warmStorageService.getDataSetMetadata({ dataSetId })
+            if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
+              return
+            }
 
-          if (index < firstMatchIndex) {
-            firstMatchIndex = index
-          }
+            if (index < firstMatchIndex) {
+              firstMatchIndex = index
+            }
 
-          if (index > bestNonEmptyIndex) {
-            return
-          }
+            if (index > bestNonEmptyIndex) {
+              return
+            }
 
-          const hasPieces = await warmStorageService.hasActivePieces({ dataSetId })
-          evaluated[index] = { dataSetId, dataSetMetadata, hasPieces }
-          if (hasPieces && index < bestNonEmptyIndex) {
-            bestNonEmptyIndex = index
-          }
-        })
+            const activePieceCount = await warmStorageService.getActivePieceCount({ dataSetId })
+            evaluated[index] = { dataSetId, dataSetMetadata, activePieceCount }
+            if (activePieceCount > 0n && index < bestNonEmptyIndex) {
+              bestNonEmptyIndex = index
+            }
+          })
+        )
       )
-    )
+    } finally {
+      // A rejected read settles Promise.all immediately, but the queue keeps
+      // draining the tasks it has not started yet. Clear it so a failed resolve
+      // stops issuing reads instead of running the fan-out this is meant to
+      // bound. In-flight reads (at most RESOLVE_CONCURRENCY) cannot be cancelled
+      // and run to completion. On success the queue is already empty.
+      queue.clear()
+    }
 
     const selectedIndex = bestNonEmptyIndex === Number.POSITIVE_INFINITY ? firstMatchIndex : bestNonEmptyIndex
     const selectedDataSet = selectedIndex === Number.POSITIVE_INFINITY ? null : evaluated[selectedIndex]

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -463,8 +463,8 @@ export class StorageContext {
    * 1. Filters for the provider's active datasets owned by the client
    * 2. Sorts by dataSetId ascending (oldest first)
    * 3. Evaluates datasets oldest-first through a sliding pool of at most
-   *    RESOLVE_CONCURRENCY reads, reading metadata before activePieceCount
-   * 4. Prefers the oldest metadata match with activePieceCount > 0, otherwise the
+   *    RESOLVE_CONCURRENCY reads, reading metadata before checking for pieces
+   * 4. Prefers the oldest metadata match that has active pieces, otherwise the
    *    oldest metadata match; returns null when nothing matches
    * 5. Stops starting datasets newer than the oldest non-empty match once it is
    *    known, so the read fan-out shrinks to roughly the match position
@@ -496,18 +496,21 @@ export class StorageContext {
     type EvaluatedDataSet = {
       dataSetId: bigint
       dataSetMetadata: Record<string, string>
-      activePieceCount: bigint
+      hasPieces: boolean
     }
 
-    // Sort ascending by ID (oldest first) for deterministic selection
+    // Sort ascending by ID (oldest first) for deterministic selection. Compare
+    // as bigint so ordering stays correct for IDs beyond Number.MAX_SAFE_INTEGER.
     const sortedDataSets = providerDataSets.sort((a, b) => {
-      return Number(a.dataSetId) - Number(b.dataSetId)
+      if (a.dataSetId < b.dataSetId) return -1
+      if (a.dataSetId > b.dataSetId) return 1
+      return 0
     })
 
     // Result is selected by index, not completion order, because reads finish out
     // of order: `bestNonEmptyIndex` is the oldest non-empty metadata match and
     // `firstMatchIndex` the oldest metadata match (the fallback). Metadata is read
-    // first and getActivePieceCount only on a metadata match, so non-matching
+    // first and hasActivePieces only on a metadata match, so non-matching
     // datasets skip the piece-count read.
     const evaluated: (EvaluatedDataSet | null)[] = new Array(sortedDataSets.length).fill(null)
     let firstMatchIndex = Number.POSITIVE_INFINITY
@@ -534,9 +537,9 @@ export class StorageContext {
         return
       }
 
-      const activePieceCount = await warmStorageService.getActivePieceCount({ dataSetId })
-      evaluated[index] = { dataSetId, dataSetMetadata, activePieceCount }
-      if (activePieceCount > 0n && index < bestNonEmptyIndex) {
+      const hasPieces = await warmStorageService.hasActivePieces({ dataSetId })
+      evaluated[index] = { dataSetId, dataSetMetadata, hasPieces }
+      if (hasPieces && index < bestNonEmptyIndex) {
         bestNonEmptyIndex = index
       }
     }

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -50,7 +50,6 @@ import {
   type ResolvedLocation,
   selectProviders,
 } from '@filoz/synapse-core/warm-storage'
-import PQueue from 'p-queue'
 import type { Account, Address, Chain, Client, Hash, Hex, Transport } from 'viem'
 import { getBlockNumber } from 'viem/actions'
 import { SPRegistryService } from '../sp-registry/index.ts'
@@ -86,10 +85,12 @@ const NO_REMAINING_PROVIDERS_ERROR_MESSAGE = 'No approved service providers avai
 /**
  * Maximum concurrent per-dataset reads while resolving a provider's matching
  * data set in {@link StorageContext.resolveByProviderId}. Datasets are evaluated
- * oldest-first by a pool of this many workers, capping RPC fan-out for clients
- * with many datasets per provider (FilOzone/synapse-sdk#631).
+ * oldest-first by a sliding pool of this many reads, capping RPC fan-out for
+ * clients with many datasets per provider (FilOzone/synapse-sdk#631).
+ *
+ * Exported so tests can derive expected call bounds from it instead of hard-coding.
  */
-const RESOLVE_CONCURRENCY = 10
+export const RESOLVE_CONCURRENCY = 10
 
 export interface StorageContextOptions {
   /** The Synapse instance */
@@ -461,14 +462,15 @@ export class StorageContext {
    * Selection logic:
    * 1. Filters for the provider's active datasets owned by the client
    * 2. Sorts by dataSetId ascending (oldest first)
-   * 3. Evaluates datasets oldest-first with bounded concurrency, reading metadata
-   *    before activePieceCount
+   * 3. Evaluates datasets oldest-first through a sliding pool of at most
+   *    RESOLVE_CONCURRENCY reads, reading metadata before activePieceCount
    * 4. Prefers the oldest metadata match with activePieceCount > 0, otherwise the
    *    oldest metadata match; returns null when nothing matches
-   * 5. Stops once the oldest non-empty metadata match is known
+   * 5. Stops starting datasets newer than the oldest non-empty match once it is
+   *    known, so the read fan-out shrinks to roughly the match position
    *
-   * Reads are bounded by RESOLVE_CONCURRENCY to cap RPC fan-out for clients with
-   * many datasets per provider (FilOzone/synapse-sdk#631).
+   * The pool caps RPC fan-out for clients with many datasets per provider
+   * (FilOzone/synapse-sdk#631).
    */
   private static async resolveByProviderId(
     clientAddress: Address,
@@ -502,58 +504,81 @@ export class StorageContext {
       return Number(a.dataSetId) - Number(b.dataSetId)
     })
 
-    // Evaluate datasets oldest-first with at most RESOLVE_CONCURRENCY reads in
-    // flight, bounded by a queue. Metadata is read first and getActivePieceCount
-    // only on a metadata match, so the piece-count read is skipped for
-    // non-matching datasets.
-    //
-    // Reads complete out of order, so the result is selected by index rather than
-    // completion order: `bestNonEmptyIndex` tracks the oldest non-empty match and
-    // `firstMatchIndex` the oldest metadata match (the fallback). A task whose
-    // index is newer than a known non-empty match skips its reads, so the reads
-    // stop once the oldest non-empty match is found.
-    const queue = new PQueue({ concurrency: RESOLVE_CONCURRENCY })
+    // Result is selected by index, not completion order, because reads finish out
+    // of order: `bestNonEmptyIndex` is the oldest non-empty metadata match and
+    // `firstMatchIndex` the oldest metadata match (the fallback). Metadata is read
+    // first and getActivePieceCount only on a metadata match, so non-matching
+    // datasets skip the piece-count read.
     const evaluated: (EvaluatedDataSet | null)[] = new Array(sortedDataSets.length).fill(null)
     let firstMatchIndex = Number.POSITIVE_INFINITY
     let bestNonEmptyIndex = Number.POSITIVE_INFINITY
 
-    try {
-      await Promise.all(
-        sortedDataSets.map((dataSet, index) =>
-          queue.add(async () => {
-            if (index > bestNonEmptyIndex) {
-              return
-            }
+    const evaluate = async (index: number, dataSetId: bigint): Promise<void> => {
+      // bestNonEmptyIndex can drop below this index after the task starts (an
+      // older read finished and found pieces), so re-check here and after the
+      // metadata read to drop work that can no longer win.
+      if (index > bestNonEmptyIndex) {
+        return
+      }
 
-            const { dataSetId } = dataSet
-            const dataSetMetadata = await warmStorageService.getDataSetMetadata({ dataSetId })
-            if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
-              return
-            }
+      const dataSetMetadata = await warmStorageService.getDataSetMetadata({ dataSetId })
+      if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
+        return
+      }
 
-            if (index < firstMatchIndex) {
-              firstMatchIndex = index
-            }
+      if (index < firstMatchIndex) {
+        firstMatchIndex = index
+      }
 
-            if (index > bestNonEmptyIndex) {
-              return
-            }
+      if (index > bestNonEmptyIndex) {
+        return
+      }
 
-            const activePieceCount = await warmStorageService.getActivePieceCount({ dataSetId })
-            evaluated[index] = { dataSetId, dataSetMetadata, activePieceCount }
-            if (activePieceCount > 0n && index < bestNonEmptyIndex) {
-              bestNonEmptyIndex = index
-            }
+      const activePieceCount = await warmStorageService.getActivePieceCount({ dataSetId })
+      evaluated[index] = { dataSetId, dataSetMetadata, activePieceCount }
+      if (activePieceCount > 0n && index < bestNonEmptyIndex) {
+        bestNonEmptyIndex = index
+      }
+    }
+
+    // Sliding pool: keep at most RESOLVE_CONCURRENCY reads in flight, topping up
+    // the instant one finishes so the window slides forward instead of stalling
+    // at a batch boundary. Datasets newer than the oldest non-empty match are
+    // never started, so the fan-out shrinks to roughly the match position.
+    const inFlight = new Set<Promise<void>>()
+    let nextIndex = 0
+    let failure: unknown
+    while (nextIndex < sortedDataSets.length || inFlight.size > 0) {
+      while (
+        failure == null &&
+        inFlight.size < RESOLVE_CONCURRENCY &&
+        nextIndex < sortedDataSets.length &&
+        nextIndex <= bestNonEmptyIndex
+      ) {
+        const index = nextIndex++
+        const task = evaluate(index, sortedDataSets[index].dataSetId)
+          .catch((error) => {
+            failure ??= error
           })
-        )
-      )
-    } finally {
-      // A rejected read settles Promise.all immediately, but the queue keeps
-      // draining the tasks it has not started yet. Clear it so a failed resolve
-      // stops issuing reads instead of running the fan-out this is meant to
-      // bound. In-flight reads (at most RESOLVE_CONCURRENCY) cannot be cancelled
-      // and run to completion. On success the queue is already empty.
-      queue.clear()
+          .finally(() => {
+            inFlight.delete(task)
+          })
+        inFlight.add(task)
+      }
+
+      // Nothing left to start (failure, or every remaining dataset is newer than
+      // the oldest non-empty match) and nothing in flight: done.
+      if (inFlight.size === 0) {
+        break
+      }
+      await Promise.race(inFlight)
+      if (failure != null) {
+        break
+      }
+    }
+
+    if (failure != null) {
+      throw failure
     }
 
     const selectedIndex = bestNonEmptyIndex === Number.POSITIVE_INFINITY ? firstMatchIndex : bestNonEmptyIndex

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -50,6 +50,7 @@ import {
   type ResolvedLocation,
   selectProviders,
 } from '@filoz/synapse-core/warm-storage'
+import PQueue from 'p-queue'
 import type { Account, Address, Chain, Client, Hash, Hex, Transport } from 'viem'
 import { getBlockNumber } from 'viem/actions'
 import { SPRegistryService } from '../sp-registry/index.ts'
@@ -502,48 +503,49 @@ export class StorageContext {
     })
 
     // Evaluate datasets oldest-first with at most RESOLVE_CONCURRENCY reads in
-    // flight. A pool of workers pulls datasets in ascending-id order; each reads
-    // metadata first and only reads activePieceCount on a metadata match, so the
-    // expensive piece-count read is skipped for non-matching datasets.
+    // flight, bounded by a queue. Metadata is read first and getActivePieceCount
+    // only on a metadata match, so the piece-count read is skipped for
+    // non-matching datasets.
     //
     // Reads complete out of order, so the result is selected by index rather than
     // completion order: `bestNonEmptyIndex` tracks the oldest non-empty match and
-    // `firstMatchIndex` the oldest metadata match (the fallback). A worker stops
-    // pulling datasets newer than a known non-empty match, since none of those can
-    // be older than it; datasets older than it are always pulled, so the oldest
-    // non-empty match is found.
+    // `firstMatchIndex` the oldest metadata match (the fallback). A task whose
+    // index is newer than a known non-empty match skips its reads, so the reads
+    // stop once the oldest non-empty match is found.
+    const queue = new PQueue({ concurrency: RESOLVE_CONCURRENCY })
     const evaluated: (EvaluatedDataSet | null)[] = new Array(sortedDataSets.length).fill(null)
     let firstMatchIndex = Number.POSITIVE_INFINITY
     let bestNonEmptyIndex = Number.POSITIVE_INFINITY
-    let nextIndex = 0
 
-    const worker = async (): Promise<void> => {
-      while (true) {
-        const index = nextIndex++
-        if (index >= sortedDataSets.length || index > bestNonEmptyIndex) {
-          return
-        }
+    await Promise.all(
+      sortedDataSets.map((dataSet, index) =>
+        queue.add(async () => {
+          if (index > bestNonEmptyIndex) {
+            return
+          }
 
-        const { dataSetId } = sortedDataSets[index]
-        const dataSetMetadata = await warmStorageService.getDataSetMetadata({ dataSetId })
-        if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
-          continue
-        }
+          const { dataSetId } = dataSet
+          const dataSetMetadata = await warmStorageService.getDataSetMetadata({ dataSetId })
+          if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
+            return
+          }
 
-        if (index < firstMatchIndex) {
-          firstMatchIndex = index
-        }
+          if (index < firstMatchIndex) {
+            firstMatchIndex = index
+          }
 
-        const hasPieces = await warmStorageService.hasActivePieces({ dataSetId })
-        evaluated[index] = { dataSetId, dataSetMetadata, hasPieces }
-        if (hasPieces && index < bestNonEmptyIndex) {
-          bestNonEmptyIndex = index
-        }
-      }
-    }
+          if (index > bestNonEmptyIndex) {
+            return
+          }
 
-    const workerCount = Math.min(RESOLVE_CONCURRENCY, sortedDataSets.length)
-    await Promise.all(Array.from({ length: workerCount }, () => worker()))
+          const hasPieces = await warmStorageService.hasActivePieces({ dataSetId })
+          evaluated[index] = { dataSetId, dataSetMetadata, hasPieces }
+          if (hasPieces && index < bestNonEmptyIndex) {
+            bestNonEmptyIndex = index
+          }
+        })
+      )
+    )
 
     const selectedIndex = bestNonEmptyIndex === Number.POSITIVE_INFINITY ? firstMatchIndex : bestNonEmptyIndex
     const selectedDataSet = selectedIndex === Number.POSITIVE_INFINITY ? null : evaluated[selectedIndex]

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -82,6 +82,14 @@ import { terminateServiceFlow } from './terminate.ts'
 
 const NO_REMAINING_PROVIDERS_ERROR_MESSAGE = 'No approved service providers available'
 
+/**
+ * Maximum concurrent per-dataset reads while resolving a provider's matching
+ * data set in {@link StorageContext.resolveByProviderId}. Datasets are evaluated
+ * oldest-first by a pool of this many workers, capping RPC fan-out for clients
+ * with many datasets per provider (FilOzone/synapse-sdk#631).
+ */
+const RESOLVE_CONCURRENCY = 10
+
 export interface StorageContextOptions {
   /** The Synapse instance */
   synapse: Synapse
@@ -450,14 +458,16 @@ export class StorageContext {
    * Resolve the best matching DataSet for a Provider using a specific provider ID.
    *
    * Selection logic:
-   * 1. Filters for datasets belonging to this provider
+   * 1. Filters for the provider's active datasets owned by the client
    * 2. Sorts by dataSetId ascending (oldest first)
-   * 3. Searches in batches for metadata match
-   * 4. Prioritizes datasets with pieces > 0, then falls back to the oldest valid dataset
-   * 5. Exits early as soon as a non-empty matching dataset is found
+   * 3. Evaluates datasets oldest-first with bounded concurrency, reading metadata
+   *    before activePieceCount
+   * 4. Prefers the oldest metadata match with activePieceCount > 0, otherwise the
+   *    oldest metadata match; returns null when nothing matches
+   * 5. Stops once the oldest non-empty metadata match is known
    *
-   * The batched enrichment exists to bound RPC calls for accounts with many
-   * datasets. Before simplifying, see https://github.com/FilOzone/synapse-sdk/issues/631
+   * Reads are bounded by RESOLVE_CONCURRENCY to cap RPC fan-out for clients with
+   * many datasets per provider (FilOzone/synapse-sdk#631).
    */
   private static async resolveByProviderId(
     clientAddress: Address,
@@ -491,50 +501,52 @@ export class StorageContext {
       return Number(a.dataSetId) - Number(b.dataSetId)
     })
 
-    // Batch enrichment to bound concurrent RPC calls (PR #487)
-    const MIN_BATCH_SIZE = 50
-    const MAX_BATCH_SIZE = 200
-    const BATCH_SIZE = Math.min(MAX_BATCH_SIZE, Math.max(MIN_BATCH_SIZE, Math.ceil(sortedDataSets.length / 3), 1))
-    let selectedDataSet: EvaluatedDataSet | null = null
+    // Evaluate datasets oldest-first with at most RESOLVE_CONCURRENCY reads in
+    // flight. A pool of workers pulls datasets in ascending-id order; each reads
+    // metadata first and only reads activePieceCount on a metadata match, so the
+    // expensive piece-count read is skipped for non-matching datasets.
+    //
+    // Reads complete out of order, so the result is selected by index rather than
+    // completion order: `bestNonEmptyIndex` tracks the oldest non-empty match and
+    // `firstMatchIndex` the oldest metadata match (the fallback). A worker stops
+    // pulling datasets newer than a known non-empty match, since none of those can
+    // be older than it; datasets older than it are always pulled, so the oldest
+    // non-empty match is found.
+    const evaluated: (EvaluatedDataSet | null)[] = new Array(sortedDataSets.length).fill(null)
+    let firstMatchIndex = Number.POSITIVE_INFINITY
+    let bestNonEmptyIndex = Number.POSITIVE_INFINITY
+    let nextIndex = 0
 
-    for (let i = 0; i < sortedDataSets.length; i += BATCH_SIZE) {
-      const batchResults: (EvaluatedDataSet | null)[] = await Promise.all(
-        sortedDataSets.slice(i, i + BATCH_SIZE).map(async (dataSet) => {
-          const { dataSetId } = dataSet
-          const [dataSetMetadata, hasPieces] = await Promise.all([
-            warmStorageService.getDataSetMetadata({ dataSetId }),
-            warmStorageService.hasActivePieces({ dataSetId }),
-          ])
-
-          if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
-            return null
-          }
-
-          return {
-            dataSetId,
-            dataSetMetadata,
-            hasPieces,
-          }
-        })
-      )
-
-      for (const result of batchResults) {
-        if (result == null) continue
-
-        if (result.hasPieces) {
-          selectedDataSet = result
-          break
+    const worker = async (): Promise<void> => {
+      while (true) {
+        const index = nextIndex++
+        if (index >= sortedDataSets.length || index > bestNonEmptyIndex) {
+          return
         }
 
-        if (selectedDataSet == null) {
-          selectedDataSet = result
+        const { dataSetId } = sortedDataSets[index]
+        const dataSetMetadata = await warmStorageService.getDataSetMetadata({ dataSetId })
+        if (!metadataMatches(dataSetMetadata, requestedMetadata)) {
+          continue
         }
-      }
 
-      if (selectedDataSet?.hasPieces) {
-        break
+        if (index < firstMatchIndex) {
+          firstMatchIndex = index
+        }
+
+        const hasPieces = await warmStorageService.hasActivePieces({ dataSetId })
+        evaluated[index] = { dataSetId, dataSetMetadata, hasPieces }
+        if (hasPieces && index < bestNonEmptyIndex) {
+          bestNonEmptyIndex = index
+        }
       }
     }
+
+    const workerCount = Math.min(RESOLVE_CONCURRENCY, sortedDataSets.length)
+    await Promise.all(Array.from({ length: workerCount }, () => worker()))
+
+    const selectedIndex = bestNonEmptyIndex === Number.POSITIVE_INFINITY ? firstMatchIndex : bestNonEmptyIndex
+    const selectedDataSet = selectedIndex === Number.POSITIVE_INFINITY ? null : evaluated[selectedIndex]
 
     if (selectedDataSet != null) {
       return {

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -346,6 +346,141 @@ describe('StorageService', () => {
       assert.equal(service.dataSetId, 2n)
     })
 
+    it('should bound RPC fan-out when a provider has many data sets (#631)', async () => {
+      // One provider with many active, metadata-matching data sets owned by the
+      // client, the oldest of which already has pieces. The fan-out must stay
+      // bounded by the resolve concurrency rather than the data-set count.
+      const DATA_SET_COUNT = 196
+      const expectedDataSetBase = {
+        cacheMissRailId: 0n,
+        cdnRailId: 0n,
+        clientDataSetId: 0n,
+        commissionBps: 100n,
+        payee: Mocks.ADDRESSES.serviceProvider1,
+        payer: Mocks.ADDRESSES.client1,
+        pdpEndEpoch: 0n,
+        providerId: 1n,
+        serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+      }
+      const expectedDataSets = Array.from({ length: DATA_SET_COUNT }, (_, i) => ({
+        ...expectedDataSetBase,
+        dataSetId: BigInt(i + 1),
+        pdpRailId: BigInt(i + 1),
+      }))
+
+      let getActivePieceCountCalls = 0
+      let getAllDataSetMetadataCalls = 0
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          pdpVerifier: {
+            ...Mocks.presets.basic.pdpVerifier,
+            getActivePieceCount: (args) => {
+              getActivePieceCountCalls++
+              const [dataSetId] = args
+              return dataSetId === 1n ? [2n] : [0n]
+            },
+          },
+          warmStorageView: {
+            ...Mocks.presets.basic.warmStorageView,
+            // Paginate (contract page size is 100) to avoid an infinite loop.
+            getClientDataSets: (args) => {
+              const offset = Number(args[1])
+              const limit = Number(args[2])
+              return [expectedDataSets.slice(offset, offset + limit)]
+            },
+            getAllDataSetMetadata: () => {
+              getAllDataSetMetadataCalls++
+              return [[], []]
+            },
+            getDataSet: (args) => {
+              const [dataSetId] = args
+              return [expectedDataSets.find((ds) => ds.dataSetId === dataSetId) ?? ({} as (typeof expectedDataSets)[0])]
+            },
+          },
+        }),
+        Mocks.PING({
+          baseUrl: Mocks.PROVIDERS.provider1.products[0].offering.serviceURL,
+        })
+      )
+      const synapse = new Synapse({ client, source: null })
+      const warmStorageService = new WarmStorageService({ client })
+
+      const service = await StorageContext.create({ synapse, warmStorageService, providerId: 1n })
+
+      // Oldest non-empty match is selected, and the fan-out stays bounded.
+      assert.equal(service.dataSetId, 1n)
+      assert.ok(
+        getActivePieceCountCalls <= 20,
+        `expected <=20 getActivePieceCount calls, got ${getActivePieceCountCalls} (unbounded fan-out regression)`
+      )
+      assert.ok(
+        getAllDataSetMetadataCalls <= 20,
+        `expected <=20 getAllDataSetMetadata calls, got ${getAllDataSetMetadataCalls} (unbounded fan-out regression)`
+      )
+    })
+
+    it('should select the oldest non-empty match across the resolve window (#631)', async () => {
+      // The oldest metadata match is empty and the only non-empty match lives
+      // past the first window of in-flight reads. Reads complete out of order, so
+      // selection must still return the oldest non-empty match, not the first to
+      // resolve or the empty fallback.
+      const DATA_SET_COUNT = 30
+      const NON_EMPTY_ID = 25n
+      const expectedDataSetBase = {
+        cacheMissRailId: 0n,
+        cdnRailId: 0n,
+        clientDataSetId: 0n,
+        commissionBps: 100n,
+        payee: Mocks.ADDRESSES.serviceProvider1,
+        payer: Mocks.ADDRESSES.client1,
+        pdpEndEpoch: 0n,
+        providerId: 1n,
+        serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+      }
+      const expectedDataSets = Array.from({ length: DATA_SET_COUNT }, (_, i) => ({
+        ...expectedDataSetBase,
+        dataSetId: BigInt(i + 1),
+        pdpRailId: BigInt(i + 1),
+      }))
+
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          pdpVerifier: {
+            ...Mocks.presets.basic.pdpVerifier,
+            getActivePieceCount: (args) => {
+              const [dataSetId] = args
+              return dataSetId === NON_EMPTY_ID ? [2n] : [0n]
+            },
+          },
+          warmStorageView: {
+            ...Mocks.presets.basic.warmStorageView,
+            getClientDataSets: (args) => {
+              const offset = Number(args[1])
+              const limit = Number(args[2])
+              return [expectedDataSets.slice(offset, offset + limit)]
+            },
+            getAllDataSetMetadata: () => [[], []],
+            getDataSet: (args) => {
+              const [dataSetId] = args
+              return [expectedDataSets.find((ds) => ds.dataSetId === dataSetId) ?? ({} as (typeof expectedDataSets)[0])]
+            },
+          },
+        }),
+        Mocks.PING({
+          baseUrl: Mocks.PROVIDERS.provider1.products[0].offering.serviceURL,
+        })
+      )
+      const synapse = new Synapse({ client, source: null })
+      const warmStorageService = new WarmStorageService({ client })
+
+      const service = await StorageContext.create({ synapse, warmStorageService, providerId: 1n })
+
+      // Oldest non-empty match wins over the oldest (empty) metadata match.
+      assert.equal(service.dataSetId, NON_EMPTY_ID)
+    })
+
     it('should handle provider selection callbacks', async () => {
       let providerCallbackFired = false
       let dataSetCallbackFired = false

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -424,9 +424,9 @@ describe('StorageService', () => {
 
     it('should select the oldest non-empty match across the resolve window (#631)', async () => {
       // The oldest metadata match is empty and the only non-empty match lives
-      // past the first window of in-flight reads. Reads complete out of order, so
-      // selection must still return the oldest non-empty match, not the first to
-      // resolve or the empty fallback.
+      // past the first window of in-flight reads, so selection must reach beyond
+      // the first window and return the non-empty match rather than the empty
+      // fallback.
       const DATA_SET_COUNT = 30
       const NON_EMPTY_ID = 25n
       const expectedDataSetBase = {
@@ -483,6 +483,78 @@ describe('StorageService', () => {
 
       // Oldest non-empty match wins over the oldest (empty) metadata match.
       assert.equal(service.dataSetId, NON_EMPTY_ID)
+    })
+
+    it('should prefer the oldest of several non-empty matches and skip newer ones (#631)', async () => {
+      // Two non-empty metadata matches: the oldest (id 1) and a newer one deep in
+      // the list (id 25). The oldest must win, and because it is found before the
+      // newer one's window starts, the newer one's getActivePieceCount is never
+      // read. This pins both the oldest-wins ordering and the early-exit guard,
+      // which a "newest non-empty wins" or "no early-exit" regression would break.
+      const DATA_SET_COUNT = 30
+      const OLDEST_NON_EMPTY_ID = 1n
+      const NEWER_NON_EMPTY_ID = 25n
+      const expectedDataSetBase = {
+        cacheMissRailId: 0n,
+        cdnRailId: 0n,
+        clientDataSetId: 0n,
+        commissionBps: 100n,
+        payee: Mocks.ADDRESSES.serviceProvider1,
+        payer: Mocks.ADDRESSES.client1,
+        pdpEndEpoch: 0n,
+        pendingOneTimePayments: 0n,
+        lifecycleReserveBalance: 0n,
+        providerId: 1n,
+        serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+      }
+      const expectedDataSets = Array.from({ length: DATA_SET_COUNT }, (_, i) => ({
+        ...expectedDataSetBase,
+        dataSetId: BigInt(i + 1),
+        pdpRailId: BigInt(i + 1),
+      }))
+
+      const pieceCountQueriedIds: bigint[] = []
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          pdpVerifier: {
+            ...Mocks.presets.basic.pdpVerifier,
+            getActivePieceCount: (args) => {
+              const [dataSetId] = args
+              pieceCountQueriedIds.push(dataSetId)
+              return dataSetId === OLDEST_NON_EMPTY_ID || dataSetId === NEWER_NON_EMPTY_ID ? [2n] : [0n]
+            },
+          },
+          warmStorageView: {
+            ...Mocks.presets.basic.warmStorageView,
+            getClientDataSets: (args) => {
+              const offset = Number(args[1])
+              const limit = Number(args[2])
+              return [expectedDataSets.slice(offset, offset + limit)]
+            },
+            getAllDataSetMetadata: () => [[], []],
+            getDataSet: (args) => {
+              const [dataSetId] = args
+              return [expectedDataSets.find((ds) => ds.dataSetId === dataSetId) ?? ({} as (typeof expectedDataSets)[0])]
+            },
+          },
+        }),
+        Mocks.PING({
+          baseUrl: Mocks.PROVIDERS.provider1.products[0].offering.serviceURL,
+        })
+      )
+      const synapse = new Synapse({ client, source: null })
+      const warmStorageService = new WarmStorageService({ client })
+
+      const service = await StorageContext.create({ synapse, warmStorageService, providerId: 1n })
+
+      // Oldest non-empty match wins.
+      assert.equal(service.dataSetId, OLDEST_NON_EMPTY_ID)
+      // The newer non-empty match is never inspected once the oldest is known.
+      assert.ok(
+        !pieceCountQueriedIds.includes(NEWER_NON_EMPTY_ID),
+        `getActivePieceCount should not be read for the newer match ${NEWER_NON_EMPTY_ID}, queried: ${pieceCountQueriedIds.join(', ')}`
+      )
     })
 
     it('should handle provider selection callbacks', async () => {

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -18,7 +18,7 @@ import {
   http as viemHttp,
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { StorageContext } from '../storage/context.ts'
+import { RESOLVE_CONCURRENCY, StorageContext } from '../storage/context.ts'
 import { Synapse } from '../synapse.ts'
 import { SIZE_CONSTANTS } from '../utils/constants.ts'
 import { WarmStorageService } from '../warm-storage/index.ts'
@@ -412,13 +412,20 @@ describe('StorageService', () => {
 
       // Oldest non-empty match is selected, and the fan-out stays bounded.
       assert.equal(service.dataSetId, 1n)
+      // Worst case before the oldest non-empty match is known is one sliding
+      // window of metadata reads plus one of piece-count reads, so derive the
+      // bound from RESOLVE_CONCURRENCY rather than hard-coding it. This is a
+      // practical fan-out ceiling for this fixture (fast, regular mock
+      // responses), not a hard total-call guarantee; the hard guarantee is
+      // bounded concurrency.
+      const maxExpectedCalls = RESOLVE_CONCURRENCY * 2
       assert.ok(
-        getActivePieceCountCalls <= 20,
-        `expected <=20 getActivePieceCount calls, got ${getActivePieceCountCalls} (unbounded fan-out regression)`
+        getActivePieceCountCalls <= maxExpectedCalls,
+        `expected <=${maxExpectedCalls} getActivePieceCount calls, got ${getActivePieceCountCalls} (unbounded fan-out regression)`
       )
       assert.ok(
-        getAllDataSetMetadataCalls <= 20,
-        `expected <=20 getAllDataSetMetadata calls, got ${getAllDataSetMetadataCalls} (unbounded fan-out regression)`
+        getAllDataSetMetadataCalls <= maxExpectedCalls,
+        `expected <=${maxExpectedCalls} getAllDataSetMetadata calls, got ${getAllDataSetMetadataCalls} (unbounded fan-out regression)`
       )
     })
 

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -359,6 +359,8 @@ describe('StorageService', () => {
         payee: Mocks.ADDRESSES.serviceProvider1,
         payer: Mocks.ADDRESSES.client1,
         pdpEndEpoch: 0n,
+        pendingOneTimePayments: 0n,
+        lifecycleReserveBalance: 0n,
         providerId: 1n,
         serviceProvider: Mocks.ADDRESSES.serviceProvider1,
       }
@@ -435,6 +437,8 @@ describe('StorageService', () => {
         payee: Mocks.ADDRESSES.serviceProvider1,
         payer: Mocks.ADDRESSES.client1,
         pdpEndEpoch: 0n,
+        pendingOneTimePayments: 0n,
+        lifecycleReserveBalance: 0n,
         providerId: 1n,
         serviceProvider: Mocks.ADDRESSES.serviceProvider1,
       }

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -15,6 +15,7 @@ import {
   createWalletClient,
   numberToHex,
   type Transport,
+  toFunctionSelector,
   http as viemHttp,
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
@@ -28,6 +29,36 @@ const server = setup()
 
 const pdpOptions = {
   baseUrl: 'https://pdp.example.com',
+}
+
+// The two per-data-set reads resolveByProviderId issues; both take the data set
+// id as their first uint256 argument, so the id is the first 32-byte word after
+// the 4-byte selector in the call data.
+const RESOLVE_READ_SELECTORS = [
+  toFunctionSelector('getAllDataSetMetadata(uint256)'),
+  toFunctionSelector('getActivePieces(uint256,uint256,uint256)'),
+]
+
+/**
+ * Mock RPC delay hook that holds every per-data-set resolve read (metadata and
+ * piece) except those for `fastSetId`, which answer immediately. `fastSetId` is
+ * then the only data set with no delay on any of its reads, so it always settles
+ * first. This forces the resolver's oldest match to be known before the sliding
+ * pool can advance, exercising the early-exit deterministically rather than
+ * relying on the order in which equal-latency mock responses happen to resolve.
+ */
+function delayNonOldestReads(fastSetId: bigint, delayMs = 50): Mocks.JSONRPCHooks {
+  return {
+    delay: async (request) => {
+      if (request.method !== 'eth_call') return
+      const data: string | undefined = request.params?.[0]?.data
+      if (data == null || !RESOLVE_READ_SELECTORS.some((selector) => data.startsWith(selector))) return
+      const setId = BigInt(`0x${data.slice(10, 74)}`)
+      if (setId !== fastSetId) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+      }
+    },
+  }
 }
 
 describe('StorageService', () => {
@@ -370,37 +401,48 @@ describe('StorageService', () => {
         pdpRailId: BigInt(i + 1),
       }))
 
-      let getActivePieceCountCalls = 0
+      const cid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+      let getActivePiecesCalls = 0
       let getAllDataSetMetadataCalls = 0
       server.use(
-        Mocks.JSONRPC({
-          ...Mocks.presets.basic,
-          pdpVerifier: {
-            ...Mocks.presets.basic.pdpVerifier,
-            getActivePieceCount: (args) => {
-              getActivePieceCountCalls++
-              const [dataSetId] = args
-              return dataSetId === 1n ? [2n] : [0n]
+        Mocks.JSONRPC(
+          {
+            ...Mocks.presets.basic,
+            pdpVerifier: {
+              ...Mocks.presets.basic.pdpVerifier,
+              getActivePieces: (args) => {
+                getActivePiecesCalls++
+                const [dataSetId] = args
+                return dataSetId === 1n ? [[{ data: bytesToHex(cid.bytes) }], [101n], false] : [[], [], false]
+              },
+            },
+            warmStorageView: {
+              ...Mocks.presets.basic.warmStorageView,
+              // Paginate (contract page size is 100) to avoid an infinite loop.
+              getClientDataSets: (args) => {
+                const offset = Number(args[1])
+                const limit = Number(args[2])
+                return [expectedDataSets.slice(offset, offset + limit)]
+              },
+              getAllDataSetMetadata: () => {
+                getAllDataSetMetadataCalls++
+                return [[], []]
+              },
+              getDataSet: (args) => {
+                const [dataSetId] = args
+                return [
+                  expectedDataSets.find((ds) => ds.dataSetId === dataSetId) ?? ({} as (typeof expectedDataSets)[0]),
+                ]
+              },
             },
           },
-          warmStorageView: {
-            ...Mocks.presets.basic.warmStorageView,
-            // Paginate (contract page size is 100) to avoid an infinite loop.
-            getClientDataSets: (args) => {
-              const offset = Number(args[1])
-              const limit = Number(args[2])
-              return [expectedDataSets.slice(offset, offset + limit)]
-            },
-            getAllDataSetMetadata: () => {
-              getAllDataSetMetadataCalls++
-              return [[], []]
-            },
-            getDataSet: (args) => {
-              const [dataSetId] = args
-              return [expectedDataSets.find((ds) => ds.dataSetId === dataSetId) ?? ({} as (typeof expectedDataSets)[0])]
-            },
-          },
-        }),
+          // Hold every non-oldest resolve read so the oldest (id 1) settles
+          // first. This makes the fan-out bound below deterministic for this
+          // fixture rather than a race on equal-latency mock responses: the
+          // oldest non-empty match is known before the sliding window can
+          // advance past its first fill.
+          delayNonOldestReads(1n)
+        ),
         Mocks.PING({
           baseUrl: Mocks.PROVIDERS.provider1.products[0].offering.serviceURL,
         })
@@ -412,16 +454,14 @@ describe('StorageService', () => {
 
       // Oldest non-empty match is selected, and the fan-out stays bounded.
       assert.equal(service.dataSetId, 1n)
-      // Worst case before the oldest non-empty match is known is one sliding
-      // window of metadata reads plus one of piece-count reads, so derive the
-      // bound from RESOLVE_CONCURRENCY rather than hard-coding it. This is a
-      // practical fan-out ceiling for this fixture (fast, regular mock
-      // responses), not a hard total-call guarantee; the hard guarantee is
-      // bounded concurrency.
+      // The oldest match (id 1) is forced to settle first, so the sliding window
+      // never advances past its first fill: at most one window of metadata reads
+      // plus one of piece reads. Derive the bound from RESOLVE_CONCURRENCY so it
+      // tracks the concurrency rather than hard-coding the count.
       const maxExpectedCalls = RESOLVE_CONCURRENCY * 2
       assert.ok(
-        getActivePieceCountCalls <= maxExpectedCalls,
-        `expected <=${maxExpectedCalls} getActivePieceCount calls, got ${getActivePieceCountCalls} (unbounded fan-out regression)`
+        getActivePiecesCalls <= maxExpectedCalls,
+        `expected <=${maxExpectedCalls} getActivePieces calls, got ${getActivePiecesCalls} (unbounded fan-out regression)`
       )
       assert.ok(
         getAllDataSetMetadataCalls <= maxExpectedCalls,
@@ -455,14 +495,15 @@ describe('StorageService', () => {
         pdpRailId: BigInt(i + 1),
       }))
 
+      const cid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
       server.use(
         Mocks.JSONRPC({
           ...Mocks.presets.basic,
           pdpVerifier: {
             ...Mocks.presets.basic.pdpVerifier,
-            getActivePieceCount: (args) => {
+            getActivePieces: (args) => {
               const [dataSetId] = args
-              return dataSetId === NON_EMPTY_ID ? [2n] : [0n]
+              return dataSetId === NON_EMPTY_ID ? [[{ data: bytesToHex(cid.bytes) }], [101n], false] : [[], [], false]
             },
           },
           warmStorageView: {
@@ -495,9 +536,12 @@ describe('StorageService', () => {
     it('should prefer the oldest of several non-empty matches and skip newer ones (#631)', async () => {
       // Two non-empty metadata matches: the oldest (id 1) and a newer one deep in
       // the list (id 25). The oldest must win, and because it is found before the
-      // newer one's window starts, the newer one's getActivePieceCount is never
+      // newer one's window starts, the newer one's getActivePieces is never
       // read. This pins both the oldest-wins ordering and the early-exit guard,
       // which a "newest non-empty wins" or "no early-exit" regression would break.
+      // The non-oldest resolve reads are delayed so the oldest match settles
+      // first, making "never read the newer match" deterministic for this
+      // fixture rather than a race on mock-response ordering.
       const DATA_SET_COUNT = 30
       const OLDEST_NON_EMPTY_ID = 1n
       const NEWER_NON_EMPTY_ID = 25n
@@ -520,32 +564,40 @@ describe('StorageService', () => {
         pdpRailId: BigInt(i + 1),
       }))
 
+      const cid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
       const pieceCountQueriedIds: bigint[] = []
       server.use(
-        Mocks.JSONRPC({
-          ...Mocks.presets.basic,
-          pdpVerifier: {
-            ...Mocks.presets.basic.pdpVerifier,
-            getActivePieceCount: (args) => {
-              const [dataSetId] = args
-              pieceCountQueriedIds.push(dataSetId)
-              return dataSetId === OLDEST_NON_EMPTY_ID || dataSetId === NEWER_NON_EMPTY_ID ? [2n] : [0n]
+        Mocks.JSONRPC(
+          {
+            ...Mocks.presets.basic,
+            pdpVerifier: {
+              ...Mocks.presets.basic.pdpVerifier,
+              getActivePieces: (args) => {
+                const [dataSetId] = args
+                pieceCountQueriedIds.push(dataSetId)
+                return dataSetId === OLDEST_NON_EMPTY_ID || dataSetId === NEWER_NON_EMPTY_ID
+                  ? [[{ data: bytesToHex(cid.bytes) }], [101n], false]
+                  : [[], [], false]
+              },
+            },
+            warmStorageView: {
+              ...Mocks.presets.basic.warmStorageView,
+              getClientDataSets: (args) => {
+                const offset = Number(args[1])
+                const limit = Number(args[2])
+                return [expectedDataSets.slice(offset, offset + limit)]
+              },
+              getAllDataSetMetadata: () => [[], []],
+              getDataSet: (args) => {
+                const [dataSetId] = args
+                return [
+                  expectedDataSets.find((ds) => ds.dataSetId === dataSetId) ?? ({} as (typeof expectedDataSets)[0]),
+                ]
+              },
             },
           },
-          warmStorageView: {
-            ...Mocks.presets.basic.warmStorageView,
-            getClientDataSets: (args) => {
-              const offset = Number(args[1])
-              const limit = Number(args[2])
-              return [expectedDataSets.slice(offset, offset + limit)]
-            },
-            getAllDataSetMetadata: () => [[], []],
-            getDataSet: (args) => {
-              const [dataSetId] = args
-              return [expectedDataSets.find((ds) => ds.dataSetId === dataSetId) ?? ({} as (typeof expectedDataSets)[0])]
-            },
-          },
-        }),
+          delayNonOldestReads(OLDEST_NON_EMPTY_ID)
+        ),
         Mocks.PING({
           baseUrl: Mocks.PROVIDERS.provider1.products[0].offering.serviceURL,
         })
@@ -560,7 +612,7 @@ describe('StorageService', () => {
       // The newer non-empty match is never inspected once the oldest is known.
       assert.ok(
         !pieceCountQueriedIds.includes(NEWER_NON_EMPTY_ID),
-        `getActivePieceCount should not be read for the newer match ${NEWER_NON_EMPTY_ID}, queried: ${pieceCountQueriedIds.join(', ')}`
+        `getActivePieces should not be read for the newer match ${NEWER_NON_EMPTY_ID}, queried: ${pieceCountQueriedIds.join(', ')}`
       )
     })
 


### PR DESCRIPTION
## What changed

`resolveByProviderId` evaluates a provider's data sets oldest-first through a sliding read pool: at most `RESOLVE_CONCURRENCY` (10) reads in flight, topping up the instant one finishes. It reads metadata first and `getActivePieceCount` only on a metadata match, and never starts a data set newer than the oldest non-empty match it has already found. So the read fan-out shrinks to roughly the match position instead of reading every candidate.

This replaces the fixed 50-200 batch, which read every candidate before inspecting any result and stalled at batch boundaries for clients with many data sets per provider.

The pool is a bounded `Set` + `Promise.race` that tops up as each read settles (the same sliding-window shape rvagg asked for, and the one already used in `apps/backend/.../ipfs-block.strategy.ts` on the dealbot side). No new dependency.

## How to verify

Selection is unchanged: oldest non-empty metadata match, else oldest metadata match, else null. Tests in `storage.test.ts`: bounded fan-out for a 196-data-set provider, oldest-non-empty selection across the window, and oldest-of-several-non-empty with the newer match never read.

Refs #631.
