### PR TITLE
Add cursor-based pagination and safer data set piece detection

### DIFF
--- a/docs/src/content/docs/developer-guides/migration-guide.md
+++ b/docs/src/content/docs/developer-guides/migration-guide.md
@@ -122,9 +122,15 @@ if (dataSet?.hasActivePieces) {
 }
 ```
 
-`WarmStorageService.hasActivePieces()` keeps the same public API, but now uses the same leaf-count proxy instead of calculating an exact count.
+`WarmStorageService.hasActivePieces()` keeps the same public API, but now uses the same leaf-count proxy instead of calculating an exact count. `EnhancedDataSetInfo` from `getClientDataSetsWithDetails()` / `findDataSets()` also exposes `hasActivePieces` instead of `activePieceCount`.
 
-The standalone `getActivePieceCount()` action remains available, but the underlying contract getter scans the data set's piece-ID range and can fail for large data sets. If you need an exact count, explicitly paginate the active pieces:
+The core `getActivePieceCount()` action remains available, but the underlying contract getter scans the data set's piece-ID range and can fail for large data sets. `WarmStorageService.getActivePieceCount()` now paginates `getActivePiecesByCursor` to derive an exact count:
+
+```ts
+const activePieceCount = await warmStorageService.getActivePieceCount({ dataSetId })
+```
+
+To paginate explicitly in core:
 
 ```ts
 let activePieceCount = 0n
@@ -135,8 +141,6 @@ for await (const _piece of paginate(({ cursor }) =>
   activePieceCount++
 }
 ```
-
-This field change is limited to the enriched data set types in `@filoz/synapse-core`; the SDK's legacy `EnhancedDataSetInfo.activePieceCount` field is unchanged.
 
 ---
 

--- a/docs/src/content/docs/developer-guides/migration-guide.md
+++ b/docs/src/content/docs/developer-guides/migration-guide.md
@@ -106,7 +106,7 @@ Raw `*Call` helpers in `@filoz/synapse-core` remain ABI-oriented: provide their 
 
 ### Action: Replace core `activePieceCount` with `hasActivePieces`
 
-The enriched `PdpDataSet` values returned by `getPdpDataSet()` and `getPdpDataSets()` no longer include an exact `activePieceCount`. They now expose `hasActivePieces`, which is derived from a bounded one-item `getActivePiecesByCursor` read:
+The enriched `PdpDataSet` values returned by `getPdpDataSet()` and `getPdpDataSets()` no longer include an exact `activePieceCount`. They now expose `hasActivePieces`, derived from a non-zero `getDataSetLeafCount` read. Leaf count is an O(1) storage lookup, unlike `getActivePiecesByCursor` and `getActivePieceCount`, which scan piece IDs and can run out of gas on large or fully drained data sets:
 
 ```ts
 // before
@@ -122,7 +122,7 @@ if (dataSet?.hasActivePieces) {
 }
 ```
 
-`WarmStorageService.hasActivePieces()` keeps the same public API, but now performs the same bounded cursor read instead of calculating an exact count.
+`WarmStorageService.hasActivePieces()` keeps the same public API, but now uses the same leaf-count proxy instead of calculating an exact count.
 
 The standalone `getActivePieceCount()` action remains available, but the underlying contract getter scans the data set's piece-ID range and can fail for large data sets. If you need an exact count, explicitly paginate the active pieces:
 

--- a/docs/src/content/docs/developer-guides/migration-guide.md
+++ b/docs/src/content/docs/developer-guides/migration-guide.md
@@ -104,6 +104,40 @@ for await (const piece of paginate(({ cursor }) =>
 
 Raw `*Call` helpers in `@filoz/synapse-core` remain ABI-oriented: provide their required contract-facing `offset` or `startPieceId` and `limit` fields explicitly when constructing multicalls.
 
+### Action: Replace core `activePieceCount` with `hasActivePieces`
+
+The enriched `PdpDataSet` values returned by `getPdpDataSet()` and `getPdpDataSets()` no longer include an exact `activePieceCount`. They now expose `hasActivePieces`, which is derived from a bounded one-item `getActivePiecesByCursor` read:
+
+```ts
+// before
+const dataSet = await getPdpDataSet(client, { dataSetId })
+if (dataSet && dataSet.activePieceCount > 0n) {
+  // the data set has pieces
+}
+
+// after
+const dataSet = await getPdpDataSet(client, { dataSetId })
+if (dataSet?.hasActivePieces) {
+  // the data set has pieces
+}
+```
+
+`WarmStorageService.hasActivePieces()` keeps the same public API, but now performs the same bounded cursor read instead of calculating an exact count.
+
+The standalone `getActivePieceCount()` action remains available, but the underlying contract getter scans the data set's piece-ID range and can fail for large data sets. If you need an exact count, explicitly paginate the active pieces:
+
+```ts
+let activePieceCount = 0n
+
+for await (const _piece of paginate(({ cursor }) =>
+  getActivePiecesByCursor(client, { dataSetId, cursor })
+)) {
+  activePieceCount++
+}
+```
+
+This field change is limited to the enriched data set types in `@filoz/synapse-core`; the SDK's legacy `EnhancedDataSetInfo.activePieceCount` field is unchanged.
+
 ---
 
 ## 1.0.0

--- a/docs/src/content/docs/developer-guides/storage/storage-operations.mdx
+++ b/docs/src/content/docs/developer-guides/storage/storage-operations.mdx
@@ -196,7 +196,7 @@ These APIs are useful when you want to inspect existing data sets, query stored 
 
 ### Getting All Data Sets
 
-Retrieve all data sets owned by your account to inspect piece counts, CDN status, and metadata:
+Retrieve all data sets owned by your account to inspect piece presence, CDN status, and metadata:
 
 ```ts twoslash
 // @lib: esnext,dom
@@ -210,7 +210,7 @@ for (const ds of dataSets) {
   console.log(`Dataset ${ds.pdpVerifierDataSetId}:`, {
     live: ds.isLive,
     cdn: ds.withCDN,
-    pieces: ds.activePieceCount,
+    hasActivePieces: ds.hasActivePieces,
     metadata: ds.metadata
   });
 }

--- a/packages/synapse-core/src/mocks/jsonrpc/index.ts
+++ b/packages/synapse-core/src/mocks/jsonrpc/index.ts
@@ -570,7 +570,7 @@ export const presets = {
         false,
       ],
       getDataSetStorageProvider: () => [ADDRESSES.serviceProvider1, ADDRESSES.zero],
-      getDataSetLeafCount: () => [0n],
+      getDataSetLeafCount: () => [2n],
       getScheduledRemovals: () => [[]],
       getNextChallengeEpoch: () => [5000n],
       findPieceIdsByCid: () => [[0n]],

--- a/packages/synapse-core/src/pdp-verifier/get-active-piece-count.ts
+++ b/packages/synapse-core/src/pdp-verifier/get-active-piece-count.ts
@@ -6,6 +6,7 @@ import { asChain } from '../chains.ts'
 import type { ActionCallChain } from '../types.ts'
 import { STRING_ERRORS, stringErrorEquals } from '../utils/contract-errors.ts'
 import { toReadClient } from '../utils/read-client.ts'
+import type { getActivePiecesByCursor } from './get-active-pieces-by-cursor.ts'
 
 export namespace getActivePieceCount {
   export type OptionsType = {
@@ -22,6 +23,10 @@ export namespace getActivePieceCount {
 
 /**
  * Get the active piece count for a data set (non-zero leaf count)
+ *
+ * This contract method scans the complete historical piece-ID range and can
+ * run out of gas for large data sets. Prefer explicitly traversing
+ * {@link getActivePiecesByCursor} when reliability for large sets is required.
  *
  * @example
  * ```ts

--- a/packages/synapse-core/src/warm-storage/find-matching-data-sets.ts
+++ b/packages/synapse-core/src/warm-storage/find-matching-data-sets.ts
@@ -41,7 +41,7 @@ export function metadataMatches(dataSetMetadata: MetadataObject, requestedMetada
  * Only active datasets are considered (live, managed, pdpEndEpoch === 0n).
  *
  * Sort order:
- *   1. Datasets with pieces (activePieceCount > 0) before empty datasets
+ *   1. Datasets with pieces before empty datasets
  *   2. Within each group, older datasets (lower ID) first
  *
  * @param dataSets - Datasets to search (typically filtered to a single provider)
@@ -54,10 +54,8 @@ export function findMatchingDataSets(dataSets: SelectionDataSet[], metadata: Met
   )
 
   return matching.sort((a, b) => {
-    // Datasets with pieces sort before empty ones
-    if (a.activePieceCount > 0n && b.activePieceCount === 0n) return -1
-    if (b.activePieceCount > 0n && a.activePieceCount === 0n) return 1
-    // Within same group, oldest dataset first (lower ID)
+    if (a.hasActivePieces && !b.hasActivePieces) return -1
+    if (b.hasActivePieces && !a.hasActivePieces) return 1
     return Number(a.dataSetId - b.dataSetId)
   })
 }

--- a/packages/synapse-core/src/warm-storage/get-pdp-data-set.ts
+++ b/packages/synapse-core/src/warm-storage/get-pdp-data-set.ts
@@ -2,10 +2,8 @@ import { type Address, type Chain, type Client, isAddressEqual, type ReadContrac
 import { multicall } from 'viem/actions'
 import { asChain } from '../chains.ts'
 import { dataSetLiveCall } from '../pdp-verifier/data-set-live.ts'
-import {
-  type getActivePiecesByCursor,
-  getActivePiecesByCursorCall,
-} from '../pdp-verifier/get-active-pieces-by-cursor.ts'
+import type { getActivePiecesByCursor } from '../pdp-verifier/get-active-pieces-by-cursor.ts'
+import { type getDataSetLeafCount, getDataSetLeafCountCall } from '../pdp-verifier/get-data-set-leaf-count.ts'
 import { getDataSetListenerCall } from '../pdp-verifier/get-data-set-listener.ts'
 import { getPDPProviderCall, parsePDPProvider } from '../sp-registry/get-pdp-provider.ts'
 import { toReadClient } from '../utils/read-client.ts'
@@ -30,11 +28,12 @@ export namespace getPdpDataSet {
 /**
  * Get a PDP data set by ID.
  *
- * The result reports piece presence from a one-item cursor read, but
- * intentionally omits an exact active-piece count because the contract's count
- * getter performs a linear scan and can fail for large data sets. To derive an
- * exact count explicitly, traverse {@link getActivePiecesByCursor} with
- * `paginate` and count the yielded pieces.
+ * The result reports piece presence from a non-zero {@link getDataSetLeafCount}
+ * read, which is an O(1) storage lookup, rather than scanning piece IDs. Exact
+ * active-piece counts are omitted because the contract's count getter performs
+ * a linear scan and can fail for large data sets. To derive an exact count
+ * explicitly, traverse {@link getActivePiecesByCursor} with `paginate` and
+ * count the yielded pieces.
  *
  * @param client - The client to use to get the PDP data set.
  * @param options - {@link getPdpDataSet.OptionsType}
@@ -84,7 +83,7 @@ export async function getPdpDataSet(
 }
 
 /**
- * Read PDP data set information without calculating an active-piece count.
+ * Read PDP data set information.
  *
  * @param client - The client to use to read the PDP data set info.
  * @param options
@@ -98,7 +97,7 @@ export async function readPdpDataSetInfo(
   }
 ): Promise<PdpDataSetInfo> {
   const chain = asChain(client.chain)
-  const [live, listener, _metadata, _pdpProvider, activePieces] = await multicall(toReadClient(client), {
+  const [live, listener, _metadata, _pdpProvider, leafCount] = await multicall(toReadClient(client), {
     allowFailure: false,
     contracts: [
       dataSetLiveCall({
@@ -117,11 +116,9 @@ export async function readPdpDataSetInfo(
         chain: client.chain,
         providerId: options.providerId,
       }),
-      getActivePiecesByCursorCall({
+      getDataSetLeafCountCall({
         chain: client.chain,
         dataSetId: options.dataSetInfo.dataSetId,
-        startPieceId: 0n,
-        limit: 1n,
       }),
     ],
   })
@@ -135,6 +132,6 @@ export async function readPdpDataSetInfo(
     cdn: options.dataSetInfo.cdnRailId > 0n && 'withCDN' in metadata,
     metadata,
     provider: pdpProvider,
-    hasActivePieces: activePieces[1].length > 0,
+    hasActivePieces: leafCount > 0n,
   }
 }

--- a/packages/synapse-core/src/warm-storage/get-pdp-data-set.ts
+++ b/packages/synapse-core/src/warm-storage/get-pdp-data-set.ts
@@ -2,7 +2,10 @@ import { type Address, type Chain, type Client, isAddressEqual, type ReadContrac
 import { multicall } from 'viem/actions'
 import { asChain } from '../chains.ts'
 import { dataSetLiveCall } from '../pdp-verifier/data-set-live.ts'
-import { getActivePieceCountCall } from '../pdp-verifier/get-active-piece-count.ts'
+import {
+  type getActivePiecesByCursor,
+  getActivePiecesByCursorCall,
+} from '../pdp-verifier/get-active-pieces-by-cursor.ts'
 import { getDataSetListenerCall } from '../pdp-verifier/get-data-set-listener.ts'
 import { getPDPProviderCall, parsePDPProvider } from '../sp-registry/get-pdp-provider.ts'
 import { toReadClient } from '../utils/read-client.ts'
@@ -25,7 +28,13 @@ export namespace getPdpDataSet {
 }
 
 /**
- * Get a PDP data set by ID
+ * Get a PDP data set by ID.
+ *
+ * The result reports piece presence from a one-item cursor read, but
+ * intentionally omits an exact active-piece count because the contract's count
+ * getter performs a linear scan and can fail for large data sets. To derive an
+ * exact count explicitly, traverse {@link getActivePiecesByCursor} with
+ * `paginate` and count the yielded pieces.
  *
  * @param client - The client to use to get the PDP data set.
  * @param options - {@link getPdpDataSet.OptionsType}
@@ -75,7 +84,7 @@ export async function getPdpDataSet(
 }
 
 /**
- * Read the PDP data set info.
+ * Read PDP data set information without calculating an active-piece count.
  *
  * @param client - The client to use to read the PDP data set info.
  * @param options
@@ -89,7 +98,7 @@ export async function readPdpDataSetInfo(
   }
 ): Promise<PdpDataSetInfo> {
   const chain = asChain(client.chain)
-  const [live, listener, _metadata, _pdpProvider, activePieceCount] = await multicall(toReadClient(client), {
+  const [live, listener, _metadata, _pdpProvider, activePieces] = await multicall(toReadClient(client), {
     allowFailure: false,
     contracts: [
       dataSetLiveCall({
@@ -108,9 +117,11 @@ export async function readPdpDataSetInfo(
         chain: client.chain,
         providerId: options.providerId,
       }),
-      getActivePieceCountCall({
+      getActivePiecesByCursorCall({
         chain: client.chain,
         dataSetId: options.dataSetInfo.dataSetId,
+        startPieceId: 0n,
+        limit: 1n,
       }),
     ],
   })
@@ -124,6 +135,6 @@ export async function readPdpDataSetInfo(
     cdn: options.dataSetInfo.cdnRailId > 0n && 'withCDN' in metadata,
     metadata,
     provider: pdpProvider,
-    activePieceCount,
+    hasActivePieces: activePieces[1].length > 0,
   }
 }

--- a/packages/synapse-core/src/warm-storage/get-pdp-data-sets.ts
+++ b/packages/synapse-core/src/warm-storage/get-pdp-data-sets.ts
@@ -3,10 +3,8 @@ import { multicall } from 'viem/actions'
 import { asChain } from '../chains.ts'
 import type { Page, paginate } from '../pagination.ts'
 import { type dataSetLive, dataSetLiveCall } from '../pdp-verifier/data-set-live.ts'
-import {
-  type getActivePiecesByCursor,
-  getActivePiecesByCursorCall,
-} from '../pdp-verifier/get-active-pieces-by-cursor.ts'
+import type { getActivePiecesByCursor } from '../pdp-verifier/get-active-pieces-by-cursor.ts'
+import { type getDataSetLeafCount, getDataSetLeafCountCall } from '../pdp-verifier/get-data-set-leaf-count.ts'
 import { type getDataSetListener, getDataSetListenerCall } from '../pdp-verifier/get-data-set-listener.ts'
 import { type getPDPProvider, getPDPProviderCall, parsePDPProvider } from '../sp-registry/get-pdp-provider.ts'
 import type { PDPProvider } from '../sp-registry/types.ts'
@@ -27,7 +25,7 @@ type DataSetEnrichmentResults = [
   dataSetLive.OutputType,
   getDataSetListener.ContractOutputType,
   getAllDataSetMetadata.ContractOutputType,
-  getActivePiecesByCursor.ContractOutputType,
+  getDataSetLeafCount.OutputType,
 ]
 
 export namespace getPdpDataSets {
@@ -45,9 +43,10 @@ export namespace getPdpDataSets {
  * Only the current source page is enriched, in bounded batches with source
  * order preserved. Pass `nextCursor` back as `cursor`; treat it as
  * opaque. Use {@link paginate} to traverse every page. Results report piece
- * presence from a one-item cursor read, but intentionally omit exact
- * active-piece counts because the contract's count getter performs a linear
- * scan and can fail for large data sets. To derive a count explicitly, traverse
+ * presence from a non-zero {@link getDataSetLeafCount} read, which is an O(1)
+ * storage lookup, rather than scanning piece IDs. Exact active-piece counts are
+ * omitted because the contract's count getter performs a linear scan and can
+ * fail for large data sets. To derive a count explicitly, traverse
  * {@link getActivePiecesByCursor} and count the yielded pieces.
  *
  * @param client - The client to use to get data sets for a client address.
@@ -135,7 +134,7 @@ async function enrichDataSetBatch(
     dataSetLiveCall({ chain: client.chain, dataSetId }),
     getDataSetListenerCall({ chain: client.chain, dataSetId }),
     getAllDataSetMetadataCall({ chain: client.chain, dataSetId }),
-    getActivePiecesByCursorCall({ chain: client.chain, dataSetId, startPieceId: 0n, limit: 1n }),
+    getDataSetLeafCountCall({ chain: client.chain, dataSetId }),
   ])
   const providerCalls = missingProviderIds.map((providerId) => getPDPProviderCall({ chain: client.chain, providerId }))
   const results = await multicall(toReadClient(client), {
@@ -156,7 +155,7 @@ async function enrichDataSetBatch(
 
   return dataSets.map((dataSet, index) => {
     const resultOffset = index * DATA_SET_CALL_COUNT
-    const [live, listener, rawMetadata, activePieces] = results.slice(
+    const [live, listener, rawMetadata, leafCount] = results.slice(
       resultOffset,
       resultOffset + DATA_SET_CALL_COUNT
     ) as DataSetEnrichmentResults
@@ -173,7 +172,7 @@ async function enrichDataSetBatch(
       cdn: dataSet.cdnRailId > 0n && 'withCDN' in metadata,
       metadata,
       provider,
-      hasActivePieces: activePieces[1].length > 0,
+      hasActivePieces: leafCount > 0n,
     }
   })
 }

--- a/packages/synapse-core/src/warm-storage/get-pdp-data-sets.ts
+++ b/packages/synapse-core/src/warm-storage/get-pdp-data-sets.ts
@@ -3,7 +3,10 @@ import { multicall } from 'viem/actions'
 import { asChain } from '../chains.ts'
 import type { Page, paginate } from '../pagination.ts'
 import { type dataSetLive, dataSetLiveCall } from '../pdp-verifier/data-set-live.ts'
-import { type getActivePieceCount, getActivePieceCountCall } from '../pdp-verifier/get-active-piece-count.ts'
+import {
+  type getActivePiecesByCursor,
+  getActivePiecesByCursorCall,
+} from '../pdp-verifier/get-active-pieces-by-cursor.ts'
 import { type getDataSetListener, getDataSetListenerCall } from '../pdp-verifier/get-data-set-listener.ts'
 import { type getPDPProvider, getPDPProviderCall, parsePDPProvider } from '../sp-registry/get-pdp-provider.ts'
 import type { PDPProvider } from '../sp-registry/types.ts'
@@ -24,7 +27,7 @@ type DataSetEnrichmentResults = [
   dataSetLive.OutputType,
   getDataSetListener.ContractOutputType,
   getAllDataSetMetadata.ContractOutputType,
-  getActivePieceCount.OutputType,
+  getActivePiecesByCursor.ContractOutputType,
 ]
 
 export namespace getPdpDataSets {
@@ -41,7 +44,11 @@ export namespace getPdpDataSets {
  *
  * Only the current source page is enriched, in bounded batches with source
  * order preserved. Pass `nextCursor` back as `cursor`; treat it as
- * opaque. Use {@link paginate} to traverse every page.
+ * opaque. Use {@link paginate} to traverse every page. Results report piece
+ * presence from a one-item cursor read, but intentionally omit exact
+ * active-piece counts because the contract's count getter performs a linear
+ * scan and can fail for large data sets. To derive a count explicitly, traverse
+ * {@link getActivePiecesByCursor} and count the yielded pieces.
  *
  * @param client - The client to use to get data sets for a client address.
  * @param options - {@link getPdpDataSets.OptionsType}
@@ -97,7 +104,7 @@ export async function getPdpDataSets(
 
 /**
  * Enrich one bounded batch of source data sets with their PDP state, metadata,
- * provider details, and active-piece counts.
+ * provider details, and active-piece presence.
  *
  * The four data-set-specific reads are flattened into one Viem multicall. PDP
  * provider reads are deduplicated by provider ID and cached in `providers`, so
@@ -128,7 +135,7 @@ async function enrichDataSetBatch(
     dataSetLiveCall({ chain: client.chain, dataSetId }),
     getDataSetListenerCall({ chain: client.chain, dataSetId }),
     getAllDataSetMetadataCall({ chain: client.chain, dataSetId }),
-    getActivePieceCountCall({ chain: client.chain, dataSetId }),
+    getActivePiecesByCursorCall({ chain: client.chain, dataSetId, startPieceId: 0n, limit: 1n }),
   ])
   const providerCalls = missingProviderIds.map((providerId) => getPDPProviderCall({ chain: client.chain, providerId }))
   const results = await multicall(toReadClient(client), {
@@ -149,7 +156,7 @@ async function enrichDataSetBatch(
 
   return dataSets.map((dataSet, index) => {
     const resultOffset = index * DATA_SET_CALL_COUNT
-    const [live, listener, rawMetadata, activePieceCount] = results.slice(
+    const [live, listener, rawMetadata, activePieces] = results.slice(
       resultOffset,
       resultOffset + DATA_SET_CALL_COUNT
     ) as DataSetEnrichmentResults
@@ -166,7 +173,7 @@ async function enrichDataSetBatch(
       cdn: dataSet.cdnRailId > 0n && 'withCDN' in metadata,
       metadata,
       provider,
-      activePieceCount,
+      hasActivePieces: activePieces[1].length > 0,
     }
   })
 }

--- a/packages/synapse-core/src/warm-storage/location-types.ts
+++ b/packages/synapse-core/src/warm-storage/location-types.ts
@@ -2,12 +2,12 @@ import type { PDPProvider } from '../sp-registry/types.ts'
 import type { MetadataObject } from '../utils/metadata.ts'
 
 /**
- * Dataset with piece count, for provider selection.
+ * Dataset with piece-presence information used for provider selection.
  *
  * Picks the fields that selectProviders() and findMatchingDataSets()
- * need, plus activePieceCount which is fetched separately via multicall.
+ * need, plus whether the data set contains an active piece.
  *
- * Core callers can spread a PdpDataSet directly: `{ ...ds, activePieceCount }`.
+ * Core callers can spread a PdpDataSet directly.
  * SDK callers map from EnhancedDataSetInfo (different field names).
  */
 export interface SelectionDataSet {
@@ -17,8 +17,8 @@ export interface SelectionDataSet {
   providerId: bigint
   /** Data set metadata (key-value pairs) */
   metadata: MetadataObject
-  /** Number of active pieces in the dataset (0 = empty) */
-  activePieceCount: bigint
+  /** Whether the data set contains at least one active piece */
+  hasActivePieces: boolean
   /** End epoch for PDP service (0 = active) */
   pdpEndEpoch: bigint
   /** Whether the data set is live in the PDP Verifier */
@@ -44,7 +44,7 @@ export interface ProviderSelectionInput {
   /** Array of endorsed provider IDs (from endorsements.getProviderIds).
    *  Non-empty = restrict to endorsed only. Empty = use all providers. */
   endorsedIds: bigint[]
-  /** Client's existing datasets with metadata and piece counts */
+  /** Client's existing datasets with metadata and piece-presence information */
   clientDataSets: SelectionDataSet[]
 }
 

--- a/packages/synapse-core/src/warm-storage/location-types.ts
+++ b/packages/synapse-core/src/warm-storage/location-types.ts
@@ -5,7 +5,7 @@ import type { MetadataObject } from '../utils/metadata.ts'
  * Dataset with piece-presence information used for provider selection.
  *
  * Picks the fields that selectProviders() and findMatchingDataSets()
- * need, plus whether the data set contains an active piece.
+ * need, plus whether the data set contains at least one active piece.
  *
  * Core callers can spread a PdpDataSet directly.
  * SDK callers map from EnhancedDataSetInfo (different field names).

--- a/packages/synapse-core/src/warm-storage/types.ts
+++ b/packages/synapse-core/src/warm-storage/types.ts
@@ -44,8 +44,8 @@ export type PdpDataSetInfo = {
   metadata: MetadataObject
   /** PDP provider associated with the data set. */
   provider: PDPProvider
-  /** Number of active (non-zero) pieces in the data set. */
-  activePieceCount: bigint
+  /** Whether the data set contains at least one active piece. */
+  hasActivePieces: boolean
 }
 
 export interface PdpDataSet extends DataSetInfo, PdpDataSetInfo {}

--- a/packages/synapse-core/src/warm-storage/types.ts
+++ b/packages/synapse-core/src/warm-storage/types.ts
@@ -44,7 +44,7 @@ export type PdpDataSetInfo = {
   metadata: MetadataObject
   /** PDP provider associated with the data set. */
   provider: PDPProvider
-  /** Whether the data set contains at least one active piece. */
+  /** Whether the data set contains at least one active piece (non-zero leaf count). */
   hasActivePieces: boolean
 }
 

--- a/packages/synapse-core/test/find-matching-data-sets.test.ts
+++ b/packages/synapse-core/test/find-matching-data-sets.test.ts
@@ -8,7 +8,7 @@ function makeDataSet(
 ): SelectionDataSet {
   return {
     metadata: {},
-    activePieceCount: 0n,
+    hasActivePieces: false,
     pdpEndEpoch: 0n,
     live: true,
     managed: true,
@@ -71,18 +71,18 @@ describe('findMatchingDataSets', () => {
 
   it('sorts datasets with pieces before empty ones', () => {
     const dataSets = [
-      makeDataSet({ dataSetId: 1n, providerId: 1n, metadata: { source: 'app' }, activePieceCount: 0n }),
-      makeDataSet({ dataSetId: 2n, providerId: 2n, metadata: { source: 'app' }, activePieceCount: 5n }),
+      makeDataSet({ dataSetId: 1n, providerId: 1n, metadata: { source: 'app' }, hasActivePieces: false }),
+      makeDataSet({ dataSetId: 2n, providerId: 2n, metadata: { source: 'app' }, hasActivePieces: true }),
     ]
     const result = findMatchingDataSets(dataSets, { source: 'app' })
     assert.equal(result[0].dataSetId, 2n)
     assert.equal(result[1].dataSetId, 1n)
   })
 
-  it('sorts by ID ascending within same piece group', () => {
+  it('sorts by ID ascending', () => {
     const dataSets = [
-      makeDataSet({ dataSetId: 10n, providerId: 1n, metadata: { source: 'app' }, activePieceCount: 3n }),
-      makeDataSet({ dataSetId: 5n, providerId: 2n, metadata: { source: 'app' }, activePieceCount: 3n }),
+      makeDataSet({ dataSetId: 10n, providerId: 1n, metadata: { source: 'app' }, hasActivePieces: true }),
+      makeDataSet({ dataSetId: 5n, providerId: 2n, metadata: { source: 'app' }, hasActivePieces: true }),
     ]
     const result = findMatchingDataSets(dataSets, { source: 'app' })
     assert.equal(result[0].dataSetId, 5n)
@@ -134,15 +134,14 @@ describe('findMatchingDataSets', () => {
     assert.equal(result.length, 0)
   })
 
-  it('full sorting: pieces first, then by ID within groups', () => {
+  it('sorts by piece presence and then by ID', () => {
     const dataSets = [
-      makeDataSet({ dataSetId: 10n, providerId: 1n, metadata: { source: 'app' }, activePieceCount: 0n }),
-      makeDataSet({ dataSetId: 5n, providerId: 2n, metadata: { source: 'app' }, activePieceCount: 3n }),
-      makeDataSet({ dataSetId: 3n, providerId: 3n, metadata: { source: 'app' }, activePieceCount: 0n }),
-      makeDataSet({ dataSetId: 8n, providerId: 4n, metadata: { source: 'app' }, activePieceCount: 7n }),
+      makeDataSet({ dataSetId: 10n, providerId: 1n, metadata: { source: 'app' }, hasActivePieces: false }),
+      makeDataSet({ dataSetId: 5n, providerId: 2n, metadata: { source: 'app' }, hasActivePieces: true }),
+      makeDataSet({ dataSetId: 3n, providerId: 3n, metadata: { source: 'app' }, hasActivePieces: false }),
+      makeDataSet({ dataSetId: 8n, providerId: 4n, metadata: { source: 'app' }, hasActivePieces: true }),
     ]
     const result = findMatchingDataSets(dataSets, { source: 'app' })
-    // Pieces first (5n, 8n by ID ascending), then empty (3n, 10n by ID ascending)
     assert.deepEqual(
       result.map((ds) => ds.dataSetId),
       [5n, 8n, 3n, 10n]

--- a/packages/synapse-core/test/get-data-set-leaf-count.test.ts
+++ b/packages/synapse-core/test/get-data-set-leaf-count.test.ts
@@ -69,7 +69,7 @@ describe('getDataSetLeafCount', () => {
       const count = await getDataSetLeafCount(client, { dataSetId: 1n })
 
       assert.equal(typeof count, 'bigint')
-      assert.equal(count, 0n)
+      assert.equal(count, 2n)
     })
 
     it('should return 0 when the data set is not live', async () => {

--- a/packages/synapse-core/test/get-pdp-data-set.test.ts
+++ b/packages/synapse-core/test/get-pdp-data-set.test.ts
@@ -60,6 +60,32 @@ describe('getPdpDataSet', () => {
       assert.equal(dataSet.provider.name, 'Test Provider')
       assert.equal(dataSet.provider.serviceProvider.toLowerCase(), ADDRESSES.serviceProvider1.toLowerCase())
       assert.equal(typeof dataSet.hasActivePieces, 'boolean')
+      assert.equal(dataSet.hasActivePieces, true)
+    })
+
+    it('should report hasActivePieces false when leaf count is zero', async () => {
+      server.use(
+        JSONRPC({
+          ...presets.basic,
+          pdpVerifier: {
+            ...presets.basic.pdpVerifier,
+            getDataSetLeafCount: () => [0n],
+          },
+        })
+      )
+
+      const client = createPublicClient({
+        chain: calibration,
+        transport: http(),
+      })
+
+      const dataSet = await getPdpDataSet(client, {
+        dataSetId: 1n,
+      })
+
+      assert.ok(dataSet)
+      if (!dataSet) return
+      assert.equal(dataSet.hasActivePieces, false)
     })
 
     it('should return undefined for non-existent data set', async () => {

--- a/packages/synapse-core/test/get-pdp-data-set.test.ts
+++ b/packages/synapse-core/test/get-pdp-data-set.test.ts
@@ -59,6 +59,7 @@ describe('getPdpDataSet', () => {
       assert.equal(dataSet.provider.id, 1n)
       assert.equal(dataSet.provider.name, 'Test Provider')
       assert.equal(dataSet.provider.serviceProvider.toLowerCase(), ADDRESSES.serviceProvider1.toLowerCase())
+      assert.equal(typeof dataSet.hasActivePieces, 'boolean')
     })
 
     it('should return undefined for non-existent data set', async () => {

--- a/packages/synapse-core/test/get-pdp-data-sets.test.ts
+++ b/packages/synapse-core/test/get-pdp-data-sets.test.ts
@@ -59,6 +59,7 @@ describe('getPdpDataSets', () => {
       assert.ok(first.provider)
       assert.equal(first.provider.id, 1n)
       assert.equal(first.provider.name, 'Test Provider')
+      assert.equal(typeof first.hasActivePieces, 'boolean')
     })
 
     it('should return empty array for client with no data sets', async () => {

--- a/packages/synapse-core/test/get-pdp-data-sets.test.ts
+++ b/packages/synapse-core/test/get-pdp-data-sets.test.ts
@@ -60,6 +60,7 @@ describe('getPdpDataSets', () => {
       assert.equal(first.provider.id, 1n)
       assert.equal(first.provider.name, 'Test Provider')
       assert.equal(typeof first.hasActivePieces, 'boolean')
+      assert.equal(first.hasActivePieces, true)
     })
 
     it('should return empty array for client with no data sets', async () => {

--- a/packages/synapse-core/test/get-pieces.test.ts
+++ b/packages/synapse-core/test/get-pieces.test.ts
@@ -30,7 +30,7 @@ describe('getPieces', () => {
       managed: true,
       cdn: false,
       metadata: Object.create(null),
-      activePieceCount: 2n,
+      hasActivePieces: true,
       provider: {
         id: 1n,
         serviceProvider: ADDRESSES.serviceProvider1,

--- a/packages/synapse-core/test/select-providers.test.ts
+++ b/packages/synapse-core/test/select-providers.test.ts
@@ -33,7 +33,7 @@ function makeDataSet(
 ): SelectionDataSet {
   return {
     metadata: {},
-    activePieceCount: 0n,
+    hasActivePieces: false,
     pdpEndEpoch: 0n,
     live: true,
     managed: true,
@@ -133,13 +133,11 @@ describe('selectProviders', () => {
             dataSetId: 10n,
             providerId: 1n,
             metadata: { source: 'app' },
-            activePieceCount: 5n,
           }),
           makeDataSet({
             dataSetId: 20n,
             providerId: 2n,
             metadata: { source: 'app' },
-            activePieceCount: 3n,
           }),
         ],
         metadata: { source: 'app' },
@@ -160,7 +158,6 @@ describe('selectProviders', () => {
             dataSetId: 20n,
             providerId: 2n,
             metadata: { source: 'app' },
-            activePieceCount: 3n,
           }),
         ],
         metadata: { source: 'app' },
@@ -190,7 +187,6 @@ describe('selectProviders', () => {
             dataSetId: 20n,
             providerId: 2n,
             metadata: { source: 'app' },
-            activePieceCount: 10n,
           }),
         ],
         metadata: { source: 'app' },
@@ -209,7 +205,6 @@ describe('selectProviders', () => {
             dataSetId: 20n,
             providerId: 2n,
             metadata: { source: 'app' },
-            activePieceCount: 3n,
           }),
         ],
         metadata: { source: 'app' },
@@ -254,13 +249,11 @@ describe('selectProviders', () => {
             dataSetId: 10n,
             providerId: 1n,
             metadata: { source: 'app' },
-            activePieceCount: 5n,
           }),
           makeDataSet({
             dataSetId: 20n,
             providerId: 2n,
             metadata: { source: 'app' },
-            activePieceCount: 3n,
           }),
         ],
         metadata: { source: 'app' },
@@ -282,7 +275,6 @@ describe('selectProviders', () => {
             dataSetId: 10n,
             providerId: 1n,
             metadata: { source: 'app' },
-            activePieceCount: 5n,
           }),
         ],
         metadata: { source: 'app' },
@@ -300,7 +292,7 @@ describe('selectProviders', () => {
   })
 
   describe('dataset preference', () => {
-    it('prefers dataset with pieces over empty dataset on same provider', () => {
+    it('prefers dataset with pieces over an older empty dataset on the same provider', () => {
       const result = selectProviders({
         providers: [provider1],
         endorsedIds: [],
@@ -309,13 +301,12 @@ describe('selectProviders', () => {
             dataSetId: 5n,
             providerId: 1n,
             metadata: { source: 'app' },
-            activePieceCount: 0n,
           }),
           makeDataSet({
             dataSetId: 10n,
             providerId: 1n,
             metadata: { source: 'app' },
-            activePieceCount: 3n,
+            hasActivePieces: true,
           }),
         ],
         metadata: { source: 'app' },
@@ -323,7 +314,7 @@ describe('selectProviders', () => {
       assert.equal(result[0].dataSetId, 10n)
     })
 
-    it('prefers older dataset when both have pieces', () => {
+    it('prefers the oldest matching dataset when both have pieces', () => {
       const result = selectProviders({
         providers: [provider1],
         endorsedIds: [],
@@ -332,13 +323,13 @@ describe('selectProviders', () => {
             dataSetId: 10n,
             providerId: 1n,
             metadata: { source: 'app' },
-            activePieceCount: 3n,
+            hasActivePieces: true,
           }),
           makeDataSet({
             dataSetId: 5n,
             providerId: 1n,
             metadata: { source: 'app' },
-            activePieceCount: 3n,
+            hasActivePieces: true,
           }),
         ],
         metadata: { source: 'app' },
@@ -357,13 +348,11 @@ describe('selectProviders', () => {
             dataSetId: 10n,
             providerId: 1n,
             metadata: { env: 'prod' },
-            activePieceCount: 5n,
           }),
           makeDataSet({
             dataSetId: 20n,
             providerId: 2n,
             metadata: { env: 'test' },
-            activePieceCount: 5n,
           }),
         ],
         metadata: { env: 'test' },

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -514,7 +514,7 @@ export class StorageContext {
     // of order: `bestNonEmptyIndex` is the oldest non-empty metadata match and
     // `firstMatchIndex` the oldest metadata match (the fallback). Metadata is read
     // first and hasActivePieces only on a metadata match, so non-matching
-    // datasets skip the piece-count read.
+    // datasets skip the leaf-count read.
     const evaluated: (EvaluatedDataSet | null)[] = new Array(sortedDataSets.length).fill(null)
     let firstMatchIndex = Number.POSITIVE_INFINITY
     let bestNonEmptyIndex = Number.POSITIVE_INFINITY

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -31,14 +31,13 @@ const server = setup()
 const pdpOptions = {
   baseUrl: 'https://pdp.example.com',
 }
-const activePieceCid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
 
 // The two per-data-set reads resolveByProviderId issues; both take the data set
 // id as their first uint256 argument, so the id is the first 32-byte word after
 // the 4-byte selector in the call data.
 const RESOLVE_READ_SELECTORS = [
   toFunctionSelector('getAllDataSetMetadata(uint256)'),
-  toFunctionSelector('getActivePiecesByCursor(uint256,uint256,uint256)'),
+  toFunctionSelector('getDataSetLeafCount(uint256)'),
 ]
 
 /**
@@ -347,13 +346,9 @@ describe('StorageService', () => {
           ...Mocks.presets.basic,
           pdpVerifier: {
             ...Mocks.presets.basic.pdpVerifier,
-            getActivePiecesByCursor: (args) => {
+            getDataSetLeafCount: (args) => {
               const [dataSetId] = args
-              if (dataSetId === 2n) {
-                const cid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
-                return [[{ data: bytesToHex(cid.bytes) }], [1n], false]
-              }
-              return [[], [], false]
+              return [dataSetId === 2n ? 1n : 0n]
             },
           },
           warmStorageView: {
@@ -403,7 +398,7 @@ describe('StorageService', () => {
         pdpRailId: BigInt(i + 1),
       }))
 
-      let getActivePiecesByCursorCalls = 0
+      let getDataSetLeafCountCalls = 0
       let getAllDataSetMetadataCalls = 0
       server.use(
         Mocks.JSONRPC(
@@ -411,10 +406,10 @@ describe('StorageService', () => {
             ...Mocks.presets.basic,
             pdpVerifier: {
               ...Mocks.presets.basic.pdpVerifier,
-              getActivePiecesByCursor: (args) => {
-                getActivePiecesByCursorCalls++
+              getDataSetLeafCount: (args) => {
+                getDataSetLeafCountCalls++
                 const [dataSetId] = args
-                return dataSetId === 1n ? [[{ data: bytesToHex(activePieceCid.bytes) }], [1n], false] : [[], [], false]
+                return [dataSetId === 1n ? 1n : 0n]
               },
             },
             warmStorageView: {
@@ -461,8 +456,8 @@ describe('StorageService', () => {
       // tracks the concurrency rather than hard-coding the count.
       const maxExpectedCalls = RESOLVE_CONCURRENCY * 2
       assert.ok(
-        getActivePiecesByCursorCalls <= maxExpectedCalls,
-        `expected <=${maxExpectedCalls} getActivePiecesByCursor calls, got ${getActivePiecesByCursorCalls} (unbounded fan-out regression)`
+        getDataSetLeafCountCalls <= maxExpectedCalls,
+        `expected <=${maxExpectedCalls} getDataSetLeafCount calls, got ${getDataSetLeafCountCalls} (unbounded fan-out regression)`
       )
       assert.ok(
         getAllDataSetMetadataCalls <= maxExpectedCalls,
@@ -501,11 +496,9 @@ describe('StorageService', () => {
           ...Mocks.presets.basic,
           pdpVerifier: {
             ...Mocks.presets.basic.pdpVerifier,
-            getActivePiecesByCursor: (args) => {
+            getDataSetLeafCount: (args) => {
               const [dataSetId] = args
-              return dataSetId === NON_EMPTY_ID
-                ? [[{ data: bytesToHex(activePieceCid.bytes) }], [1n], false]
-                : [[], [], false]
+              return [dataSetId === NON_EMPTY_ID ? 1n : 0n]
             },
           },
           warmStorageView: {
@@ -538,7 +531,7 @@ describe('StorageService', () => {
     it('should prefer the oldest of several non-empty matches and skip newer ones (#631)', async () => {
       // Two non-empty metadata matches: the oldest (id 1) and a newer one deep in
       // the list (id 25). The oldest must win, and because it is found before the
-      // newer one's window starts, the newer one's active-piece count is never
+      // newer one's window starts, the newer one's leaf count is never
       // read. This pins both the oldest-wins ordering and the early-exit guard,
       // which a "newest non-empty wins" or "no early-exit" regression would break.
       // The non-oldest resolve reads are delayed so the oldest match settles
@@ -573,12 +566,10 @@ describe('StorageService', () => {
             ...Mocks.presets.basic,
             pdpVerifier: {
               ...Mocks.presets.basic.pdpVerifier,
-              getActivePiecesByCursor: (args) => {
+              getDataSetLeafCount: (args) => {
                 const [dataSetId] = args
                 pieceCountQueriedIds.push(dataSetId)
-                return dataSetId === OLDEST_NON_EMPTY_ID || dataSetId === NEWER_NON_EMPTY_ID
-                  ? [[{ data: bytesToHex(activePieceCid.bytes) }], [1n], false]
-                  : [[], [], false]
+                return [dataSetId === OLDEST_NON_EMPTY_ID || dataSetId === NEWER_NON_EMPTY_ID ? 1n : 0n]
               },
             },
             warmStorageView: {
@@ -613,7 +604,7 @@ describe('StorageService', () => {
       // The newer non-empty match is never inspected once the oldest is known.
       assert.ok(
         !pieceCountQueriedIds.includes(NEWER_NON_EMPTY_ID),
-        `getActivePiecesByCursor should not be read for the newer match ${NEWER_NON_EMPTY_ID}, queried: ${pieceCountQueriedIds.join(', ')}`
+        `getDataSetLeafCount should not be read for the newer match ${NEWER_NON_EMPTY_ID}, queried: ${pieceCountQueriedIds.join(', ')}`
       )
     })
 

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -31,13 +31,14 @@ const server = setup()
 const pdpOptions = {
   baseUrl: 'https://pdp.example.com',
 }
+const activePieceCid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
 
 // The two per-data-set reads resolveByProviderId issues; both take the data set
 // id as their first uint256 argument, so the id is the first 32-byte word after
 // the 4-byte selector in the call data.
 const RESOLVE_READ_SELECTORS = [
   toFunctionSelector('getAllDataSetMetadata(uint256)'),
-  toFunctionSelector('getActivePieceCount(uint256)'),
+  toFunctionSelector('getActivePiecesByCursor(uint256,uint256,uint256)'),
 ]
 
 /**
@@ -346,9 +347,13 @@ describe('StorageService', () => {
           ...Mocks.presets.basic,
           pdpVerifier: {
             ...Mocks.presets.basic.pdpVerifier,
-            getActivePieceCount: (args) => {
+            getActivePiecesByCursor: (args) => {
               const [dataSetId] = args
-              return [dataSetId === 2n ? 1n : 0n]
+              if (dataSetId === 2n) {
+                const cid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+                return [[{ data: bytesToHex(cid.bytes) }], [1n], false]
+              }
+              return [[], [], false]
             },
           },
           warmStorageView: {
@@ -398,7 +403,7 @@ describe('StorageService', () => {
         pdpRailId: BigInt(i + 1),
       }))
 
-      let getActivePieceCountCalls = 0
+      let getActivePiecesByCursorCalls = 0
       let getAllDataSetMetadataCalls = 0
       server.use(
         Mocks.JSONRPC(
@@ -406,10 +411,10 @@ describe('StorageService', () => {
             ...Mocks.presets.basic,
             pdpVerifier: {
               ...Mocks.presets.basic.pdpVerifier,
-              getActivePieceCount: (args) => {
-                getActivePieceCountCalls++
+              getActivePiecesByCursor: (args) => {
+                getActivePiecesByCursorCalls++
                 const [dataSetId] = args
-                return [dataSetId === 1n ? 1n : 0n]
+                return dataSetId === 1n ? [[{ data: bytesToHex(activePieceCid.bytes) }], [1n], false] : [[], [], false]
               },
             },
             warmStorageView: {
@@ -456,8 +461,8 @@ describe('StorageService', () => {
       // tracks the concurrency rather than hard-coding the count.
       const maxExpectedCalls = RESOLVE_CONCURRENCY * 2
       assert.ok(
-        getActivePieceCountCalls <= maxExpectedCalls,
-        `expected <=${maxExpectedCalls} getActivePieceCount calls, got ${getActivePieceCountCalls} (unbounded fan-out regression)`
+        getActivePiecesByCursorCalls <= maxExpectedCalls,
+        `expected <=${maxExpectedCalls} getActivePiecesByCursor calls, got ${getActivePiecesByCursorCalls} (unbounded fan-out regression)`
       )
       assert.ok(
         getAllDataSetMetadataCalls <= maxExpectedCalls,
@@ -496,9 +501,11 @@ describe('StorageService', () => {
           ...Mocks.presets.basic,
           pdpVerifier: {
             ...Mocks.presets.basic.pdpVerifier,
-            getActivePieceCount: (args) => {
+            getActivePiecesByCursor: (args) => {
               const [dataSetId] = args
-              return [dataSetId === NON_EMPTY_ID ? 1n : 0n]
+              return dataSetId === NON_EMPTY_ID
+                ? [[{ data: bytesToHex(activePieceCid.bytes) }], [1n], false]
+                : [[], [], false]
             },
           },
           warmStorageView: {
@@ -566,10 +573,12 @@ describe('StorageService', () => {
             ...Mocks.presets.basic,
             pdpVerifier: {
               ...Mocks.presets.basic.pdpVerifier,
-              getActivePieceCount: (args) => {
+              getActivePiecesByCursor: (args) => {
                 const [dataSetId] = args
                 pieceCountQueriedIds.push(dataSetId)
-                return [dataSetId === OLDEST_NON_EMPTY_ID || dataSetId === NEWER_NON_EMPTY_ID ? 1n : 0n]
+                return dataSetId === OLDEST_NON_EMPTY_ID || dataSetId === NEWER_NON_EMPTY_ID
+                  ? [[{ data: bytesToHex(activePieceCid.bytes) }], [1n], false]
+                  : [[], [], false]
               },
             },
             warmStorageView: {
@@ -604,7 +613,7 @@ describe('StorageService', () => {
       // The newer non-empty match is never inspected once the oldest is known.
       assert.ok(
         !pieceCountQueriedIds.includes(NEWER_NON_EMPTY_ID),
-        `getActivePieceCount should not be read for the newer match ${NEWER_NON_EMPTY_ID}, queried: ${pieceCountQueriedIds.join(', ')}`
+        `getActivePiecesByCursor should not be read for the newer match ${NEWER_NON_EMPTY_ID}, queried: ${pieceCountQueriedIds.join(', ')}`
       )
     })
 

--- a/packages/synapse-sdk/src/test/warm-storage-service.test.ts
+++ b/packages/synapse-sdk/src/test/warm-storage-service.test.ts
@@ -8,8 +8,7 @@ import { calibration } from '@filoz/synapse-core/chains'
 import * as Mocks from '@filoz/synapse-core/mocks'
 import { assert } from 'chai'
 import { setup } from 'iso-web/msw'
-import { CID } from 'multiformats/cid'
-import { type Address, bytesToHex, createWalletClient, http as viemHttp } from 'viem'
+import { type Address, createWalletClient, http as viemHttp } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { WarmStorageService } from '../warm-storage/index.ts'
 
@@ -22,7 +21,6 @@ const client = createWalletClient({
 })
 
 describe('WarmStorageService', () => {
-  const activePieceCid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
   // Helper to create WarmStorageService with factory pattern
   const createWarmStorageService = async () => {
     return new WarmStorageService({ client })
@@ -50,15 +48,15 @@ describe('WarmStorageService', () => {
   })
 
   describe('hasActivePieces', () => {
-    it('should return true when the data set has at least one active piece', async () => {
+    it('should return true when the data set has a non-zero leaf count', async () => {
       server.use(
         Mocks.JSONRPC({
           ...Mocks.presets.basic,
           pdpVerifier: {
             ...Mocks.presets.basic.pdpVerifier,
-            getActivePiecesByCursor: (args) => {
-              assert.deepEqual(args, [1n, 0n, 1n])
-              return [[{ data: bytesToHex(activePieceCid.bytes) }], [1n], false]
+            getDataSetLeafCount: (args) => {
+              assert.deepEqual(args, [1n])
+              return [2n]
             },
           },
         })
@@ -67,15 +65,15 @@ describe('WarmStorageService', () => {
       assert.isTrue(await warmStorageService.hasActivePieces({ dataSetId: 1n }))
     })
 
-    it('should return false when the data set has no active pieces', async () => {
+    it('should return false when the data set has no leaves', async () => {
       server.use(
         Mocks.JSONRPC({
           ...Mocks.presets.basic,
           pdpVerifier: {
             ...Mocks.presets.basic.pdpVerifier,
-            getActivePiecesByCursor: (args) => {
-              assert.deepEqual(args, [1n, 0n, 1n])
-              return [[], [], false]
+            getDataSetLeafCount: (args) => {
+              assert.deepEqual(args, [1n])
+              return [0n]
             },
           },
         })

--- a/packages/synapse-sdk/src/test/warm-storage-service.test.ts
+++ b/packages/synapse-sdk/src/test/warm-storage-service.test.ts
@@ -8,7 +8,8 @@ import { calibration } from '@filoz/synapse-core/chains'
 import * as Mocks from '@filoz/synapse-core/mocks'
 import { assert } from 'chai'
 import { setup } from 'iso-web/msw'
-import { type Address, createWalletClient, http as viemHttp } from 'viem'
+import { CID } from 'multiformats/cid'
+import { type Address, bytesToHex, createWalletClient, http as viemHttp } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { WarmStorageService } from '../warm-storage/index.ts'
 
@@ -80,6 +81,51 @@ describe('WarmStorageService', () => {
       )
       const warmStorageService = await createWarmStorageService()
       assert.isFalse(await warmStorageService.hasActivePieces({ dataSetId: 1n }))
+    })
+  })
+
+  describe('getActivePieceCount', () => {
+    it('should count active pieces by paginating the cursor', async () => {
+      server.use(Mocks.JSONRPC(Mocks.presets.basic))
+      const warmStorageService = await createWarmStorageService()
+      assert.equal(await warmStorageService.getActivePieceCount({ dataSetId: 1n }), 2n)
+    })
+
+    it('should return zero when the data set has no active pieces', async () => {
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          pdpVerifier: {
+            ...Mocks.presets.basic.pdpVerifier,
+            getActivePiecesByCursor: () => [[], [], false],
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+      assert.equal(await warmStorageService.getActivePieceCount({ dataSetId: 1n }), 0n)
+    })
+
+    it('should sum pieces across cursor pages', async () => {
+      const first = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+      const second = CID.parse('bafkzcibeqcad6efnpwn62p5vvs5x3nh3j7xkzfgb3xtitcdm2hulmty3xx4tl3wace')
+      server.use(
+        Mocks.JSONRPC({
+          ...Mocks.presets.basic,
+          pdpVerifier: {
+            ...Mocks.presets.basic.pdpVerifier,
+            getActivePiecesByCursor: (args) => {
+              const startPieceId = args[1]
+              if (startPieceId === 0n) {
+                return [[{ data: bytesToHex(first.bytes) }], [1n], true]
+              }
+              assert.equal(startPieceId, 2n)
+              return [[{ data: bytesToHex(second.bytes) }], [2n], false]
+            },
+          },
+        })
+      )
+      const warmStorageService = await createWarmStorageService()
+      assert.equal(await warmStorageService.getActivePieceCount({ dataSetId: 1n }), 2n)
     })
   })
 
@@ -485,7 +531,7 @@ describe('WarmStorageService', () => {
       assert.lengthOf(detailedDataSets, 1)
       assert.equal(detailedDataSets[0].pdpRailId, 48n)
       assert.equal(detailedDataSets[0].pdpVerifierDataSetId, 242n)
-      assert.equal(detailedDataSets[0].activePieceCount, 2n)
+      assert.isTrue(detailedDataSets[0].hasActivePieces)
       assert.isTrue(detailedDataSets[0].isLive)
       assert.isTrue(detailedDataSets[0].isManaged)
     })

--- a/packages/synapse-sdk/src/test/warm-storage-service.test.ts
+++ b/packages/synapse-sdk/src/test/warm-storage-service.test.ts
@@ -8,7 +8,8 @@ import { calibration } from '@filoz/synapse-core/chains'
 import * as Mocks from '@filoz/synapse-core/mocks'
 import { assert } from 'chai'
 import { setup } from 'iso-web/msw'
-import { type Address, createWalletClient, http as viemHttp } from 'viem'
+import { CID } from 'multiformats/cid'
+import { type Address, bytesToHex, createWalletClient, http as viemHttp } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { WarmStorageService } from '../warm-storage/index.ts'
 
@@ -21,6 +22,7 @@ const client = createWalletClient({
 })
 
 describe('WarmStorageService', () => {
+  const activePieceCid = CID.parse('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
   // Helper to create WarmStorageService with factory pattern
   const createWarmStorageService = async () => {
     return new WarmStorageService({ client })
@@ -54,7 +56,10 @@ describe('WarmStorageService', () => {
           ...Mocks.presets.basic,
           pdpVerifier: {
             ...Mocks.presets.basic.pdpVerifier,
-            getActivePieceCount: () => [1n],
+            getActivePiecesByCursor: (args) => {
+              assert.deepEqual(args, [1n, 0n, 1n])
+              return [[{ data: bytesToHex(activePieceCid.bytes) }], [1n], false]
+            },
           },
         })
       )
@@ -68,7 +73,10 @@ describe('WarmStorageService', () => {
           ...Mocks.presets.basic,
           pdpVerifier: {
             ...Mocks.presets.basic.pdpVerifier,
-            getActivePieceCount: () => [0n],
+            getActivePiecesByCursor: (args) => {
+              assert.deepEqual(args, [1n, 0n, 1n])
+              return [[], [], false]
+            },
           },
         })
       )

--- a/packages/synapse-sdk/src/types.ts
+++ b/packages/synapse-sdk/src/types.ts
@@ -256,8 +256,8 @@ export interface DataSetInfo {
 export interface EnhancedDataSetInfo extends DataSetInfo {
   /** PDPVerifier global data set ID */
   pdpVerifierDataSetId: bigint
-  /** Number of active pieces in the data set (excludes removed pieces) */
-  activePieceCount: bigint
+  /** Whether the data set contains at least one active piece (non-zero leaf count). */
+  hasActivePieces: boolean
   /** Whether the data set is live on-chain */
   isLive: boolean
   /** Whether this data set is managed by the current Warm Storage contract */

--- a/packages/synapse-sdk/src/warm-storage/service.ts
+++ b/packages/synapse-sdk/src/warm-storage/service.ts
@@ -146,7 +146,11 @@ export class WarmStorageService {
 
   /**
    * Get all data sets for a client with enhanced details
-   * This includes live status and management information
+   * This includes live status and management information.
+   *
+   * `activePieceCount` still uses the contract's linear-scan getter and can run
+   * out of gas for large data sets. Prefer {@link hasActivePieces} when only
+   * presence is needed.
    * @param options - Options for the client data sets
    * @param options.address - The client address. Defaults to the client account address.
    * @param options.onlyManaged - If true, only return data sets managed by this Warm Storage contract. Defaults to false.
@@ -279,6 +283,10 @@ export class WarmStorageService {
 
   /**
    * Get the count of active pieces in a dataset (excludes removed pieces)
+   *
+   * The contract getter scans the data set's piece-ID range and can run out of
+   * gas for large data sets. Prefer {@link hasActivePieces} when only presence
+   * is needed, or paginate `getActivePiecesByCursor` to derive an exact count.
    * @param options - Options for the data set
    * @param options.dataSetId - The PDPVerifier data set ID
    * @returns The number of active pieces
@@ -290,18 +298,15 @@ export class WarmStorageService {
   /**
    * Report whether a data set has at least one active piece.
    *
-   * Reads one cursor-paginated piece rather than calculating the exact active
-   * piece count, which can run out of gas for large data sets.
+   * Uses a non-zero PDP leaf count as a proxy rather than scanning piece IDs or
+   * calculating the exact active piece count, both of which can run out of gas
+   * for large data sets.
    * @param options - Options for the data set
    * @param options.dataSetId - The PDPVerifier data set ID
    * @returns True when the data set has at least one active piece
    */
   async hasActivePieces(options: { dataSetId: bigint }): Promise<boolean> {
-    const page = await PDPVerifier.getActivePiecesByCursor(this._client, {
-      ...options,
-      limit: 1n,
-    })
-    return page.items.length > 0
+    return (await PDPVerifier.getDataSetLeafCount(this._client, options)) > 0n
   }
 
   // ========== Metadata Operations ==========

--- a/packages/synapse-sdk/src/warm-storage/service.ts
+++ b/packages/synapse-sdk/src/warm-storage/service.ts
@@ -148,9 +148,8 @@ export class WarmStorageService {
    * Get all data sets for a client with enhanced details
    * This includes live status and management information.
    *
-   * `activePieceCount` still uses the contract's linear-scan getter and can run
-   * out of gas for large data sets. Prefer {@link hasActivePieces} when only
-   * presence is needed.
+   * Piece presence uses a non-zero PDP leaf count rather than an exact active
+   * piece count. Prefer {@link getActivePieceCount} when an exact count is needed.
    * @param options - Options for the client data sets
    * @param options.address - The client address. Defaults to the client account address.
    * @param options.onlyManaged - If true, only return data sets managed by this Warm Storage contract. Defaults to false.
@@ -195,15 +194,13 @@ export class WarmStorageService {
           return null // Will be filtered out
         }
 
-        // Get active piece count only if the data set is live
-        const activePieceCount = isLive
-          ? await PDPVerifier.getActivePieceCount(this._client, { dataSetId: dataSet.dataSetId })
-          : 0n
+        // Get piece presence only if the data set is live
+        const hasActivePieces = isLive ? await this.hasActivePieces({ dataSetId: dataSet.dataSetId }) : false
 
         return {
           ...dataSet,
           pdpVerifierDataSetId: dataSet.dataSetId,
-          activePieceCount,
+          hasActivePieces,
           isLive,
           isManaged,
           withCDN: dataSet.cdnRailId > 0 && metadata[0].includes(METADATA_KEYS.WITH_CDN),
@@ -284,15 +281,18 @@ export class WarmStorageService {
   /**
    * Get the count of active pieces in a dataset (excludes removed pieces)
    *
-   * The contract getter scans the data set's piece-ID range and can run out of
-   * gas for large data sets. Prefer {@link hasActivePieces} when only presence
-   * is needed, or paginate `getActivePiecesByCursor` to derive an exact count.
+   * Paginates `getActivePiecesByCursor` rather than calling the contract's
+   * linear-scan getter, which can run out of gas for large data sets.
+   * Prefer {@link hasActivePieces} when only presence is needed.
    * @param options - Options for the data set
    * @param options.dataSetId - The PDPVerifier data set ID
    * @returns The number of active pieces
    */
   async getActivePieceCount(options: { dataSetId: bigint }): Promise<bigint> {
-    return PDPVerifier.getActivePieceCount(this._client, { dataSetId: options.dataSetId })
+    const pieces = await Array.fromAsync(
+      paginate(({ cursor }) => PDPVerifier.getActivePiecesByCursor(this._client, { ...options, cursor }))
+    )
+    return BigInt(pieces.length)
   }
 
   /**

--- a/packages/synapse-sdk/src/warm-storage/service.ts
+++ b/packages/synapse-sdk/src/warm-storage/service.ts
@@ -290,13 +290,18 @@ export class WarmStorageService {
   /**
    * Report whether a data set has at least one active piece.
    *
-   * Uses the contract's dedicated active-piece count rather than paginating pieces.
+   * Reads one cursor-paginated piece rather than calculating the exact active
+   * piece count, which can run out of gas for large data sets.
    * @param options - Options for the data set
    * @param options.dataSetId - The PDPVerifier data set ID
    * @returns True when the data set has at least one active piece
    */
   async hasActivePieces(options: { dataSetId: bigint }): Promise<boolean> {
-    return (await PDPVerifier.getActivePieceCount(this._client, options)) > 0n
+    const page = await PDPVerifier.getActivePiecesByCursor(this._client, {
+      ...options,
+      limit: 1n,
+    })
+    return page.items.length > 0
   }
 
   // ========== Metadata Operations ==========


### PR DESCRIPTION
## Summary

- Replace exact active-piece counts in core data set enrichment with a bounded one-item `getActivePiecesByCursor` check
- Expose `hasActivePieces` on enriched core data sets and use it for provider selection
- Update SDK `hasActivePieces()` to use the same bounded cursor read
- Document the large-data-set risk of `getActivePieceCount` and update affected mocks and tests

## Testing

- Core and SDK type checks
- Core and SDK Node and browser test suites
- Workspace build, including `synapse-react`