### PR TITLE
fix(synapse-core): accept deployment contracts metadata

### DIFF
--- a/packages/synapse-core/wagmi.config.ts
+++ b/packages/synapse-core/wagmi.config.ts
@@ -30,6 +30,8 @@ const DeploymentSchema = z
     FWSS_IMPLEMENTATION_ADDRESS: zAddress,
     FWSS_VIEW_ADDRESS: zAddress,
     ENDORSEMENT_SET_ADDRESS: zAddress,
+    // Deployment-planning metadata is intentionally opaque to ABI generation.
+    contracts: z.record(z.string(), z.unknown()).optional(),
   })
   .strict()
 


### PR DESCRIPTION
## What changed

Allow the strict per-network deployment schema in `packages/synapse-core/wagmi.config.ts` to accept the optional top-level `contracts` metadata map produced by `filecoin-services` deployment tooling.

The metadata remains opaque because ABI generation does not consume it. Existing required address validation and strict rejection of other unknown top-level keys remain unchanged.

## Why

The [`v1.3.1` Update Synapse SDK workflow](https://github.com/FilOzone/filecoin-services/actions/runs/30998238414) failed before it could generate ABIs or open its update PR:

```text
Validation failed.
Unrecognized key: "contracts"
  at 314
Unrecognized key: "contracts"
  at 314159
```

`filecoin-services/service_contracts/deployments.json` now includes deployment-planning metadata under `contracts` for both networks. Synapse only needs the legacy address fields from that document, but its strict schema must recognize the additional documented key.

Tracks the Synapse gate in [filecoin-services#561](https://github.com/FilOzone/filecoin-services/issues/561).
