### PR TITLE
fix(synapse-core): validate PDP verifier address checksum

### DIFF
--- a/packages/synapse-core/wagmi.config.ts
+++ b/packages/synapse-core/wagmi.config.ts
@@ -4,7 +4,7 @@ import { request } from 'iso-web/http'
 import { zeroAddress } from 'viem'
 import * as z from 'zod'
 import { ZodValidationError } from './src/errors/base.ts'
-import { zAddress, zAddressLoose } from './src/utils/schemas.ts'
+import { zAddress } from './src/utils/schemas.ts'
 
 // GIT_REF can be one of: '<branch name>', '<commit>' or 'tags/<tag>'
 const FILECOIN_SERVICES_GIT_REF = '3f3eceb47ce235cdbf3fb59cd919fcb4d483b08d' // v1.3.0
@@ -20,7 +20,7 @@ const DeploymentSchema = z
     }),
     FILECOIN_PAY_ADDRESS: zAddress,
     PDP_VERIFIER_PROXY_ADDRESS: zAddress,
-    PDP_VERIFIER_IMPLEMENTATION_ADDRESS: zAddressLoose,
+    PDP_VERIFIER_IMPLEMENTATION_ADDRESS: zAddress,
     SESSION_KEY_REGISTRY_ADDRESS: zAddress,
     SERVICE_PROVIDER_REGISTRY_PROXY_ADDRESS: zAddress,
     SERVICE_PROVIDER_REGISTRY_IMPLEMENTATION_ADDRESS: zAddress,


### PR DESCRIPTION
## What changed

- validate `PDP_VERIFIER_IMPLEMENTATION_ADDRESS` with the strict EIP-55 address schema
- stop using the loose address validator in the Wagmi deployment configuration
- retain the public `zAddressLoose` export to avoid an unrelated breaking API change

## Why

The PDP verifier implementation addresses previously lost their checksum casing in the upstream deployment manifest, requiring a temporary loose validator. The upstream manifest now enforces and publishes valid EIP-55 checksums, so the exception is no longer necessary.

This makes ABI generation fail early if a future deployment manifest contains an invalid mixed-case PDP verifier implementation address.

Closes #761

## Validation

- `pnpm --filter @filoz/synapse-core run generate-abi`
- `pnpm exec biome check packages/synapse-core/wagmi.config.ts`
- `git diff --check`
