### PR TITLE
fix(ci): publish docs on every release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       paths_released: ${{ steps.release.outputs.paths_released }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
@@ -48,8 +49,7 @@ jobs:
       - run: pnpm -r --filter './packages/**' publish --access=public
   docs:
     needs: release
-    # Only publish docs if the synapse-sdk package is released (manual publish is possible from the GitHub UI)
-    if: |
-      contains(fromJson(needs.release.outputs.paths_released), 'packages/synapse-sdk')
+    # Publish docs when any package is released (manual publishing is also available from the GitHub UI)
+    if: needs.release.outputs.releases_created == 'true'
     uses: ./.github/workflows/docs.yml
     secrets: inherit


### PR DESCRIPTION
## Summary

- deploy production docs whenever Release Please creates any package release
- replace the `synapse-sdk`-only condition with Release Please's `releases_created` output

## Why

Docs publishing was skipped for `synapse-core` and `synapse-react` releases, which could leave the published documentation behind the released packages.

Fixes #835