### PR TITLE
fix(docs): upgrade @astrojs/starlight to 0.40 to restore MDX link validation

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,11 +21,11 @@
     "wagmi": "catalog:"
   },
   "devDependencies": {
-    "@astrojs/starlight": "^0.39.3",
+    "@astrojs/starlight": "^0.40.0",
     "@hugomrdias/docs": "^0.2.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "astro": "^6.4.4",
+    "astro": "^6.4.5",
     "astro-mermaid": "^2.0.2",
     "expressive-code-twoslash": "^0.6.1",
     "mermaid": "^11.12.2",


### PR DESCRIPTION
### What changed

Upgrades `@astrojs/starlight` to `^0.40.0` and the `astro` floor to `^6.4.5`. `starlight-links-validator` stays floating at `^0.24.0`.

### Why

`starlight-links-validator@0.24.1` reports links to `.mdx` pages as invalid on `@astrojs/starlight@0.39.x` (which pulls `@astrojs/mdx@5.x`), failing the docs build. mdx 5.x sources rehype plugins from the deprecated `markdown.rehypePlugins` config, which slv 0.24.1 stopped writing when it moved to Astro 6.4's unified processor (HiDeoo/starlight-links-validator#163). Starlight 0.40 brings `@astrojs/mdx@6.x`, which uses the processor model, so the validator works without a pin.

### How to verify

`pnpm -r --filter docs run build`. The generated API reference is byte-identical to the 0.39 build, and the same 1766 pages build with all internal links valid.

### Notes

- `expressive-code-twoslash@0.6.1` peers Expressive Code `^0.41.7`; Starlight 0.40 ships EC 0.43.1. pnpm warns about the mismatch, but twoslash renders fine.
- Two deprecation warnings remain from the docs' own `markdown.rehypePlugins`/`gfm` config (non-fatal). Migrating them onto the Astro 6.4 processor is a follow-up once Starlight exposes a processor-extension API.
