### PR TITLE
fix(sdk): harden provider health checks

### DIFF
--- a/packages/synapse-core/src/sp/ping.ts
+++ b/packages/synapse-core/src/sp/ping.ts
@@ -1,5 +1,17 @@
-import { request } from 'iso-web/http'
-import { RETRY_CONSTANTS } from '../utils/constants.ts'
+import { type AbortError, type HttpError, type NetworkError, request, type TimeoutError } from 'iso-web/http'
+
+const DEFAULT_TIMEOUT = 8000
+const RETRY_COUNT = 2
+const RETRY_DELAY = 500
+
+export namespace ping {
+  export type OptionsType = {
+    /** Total timeout for the ping request and its retries, in milliseconds. Defaults to 8 seconds. */
+    timeout?: number
+  }
+  export type OutputType = Response
+  export type ErrorType = AbortError | HttpError | NetworkError | TimeoutError
+}
 
 /**
  * Ping the PDP API.
@@ -7,18 +19,20 @@ import { RETRY_CONSTANTS } from '../utils/constants.ts'
  * GET /pdp/ping
  *
  * @param serviceURL - The service URL of the PDP API.
- * @returns void
- * @throws Errors {@link Error}
+ * @param options - Optional timeout configuration.
+ * @returns Response {@link ping.OutputType}
+ * @throws Errors {@link ping.ErrorType}
  */
-export async function ping(serviceURL: string) {
+export async function ping(serviceURL: string, options: ping.OptionsType = {}): Promise<ping.OutputType> {
   const response = await request.get(new URL(`pdp/ping`, serviceURL), {
     retry: {
-      minTimeout: RETRY_CONSTANTS.RETRY_DELAY,
+      retries: RETRY_COUNT,
+      minTimeout: RETRY_DELAY,
     },
-    timeout: 1000,
+    timeout: options.timeout ?? DEFAULT_TIMEOUT,
   })
   if (response.error) {
-    throw new Error('Ping failed')
+    throw response.error
   }
   return response.result
 }

--- a/packages/synapse-core/test/sp.test.ts
+++ b/packages/synapse-core/test/sp.test.ts
@@ -36,6 +36,7 @@ import {
   findPiece,
   getDataSet,
   NetworkError,
+  ping,
   TimeoutError,
   uploadPiece,
   waitForAddPieces,
@@ -65,6 +66,56 @@ describe('SP', () => {
 
   beforeEach(() => {
     server.resetHandlers()
+  })
+
+  describe('ping', () => {
+    it('retries transient failures', async () => {
+      let attempts = 0
+      server.use(
+        http.get('http://pdp.local/pdp/ping', () => {
+          attempts++
+          if (attempts < 3) {
+            return new HttpResponse(null, { status: 503, statusText: 'Service Unavailable' })
+          }
+          return new HttpResponse(null, { status: 200 })
+        })
+      )
+
+      await ping('http://pdp.local', { timeout: 5000 })
+
+      assert.equal(attempts, 3)
+    })
+
+    it('honors a custom total timeout', async () => {
+      server.use(
+        http.get('http://pdp.local/pdp/ping', async () => {
+          await delay(100)
+          return new HttpResponse(null, { status: 200 })
+        })
+      )
+
+      try {
+        await ping('http://pdp.local', { timeout: 10 })
+        assert.fail('Expected ping to time out')
+      } catch (error) {
+        assert.instanceOf(error, TimeoutError)
+        assert.equal((error as Error).message, 'Request timed out after 10ms')
+      }
+    })
+
+    it('surfaces the underlying request error', async () => {
+      server.use(
+        http.get('http://pdp.local/pdp/ping', () => new HttpResponse(null, { status: 400, statusText: 'Bad Request' }))
+      )
+
+      try {
+        await ping('http://pdp.local')
+        assert.fail('Expected ping to fail')
+      } catch (error) {
+        assert.equal((error as Error).name, 'HttpError')
+        assert.equal((error as Error).message, '400 - Bad Request')
+      }
+    })
   })
 
   describe('createDataSet', () => {

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -648,7 +648,7 @@ export class StorageContext {
         const candidates = selectProviders({
           ...input,
           endorsedIds: endorsedSlot ? input.endorsedIds : [],
-          count: endorsedSlot ? Math.max(1, input.endorsedIds.length) : 1,
+          count: endorsedSlot ? input.endorsedIds.length : 1,
           excludeProviderIds,
           metadata,
         })
@@ -667,8 +667,7 @@ export class StorageContext {
         // Await in selection order so a faster, lower-ranked provider cannot
         // displace a healthy higher-ranked provider. The checks themselves are
         // already in flight, so a failed candidate does not delay starting the next.
-        for (const healthCheck of healthChecks) {
-          const outcome = await healthCheck
+        for await (const outcome of healthChecks) {
           if (outcome.ok) {
             results.push(StorageContext.toProviderSelectionResult(outcome.candidate))
             excludeProviderIds.push(outcome.candidate.provider.id)

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -641,6 +641,8 @@ export class StorageContext {
       // Keep selecting and pinging until a healthy provider is found
       // or all candidates are exhausted
       for (;;) {
+        if (endorsedSlot && input.endorsedIds.length === 0) break
+
         // There are few endorsed providers, so check the complete ranked pool
         // concurrently. Other slots keep the existing one-at-a-time behavior.
         const candidates = selectProviders({

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -628,53 +628,78 @@ export class StorageContext {
       address: clientAddress,
     })
 
-    // Inline ping-retry loop: select a candidate from core, ping it,
-    // exclude on failure, re-select. One outer iteration per copy needed.
+    // Select a healthy candidate for each copy. Endorsed primary candidates
+    // are pinged concurrently, while results are consumed in ranked order.
     const results: ProviderSelectionResult[] = []
     const excludeProviderIds = [...options.excludeProviderIds]
 
     for (let i = 0; i < count; i++) {
       const endorsedSlot = requireEndorsedPrimary && i === 0
       let found = false
-      let pingFailures = 0
+      const pingFailures: Array<{ candidate: ResolvedLocation; error: unknown }> = []
 
       // Keep selecting and pinging until a healthy provider is found
       // or all candidates are exhausted
       for (;;) {
+        // There are few endorsed providers, so check the complete ranked pool
+        // concurrently. Other slots keep the existing one-at-a-time behavior.
         const candidates = selectProviders({
           ...input,
           endorsedIds: endorsedSlot ? input.endorsedIds : [],
-          count: 1,
+          count: endorsedSlot ? Math.max(1, input.endorsedIds.length) : 1,
           excludeProviderIds,
           metadata,
         })
 
         if (candidates.length === 0) break
 
-        const candidate = candidates[0]
-        try {
-          await SP.ping(candidate.provider.pdp.serviceURL)
-          results.push(StorageContext.toProviderSelectionResult(candidate))
-          excludeProviderIds.push(candidate.provider.id)
-          found = true
-          break
-        } catch (error) {
-          console.warn(
-            `Provider ${candidate.provider.serviceProvider} (ID: ${candidate.provider.id}) failed ping:`,
-            error instanceof Error ? error.message : String(error)
-          )
-          excludeProviderIds.push(candidate.provider.id)
-          pingFailures++
+        const healthChecks = candidates.map(async (candidate) => {
+          try {
+            await SP.ping(candidate.provider.pdp.serviceURL)
+            return { ok: true as const, candidate }
+          } catch (error) {
+            return { ok: false as const, candidate, error }
+          }
+        })
+
+        // Await in selection order so a faster, lower-ranked provider cannot
+        // displace a healthy higher-ranked provider. The checks themselves are
+        // already in flight, so a failed candidate does not delay starting the next.
+        for (const healthCheck of healthChecks) {
+          const outcome = await healthCheck
+          if (outcome.ok) {
+            results.push(StorageContext.toProviderSelectionResult(outcome.candidate))
+            excludeProviderIds.push(outcome.candidate.provider.id)
+            found = true
+            break
+          }
+          excludeProviderIds.push(outcome.candidate.provider.id)
+          pingFailures.push(outcome)
         }
+
+        if (found) break
       }
 
       if (endorsedSlot && !found) {
+        const healthCheckError =
+          pingFailures.length > 0
+            ? new AggregateError(
+                pingFailures.map(({ error }) => error),
+                pingFailures
+                  .map(
+                    ({ candidate, error }) =>
+                      `Provider ${candidate.provider.serviceProvider} (ID: ${candidate.provider.id}): ${error instanceof Error ? error.message : String(error)}`
+                  )
+                  .join('; ')
+              )
+            : undefined
         throw createError(
           'StorageContext',
           'smartSelect',
-          pingFailures > 0
-            ? `No endorsed provider available — all endorsed provider(s) failed health check`
-            : 'No endorsed provider available'
+          healthCheckError == null
+            ? 'No endorsed provider available'
+            : `No endorsed provider available — all endorsed provider(s) failed health check`,
+          healthCheckError
         )
       }
 

--- a/packages/synapse-sdk/src/test/synapse.test.ts
+++ b/packages/synapse-sdk/src/test/synapse.test.ts
@@ -639,6 +639,7 @@ describe('Synapse', () => {
     })
 
     it('selects existing data set by default when metadata matches', async () => {
+      endorsedProviderIds.push(...providerIds)
       const metadata = {
         environment: 'test',
         withCDN: '',
@@ -653,6 +654,7 @@ describe('Synapse', () => {
     })
 
     it('avoids existing data set when provider is excluded even when metadata matches', async () => {
+      endorsedProviderIds.push(...providerIds)
       const metadata = {
         environment: 'test',
         withCDN: '',
@@ -667,6 +669,7 @@ describe('Synapse', () => {
     })
 
     it('can select new data sets from different providers using default params', async () => {
+      endorsedProviderIds.push(...providerIds)
       const contexts = await synapse.storage.createContexts()
       assert.equal(contexts.length, 2)
       assert.equal((contexts[0] as any)._dataSetId, undefined)
@@ -676,6 +679,15 @@ describe('Synapse', () => {
       // should return the same contexts when invoked again
       const defaultContexts = await synapse.storage.createContexts()
       assert.isTrue(defaultContexts === contexts)
+    })
+
+    it('throws when no endorsed providers are available', async () => {
+      try {
+        await synapse.storage.createContexts({ copies: 1 })
+        assert.fail('Expected createContexts to throw when no endorsed provider is available')
+      } catch (error: any) {
+        assert.include(error.message, 'No endorsed provider available')
+      }
     })
 
     it('pings endorsed providers concurrently while preserving rank', async () => {
@@ -791,6 +803,7 @@ describe('Synapse', () => {
     })
 
     it('can attempt to create numerous contexts, returning fewer', async () => {
+      endorsedProviderIds.push(...providerIds)
       const contexts = await synapse.storage.createContexts({
         copies: 100,
       })

--- a/packages/synapse-sdk/src/test/synapse.test.ts
+++ b/packages/synapse-sdk/src/test/synapse.test.ts
@@ -678,6 +678,55 @@ describe('Synapse', () => {
       assert.isTrue(defaultContexts === contexts)
     })
 
+    it('pings endorsed providers concurrently while preserving rank', async () => {
+      endorsedProviderIds.push(...providerIds)
+      const secondPingStarted = pDefer<void>()
+      server.use(
+        http.get(`${providers[0].products[0].offering.serviceURL}/pdp/ping`, async () => {
+          await secondPingStarted.promise
+          return new HttpResponse(null, { status: 200 })
+        }),
+        http.get(`${providers[1].products[0].offering.serviceURL}/pdp/ping`, () => {
+          secondPingStarted.resolve()
+          return new HttpResponse(null, { status: 200 })
+        })
+      )
+
+      const contexts = await synapse.storage.createContexts({
+        copies: 1,
+        metadata: { environment: 'test' },
+      })
+
+      assert.equal(contexts[0].provider.id, providerIds[0])
+    })
+
+    it('does not log a recovered provider ping failure', async () => {
+      endorsedProviderIds.push(...providerIds)
+      server.use(
+        http.get(
+          `${providers[0].products[0].offering.serviceURL}/pdp/ping`,
+          () => new HttpResponse(null, { status: 400, statusText: 'Bad Request' })
+        )
+      )
+      const originalWarn = console.warn
+      const warnings: unknown[][] = []
+      console.warn = (...args: unknown[]) => {
+        warnings.push(args)
+      }
+
+      try {
+        const contexts = await synapse.storage.createContexts({
+          copies: 1,
+          metadata: { environment: 'test' },
+        })
+        assert.equal(contexts[0].provider.id, providerIds[1])
+      } finally {
+        console.warn = originalWarn
+      }
+
+      assert.lengthOf(warnings, 0)
+    })
+
     providerIds.forEach((endorsedProviderId, index) => {
       describe(`when endorsing providers[${index}]`, async () => {
         beforeEach(() => {
@@ -711,6 +760,7 @@ describe('Synapse', () => {
           } catch (error: any) {
             assert.include(error.message, 'No endorsed provider available')
             assert.include(error.message, 'failed health check')
+            assert.include(error.message, 'Network request failed')
           }
         })
 


### PR DESCRIPTION
## Summary

- raise the PDP ping deadline from 1s to 8s and retry fast failures twice with 500ms exponential backoff
- let low-level callers override the total ping timeout while preserving the existing `ping(serviceURL)` call shape
- surface the original HTTP/network/timeout error instead of replacing it with a generic `Ping failed`
- ping the ranked endorsed-provider pool concurrently while still choosing the highest-ranked healthy provider
- remove the direct `console.warn` from provider selection
- include provider-specific causes when every endorsed health check fails

## Root cause

The ping helper used a one-second total deadline around the request and retries. On a small global provider pool this made transient latency look like provider unavailability. `smartSelect` then checked endorsed candidates serially and wrote recovered failures directly to stderr, which could corrupt caller-owned terminal UIs.

## Validation

- `pnpm -C packages/synapse-core lint`
- `pnpm -C packages/synapse-sdk lint`
- `pnpm -C packages/synapse-core test` (Node and browser)
- `pnpm -C packages/synapse-sdk test` (Node and browser)

Fixes #849
Fixes #850
