### PR TITLE
fix(cli): add explicit viem client types

### DIFF
--- a/examples/cli/src/client.ts
+++ b/examples/cli/src/client.ts
@@ -1,8 +1,17 @@
 import { execSync } from 'node:child_process'
 import { basename, dirname } from 'node:path'
 import * as p from '@clack/prompts'
-import { getChain } from '@filoz/synapse-core/chains'
-import { createPublicClient, createWalletClient, type Hex, http } from 'viem'
+import { type Chain, getChain } from '@filoz/synapse-core/chains'
+import {
+  createPublicClient,
+  createWalletClient,
+  type Hex,
+  type HttpTransport,
+  http,
+  type PrivateKeyAccount,
+  type PublicClient,
+  type WalletClient,
+} from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import config from './config.ts'
 
@@ -37,7 +46,10 @@ function privateKeyFromConfig() {
   }
 }
 
-export function privateKeyClient(chainId: number) {
+export function privateKeyClient(chainId: number): {
+  client: WalletClient<HttpTransport, Chain, PrivateKeyAccount>
+  chain: Chain
+} {
   const chain = getChain(chainId)
 
   const privateKey = privateKeyFromConfig()
@@ -54,7 +66,9 @@ export function privateKeyClient(chainId: number) {
   }
 }
 
-export function publicClient(chainId: number) {
+export function publicClient(
+  chainId: number
+): PublicClient<HttpTransport, Chain> {
   const chain = getChain(chainId)
   const publicClient = createPublicClient({
     chain,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,3 +67,6 @@ trustPolicyExclude:
   # Last 4.x (Dec 2024) predates chokidar adopting trusted publishing at 5.0.0.
   # Permanent while anything depends on chokidar@^4.
   - chokidar@4.0.3
+  # 3.3.1 (Jan 2025) predates langium adopting trusted publishing at 4.x.
+  # Exact-pinned by @mermaid-js/parser; permanent while mermaid pins langium@3.
+  - langium@3.3.1


### PR DESCRIPTION
### What changed

CI lint fails on #857 (and every PR since ~Jul 10) with 17x TS2883 in `examples/cli/src/client.ts`. viem 2.54.x added token actions (`actions/token/approve`, `getAllowance`, etc.), and since pnpm-lock.yaml is gitignored, CI resolves the newest viem allowed by `minimumReleaseAge` regardless of the `^2.52.0` catalog entry. With 2.54.x, tsc can no longer name the inferred return types of `privateKeyClient`/`publicClient` without reaching into `viem/_types/actions/token/*`. This adds explicit return type annotations (`WalletClient<HttpTransport, Chain, PrivateKeyAccount>` / `PublicClient<HttpTransport, Chain>`, with `Chain` from synapse-core so downstream commands keep `genesisTimestamp`/`filbeam`).

Also adds `langium@3.3.1` to `trustPolicyExclude`. langium adopted trusted publishing at 4.x; 3.3.1 (Jan 2025) predates it, so the `no-downgrade` policy now rejects it and `pnpm install` fails with pnpm 11.5.3 (the pinned packageManager version). It's exact-pinned by `@mermaid-js/parser` via mermaid in docs.. same situation as the existing chokidar@4.0.3 exclusion.

### How to verify

Reproduced locally by re-resolving without a lockfile, which pulled viem 2.54.6 and produced the same 17 errors as the [failing job](https://github.com/FilOzone/synapse-sdk/actions/runs/29215306760/job/86709928744). With this branch, `pnpm run lint`, `pnpm run build`, and `pnpm test` all pass on viem 2.54.6.
