### PR TITLE
ci: add docs PR checks and trusted preview deploys

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,11 +1,13 @@
+# Cloudflare Workers Git integration already builds same-repo PR previews outside this repo.
+# This workflow is the in-repo docs lint/build check, covers fork PRs without Cloudflare secrets,
+# and skips docs builds when full CI already covers them.
 name: docs-check
 
 on:
   pull_request:
-    paths:
-      - "docs/**"
-      - .github/workflows/docs-check.yml
-      - .github/workflows/docs.yml
+concurrency:
+  group: docs-check-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -13,10 +15,11 @@ permissions:
 
 jobs:
   changes:
-    name: Detect docs check requirement
+    name: Detect docs changes
     runs-on: ubuntu-latest
     outputs:
-      docs_check_required: ${{ steps.detect.outputs.docs_check_required }}
+      docs_relevant_changed: ${{ steps.detect.outputs.docs_relevant_changed }}
+      docs_build_required: ${{ steps.detect.outputs.docs_build_required }}
     steps:
       - name: Detect changed paths
         id: detect
@@ -50,16 +53,18 @@ jobs:
           $files
           EOF
 
+          echo "docs_relevant_changed=${docs_relevant_changed}" >> "$GITHUB_OUTPUT"
+
           if [ "$docs_relevant_changed" = true ] && [ "$full_ci_changed" = false ]; then
-            echo "docs_check_required=true" >> "$GITHUB_OUTPUT"
+            echo "docs_build_required=true" >> "$GITHUB_OUTPUT"
           else
-            echo "docs_check_required=false" >> "$GITHUB_OUTPUT"
+            echo "docs_build_required=false" >> "$GITHUB_OUTPUT"
           fi
 
-  build-docs:
-    name: Build docs
+  check-docs:
+    name: Check docs
     needs: changes
-    if: needs.changes.outputs.docs_check_required == 'true'
+    if: needs.changes.outputs.docs_relevant_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -72,7 +77,11 @@ jobs:
           node-version: lts/*
       - name: Install Dependencies
         run: pnpm install
+      - name: Check Markdown
+        run: pnpm run check:markdown
       - name: Build packages
+        if: needs.changes.outputs.docs_build_required == 'true'
         run: pnpm run build
       - name: Build docs
+        if: needs.changes.outputs.docs_build_required == 'true'
         run: pnpm -r --filter docs run build

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,78 @@
+name: docs-check
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - .github/workflows/docs-check.yml
+      - .github/workflows/docs.yml
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changes:
+    name: Detect docs check requirement
+    runs-on: ubuntu-latest
+    outputs:
+      docs_check_required: ${{ steps.detect.outputs.docs_check_required }}
+    steps:
+      - name: Detect changed paths
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          files="$(gh pr diff "$PR_NUMBER" --repo "$REPOSITORY" --name-only)"
+          printf '%s\n' "$files"
+
+          docs_relevant_changed=false
+          full_ci_changed=false
+
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+
+            case "$file" in
+              docs/*|.github/workflows/docs.yml|.github/workflows/docs-check.yml)
+                docs_relevant_changed=true
+                ;;
+            esac
+
+            # Keep in sync with ci.yml pull_request.paths. CI already builds docs for these changes.
+            case "$file" in
+              packages/*|apps/*|.github/workflows/ci.yml|package.json|pnpm-lock.yaml|pnpm-workspace.yaml)
+                full_ci_changed=true
+                ;;
+            esac
+          done <<EOF
+          $files
+          EOF
+
+          if [ "$docs_relevant_changed" = true ] && [ "$full_ci_changed" = false ]; then
+            echo "docs_check_required=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_check_required=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build-docs:
+    name: Build docs
+    needs: changes
+    if: needs.changes.outputs.docs_check_required == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+      - name: Use Node.js lts/*
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+      - name: Install Dependencies
+        run: pnpm install
+      - name: Build packages
+        run: pnpm run build
+      - name: Build docs
+        run: pnpm -r --filter docs run build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,16 +63,20 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           set -o pipefail
-          pnpm --dir docs exec wrangler versions upload --preview-alias "pr-${PR_NUMBER}" --tag "pr-${PR_NUMBER}" --message "Trusted preview for PR #${PR_NUMBER}" | tee wrangler-output.txt
+          deploy_status=0
+          pnpm --dir docs exec wrangler versions upload --preview-alias "pr-${PR_NUMBER}" --tag "pr-${PR_NUMBER}" --message "Trusted preview for PR #${PR_NUMBER}" | tee wrangler-output.txt || deploy_status=$?
           {
             echo "### Docs preview"
             echo
             echo "Trusted PR: #${PR_NUMBER}"
             echo
+            echo "Wrangler exit status: ${deploy_status}"
+            echo
             echo '```'
             cat wrangler-output.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          exit "$deploy_status"
       - name: Upload Wrangler logs
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,18 @@
 name: documentation
 on:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Trusted PR number to deploy as a preview. Runs PR code with Cloudflare secrets; only use after review. Leave empty to deploy master to production."
+        required: false
+        default: ""
+        type: string
   workflow_call:
+    inputs:
+      pr_number:
+        required: false
+        default: ""
+        type: string
 permissions:
   contents: read
 concurrency:
@@ -12,7 +23,25 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name == 'master'
     steps:
-      - uses: actions/checkout@v7
+      - name: Validate PR number
+        if: inputs.pr_number != ''
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          case "$PR_NUMBER" in
+            ''|*[!0-9]*)
+              echo "pr_number must be numeric"
+              exit 1
+              ;;
+          esac
+      - name: Checkout Repository
+        if: inputs.pr_number == ''
+        uses: actions/checkout@v7
+      - name: Checkout trusted PR
+        if: inputs.pr_number != ''
+        uses: actions/checkout@v7
+        with:
+          ref: refs/pull/${{ inputs.pr_number }}/head
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -20,11 +49,30 @@ jobs:
       - run: pnpm install
       - run: pnpm run build
       - run: pnpm -r --filter docs run build
-      - name: Deploy docs
+      - name: Deploy production docs
+        if: inputs.pr_number == ''
         run: pnpm --dir docs exec wrangler deploy --env production
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Deploy preview docs
+        if: inputs.pr_number != ''
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -o pipefail
+          pnpm --dir docs exec wrangler versions upload --preview-alias "pr-${PR_NUMBER}" --tag "pr-${PR_NUMBER}" --message "Trusted preview for PR #${PR_NUMBER}" | tee wrangler-output.txt
+          {
+            echo "### Docs preview"
+            echo
+            echo "Trusted PR: #${PR_NUMBER}"
+            echo
+            echo '```'
+            cat wrangler-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload Wrangler logs
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,3 +1,5 @@
+# Cloudflare Workers Git integration already previews same-repo branches outside this repo.
+# The manual PR preview path is for reviewed fork PRs and uploads a non-production Worker version.
 name: documentation
 on:
   workflow_dispatch:
@@ -7,9 +9,18 @@ on:
         required: false
         default: ""
         type: string
+      pr_sha:
+        description: "Required with pr_number. Full 40-character commit SHA that was reviewed and trusted."
+        required: false
+        default: ""
+        type: string
   workflow_call:
     inputs:
       pr_number:
+        required: false
+        default: ""
+        type: string
+      pr_sha:
         required: false
         default: ""
         type: string
@@ -23,17 +34,29 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref_name == 'master'
     steps:
-      - name: Validate PR number
-        if: inputs.pr_number != ''
+      - name: Validate PR preview inputs
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
+          PR_SHA: ${{ inputs.pr_sha }}
         run: |
-          case "$PR_NUMBER" in
-            ''|*[!0-9]*)
-              echo "pr_number must be numeric"
+          if [ -z "$PR_NUMBER" ] && [ -n "$PR_SHA" ]; then
+            echo "pr_sha requires pr_number"
+            exit 1
+          fi
+
+          if [ -n "$PR_NUMBER" ]; then
+            case "$PR_NUMBER" in
+              *[!0-9]*)
+                echo "pr_number must be numeric"
+                exit 1
+                ;;
+            esac
+
+            if ! [[ "$PR_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "pr_sha must be a full 40-character hex commit SHA"
               exit 1
-              ;;
-          esac
+            fi
+          fi
       - name: Checkout Repository
         if: inputs.pr_number == ''
         uses: actions/checkout@v7
@@ -42,13 +65,29 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ inputs.pr_number }}/head
+      - name: Verify trusted PR SHA
+        if: inputs.pr_number != ''
+        env:
+          PR_SHA: ${{ inputs.pr_sha }}
+        run: |
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [ "$checked_out_sha" != "$PR_SHA" ]; then
+            echo "Checked out ${checked_out_sha}, expected ${PR_SHA}. Review the new PR head and rerun."
+            exit 1
+          fi
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
       - run: pnpm install
+      - run: pnpm run check:markdown
       - run: pnpm run build
       - run: pnpm -r --filter docs run build
+      - name: Restore trusted Wrangler config
+        if: inputs.pr_number != ''
+        run: |
+          git fetch origin master --depth=1
+          git checkout FETCH_HEAD -- docs/wrangler.json
       - name: Deploy production docs
         if: inputs.pr_number == ''
         run: pnpm --dir docs exec wrangler deploy --env production
@@ -61,14 +100,16 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PR_NUMBER: ${{ inputs.pr_number }}
+          PR_SHA: ${{ inputs.pr_sha }}
         run: |
           set -o pipefail
           deploy_status=0
-          pnpm --dir docs exec wrangler versions upload --preview-alias "pr-${PR_NUMBER}" --tag "pr-${PR_NUMBER}" --message "Trusted preview for PR #${PR_NUMBER}" | tee wrangler-output.txt || deploy_status=$?
+          pnpm --dir docs exec wrangler versions upload --preview-alias "pr-${PR_NUMBER}" --tag "pr-${PR_NUMBER}" --message "Trusted preview for PR #${PR_NUMBER} at ${PR_SHA}" | tee wrangler-output.txt || deploy_status=$?
           {
             echo "### Docs preview"
             echo
             echo "Trusted PR: #${PR_NUMBER}"
+            echo "Trusted SHA: ${PR_SHA}"
             echo
             echo "Wrangler exit status: ${deploy_status}"
             echo


### PR DESCRIPTION
Trying to do two things here:

1. Run in-repo docs validation on every PR, including fork PRs.
  - `docs-check` always runs the markdown lint for docs-relevant changes.
  - It also builds the docs when full CI is not already going to do that.
  - This gives us GitHub-visible lint/build failures, which the existing Cloudflare preview integration does not provide.
2. Allow manual preview publishing for a reviewed/trusted PR.
  - Same-repo branches already get Cloudflare Workers preview URLs from the existing Cloudflare Git integration.
  - Fork PRs do not get those previews, and we should not expose Cloudflare secrets to automatic fork PR workflows.
  - The manual `documentation` workflow now accepts a PR number and reviewed commit SHA, checks that the PR head still matches that SHA, restores the trusted Wrangler config from `master`, then uploads a non-production preview version.