### PR TITLE
chore(synapse-core): publish v1.3.1 Mainnet addresses

### DIFF
--- a/packages/synapse-core/src/abis/generated.ts
+++ b/packages/synapse-core/src/abis/generated.ts
@@ -3152,7 +3152,7 @@ export const filecoinWarmStorageServiceConfig = {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xAD28BBF18A72f728Ed816D07F5a1d7Ec40D68b5e)
+ * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab)
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x9BF9e67e83EC8613883FDdDec4D3b38AEE937177)
  */
 export const filecoinWarmStorageServiceStateViewAbi = [
@@ -3642,16 +3642,16 @@ export const filecoinWarmStorageServiceStateViewAbi = [
 ] as const
 
 /**
- * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xAD28BBF18A72f728Ed816D07F5a1d7Ec40D68b5e)
+ * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab)
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x9BF9e67e83EC8613883FDdDec4D3b38AEE937177)
  */
 export const filecoinWarmStorageServiceStateViewAddress = {
-  314: '0xAD28BBF18A72f728Ed816D07F5a1d7Ec40D68b5e',
+  314: '0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab',
   314159: '0x9BF9e67e83EC8613883FDdDec4D3b38AEE937177',
 } as const
 
 /**
- * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xAD28BBF18A72f728Ed816D07F5a1d7Ec40D68b5e)
+ * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab)
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x9BF9e67e83EC8613883FDdDec4D3b38AEE937177)
  */
 export const filecoinWarmStorageServiceStateViewConfig = {

--- a/packages/synapse-core/wagmi.config.ts
+++ b/packages/synapse-core/wagmi.config.ts
@@ -7,7 +7,7 @@ import { ZodValidationError } from './src/errors/base.ts'
 import { zAddress } from './src/utils/schemas.ts'
 
 // GIT_REF can be one of: '<branch name>', '<commit>' or 'tags/<tag>'
-const FILECOIN_SERVICES_GIT_REF = '69b8ef77b792c70582008c4c262de5a13403f224' // v1.3.1
+const FILECOIN_SERVICES_GIT_REF = '022171c0c38813e6f53a1b1ca3cf97ad1ed7414f' // v1.3.1
 const FILECOIN_SERVICES_REF = FILECOIN_SERVICES_GIT_REF.replace(/^(?![a-f0-9]{40}$)/, 'refs/')
 const BASE_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/abi`
 const DEPLOYMENTS_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/deployments.json`


### PR DESCRIPTION
## What changed

- advance `FILECOIN_SERVICES_GIT_REF` from the Calibnet deployment snapshot to the merged Mainnet deployment snapshot in FilOzone/filecoin-services#576
- regenerate the synapse-core contract output
- publish the live Mainnet FWSS StateView address `0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab`

## Why

FilOzone/synapse-sdk#911 was merged after the contract upgrade but before the final Phase 5 address-state workflow run. It therefore contains the Calibnet-era filecoin-services ref and the previous Mainnet StateView address.

This is the manual equivalent of that final workflow run, using filecoin-services commit [`022171c`](https://github.com/FilOzone/filecoin-services/commit/022171c0c38813e6f53a1b1ca3cf97ad1ed7414f), which merged the verified Mainnet deployment snapshot.

The FWSS proxy address remains unchanged. The generated ABI is unchanged; only the generated Mainnet StateView address and source links move to the live v1.3.1 View.

## Validation

- `pnpm install`
- `pnpm -r --filter @filoz/synapse-core run generate-abi`
- `pnpm run lint` (passes with one pre-existing unused-member warning)
- `pnpm run build`
- `git diff --check`

Tracked by FilOzone/filecoin-services#561.
