### PR TITLE
feat: add status page reference to docs

### DIFF
--- a/docs/src/content/docs/introduction/about.mdx
+++ b/docs/src/content/docs/introduction/about.mdx
@@ -13,6 +13,10 @@ Built on the **Filecoin Virtual Machine (FVM)** and powered by a distributed net
 
 Ready to build? [Get started with the Synapse SDK →](/getting-started/)
 
+:::tip[Stay informed]
+Subscribe to the [Filecoin Onchain Cloud status page](https://status.filecoin.cloud) for planned maintenance, downtime, and contract upgrade notices.
+:::
+
 ## Architecture
 
 FOC addresses this next-generation demand by creating composable onchain services where each capability (storage, retrieval, compute, payments, verification) can be combined, forked, or extended, giving developers the flexibility to create customized decentralized applications and data-driven services. It is built around four fundamental layers:

--- a/docs/src/content/docs/resources/additional-resources.md
+++ b/docs/src/content/docs/resources/additional-resources.md
@@ -7,6 +7,10 @@ sidebar:
 
 This section contains additional resources for Filecoin Onchain Cloud.
 
+## Service Status
+
+Subscribe to the [Filecoin Onchain Cloud status page](https://status.filecoin.cloud) for planned maintenance, downtime, and contract upgrade notices.
+
 ## Getting FIL Tokens
 
 FIL is needed for gas fees on the Filecoin network.


### PR DESCRIPTION
## Summary

- Adds a status page subscription callout to the Filecoin Onchain Cloud introduction page.
- Adds the status page to Additional Resources as the canonical operational link for planned maintenance, downtime, and contract upgrade notices.