### PR TITLE
chore: update PDP explorer URL to pdp.filecoin.cloud

### DIFF
--- a/apps/synapse-playground/src/components/pdp-link.tsx
+++ b/apps/synapse-playground/src/components/pdp-link.tsx
@@ -6,7 +6,7 @@ import { useConfig } from 'wagmi'
 export function PDPDatasetLink({ id }: { id: string }) {
   const config = useConfig()
   const chain = config.state.chainId === 314 ? 'mainnet' : 'calibration'
-  const explorerUrl = `https://pdp.vxb.ai/${chain}/dataset/${id}`
+  const explorerUrl = `https://pdp.filecoin.cloud/${chain}/dataset/${id}`
   return (
     <a
       className="hover:underline wrap-anywhere text-gray-400"
@@ -22,7 +22,7 @@ export function PDPDatasetLink({ id }: { id: string }) {
 export function PDPProviderLink({ address, name }: { address: string; name: string }) {
   const config = useConfig()
   const chain = config.state.chainId === 314 ? 'mainnet' : 'calibration'
-  const explorerUrl = `https://pdp.vxb.ai/${chain}/providers/${address}`
+  const explorerUrl = `https://pdp.filecoin.cloud/${chain}/providers/${address}`
   return (
     <a
       className="hover:underline wrap-anywhere text-gray-400"
@@ -38,7 +38,7 @@ export function PDPProviderLink({ address, name }: { address: string; name: stri
 export function PDPPieceLink({ cid, name }: { cid: string; name?: string }) {
   const config = useConfig()
   const chain = config.state.chainId === 314 ? 'mainnet' : 'calibration'
-  const explorerUrl = `https://pdp.vxb.ai/${chain}/piece/${cid}`
+  const explorerUrl = `https://pdp.filecoin.cloud/${chain}/piece/${cid}`
   return (
     <a className="hover:underline wrap-anywhere" href={explorerUrl} rel="noopener noreferrer" target="_blank">
       {name || cid}

--- a/docs/src/content/docs/resources/additional-resources.md
+++ b/docs/src/content/docs/resources/additional-resources.md
@@ -37,8 +37,8 @@ FIL is needed for gas fees on the Filecoin network.
 
 Track proofs submitted to the PDP contract.
 
-- **Mainnet**: <https://pdp.vxb.ai/mainnet>
-- **Calibration Testnet**: <https://pdp.vxb.ai/calibration>
+- **Mainnet**: <https://pdp.filecoin.cloud/mainnet>
+- **Calibration Testnet**: <https://pdp.filecoin.cloud/calibration>
 
 ### Filecoin Pay Explorer
 


### PR DESCRIPTION
This PR updates PDP explorer URL to pdp.filecoin.cloud which is now maintained by FOC WG.