### PR TITLE
feat(synapse-core): add target runway deposit helper

### DIFF
--- a/packages/synapse-core/src/pay/calculate-target-runway-deposit.ts
+++ b/packages/synapse-core/src/pay/calculate-target-runway-deposit.ts
@@ -1,0 +1,28 @@
+export namespace calculateTargetRunwayDeposit {
+  export type ParamsType = {
+    /** Unreserved account funds available toward the requested runway. */
+    availableFunds: bigint
+    /** Outstanding account debt that must be cleared by the deposit. */
+    debt: bigint
+    /** Current aggregate account spend rate in token base units per epoch. */
+    lockupRatePerEpoch: bigint
+    /** Requested runway in epochs, including any caller-selected buffer. */
+    targetRunwayInEpochs: bigint
+  }
+}
+
+/**
+ * Calculate the additional deposit required to clear current debt and reach a target runway.
+ *
+ * Uses token base units throughout and does not add an implicit epoch buffer. Callers should
+ * include any desired buffer in `targetRunwayInEpochs`.
+ *
+ * @param params - {@link calculateTargetRunwayDeposit.ParamsType}
+ * @returns Additional deposit in token base units, or `0n` when the target is already covered
+ */
+export function calculateTargetRunwayDeposit(params: calculateTargetRunwayDeposit.ParamsType): bigint {
+  const requiredBalance = params.debt + params.lockupRatePerEpoch * params.targetRunwayInEpochs
+  const depositNeeded = requiredBalance - params.availableFunds
+
+  return depositNeeded > 0n ? depositNeeded : 0n
+}

--- a/packages/synapse-core/src/pay/index.ts
+++ b/packages/synapse-core/src/pay/index.ts
@@ -11,6 +11,7 @@
 
 export * from './account-debt.ts'
 export * from './accounts.ts'
+export * from './calculate-target-runway-deposit.ts'
 export * from './deposit.ts'
 export * from './deposit-with-permit.ts'
 export * from './fund.ts'

--- a/packages/synapse-core/test/calculate-target-runway-deposit.test.ts
+++ b/packages/synapse-core/test/calculate-target-runway-deposit.test.ts
@@ -1,0 +1,35 @@
+/* globals describe it */
+
+import assert from 'assert'
+import { calculateTargetRunwayDeposit } from '../src/pay/index.ts'
+
+const params = {
+  availableFunds: 0n,
+  debt: 0n,
+  lockupRatePerEpoch: 10n,
+  targetRunwayInEpochs: 50n,
+}
+
+describe('calculateTargetRunwayDeposit', () => {
+  it('returns the exact shortfall for a healthy underfunded account', () => {
+    assert.equal(calculateTargetRunwayDeposit({ ...params, availableFunds: 400n }), 100n)
+  })
+
+  it('returns zero when the target is exactly met or exceeded', () => {
+    for (const availableFunds of [500n, 600n]) {
+      assert.equal(calculateTargetRunwayDeposit({ ...params, availableFunds }), 0n)
+    }
+  })
+
+  it('includes current debt for an account in deficit', () => {
+    assert.equal(calculateTargetRunwayDeposit({ ...params, debt: 75n }), 575n)
+  })
+
+  it('does not create a runway requirement when the per-epoch rate is zero', () => {
+    assert.equal(calculateTargetRunwayDeposit({ ...params, lockupRatePerEpoch: 0n }), 0n)
+    assert.equal(
+      calculateTargetRunwayDeposit({ ...params, availableFunds: 50n, debt: 75n, lockupRatePerEpoch: 0n }),
+      25n
+    )
+  })
+})


### PR DESCRIPTION
## What changed

Adds `calculateTargetRunwayDeposit()` to `@filoz/synapse-core/pay`.

The pure helper calculates the additional token amount needed to clear current debt and provide a requested runway:

```text
max(0, debt + lockupRatePerEpoch * targetRunwayInEpochs - availableFunds)
```

It uses `bigint` base units and leaves any buffer explicit in the requested runway.

## Why

Clients that display a suggested account top-up can use the same calculation without duplicating payment-account arithmetic.

## Scope

This does not add network requests, contract writes, date formatting, funding-status categories, or routing behavior.

## Validation

- `pnpm --filter @filoz/synapse-core run lint:fix`
- `pnpm --filter @filoz/synapse-core run build`
- `pnpm --filter @filoz/synapse-core run test`
  - 836 Node tests passed
  - 836 browser tests passed
