### PR TITLE
chore: update deps and fix commit message

### DIFF
--- a/apps/synapse-playground/package.json
+++ b/apps/synapse-playground/package.json
@@ -30,14 +30,14 @@
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "iso-ledger": "0.1.7",
-    "lucide-react": "1.28.0",
+    "lucide-react": "1.31.0",
     "nanostores": "1.4.2",
     "next-themes": "0.4.6",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-dropzone": "15.0.0",
-    "react-hook-form": "7.83.0",
-    "sonner": "2.0.7",
+    "react-hook-form": "7.85.0",
+    "sonner": "2.0.8",
     "tailwind-merge": "3.6.0",
     "tailwindcss": "4.3.3",
     "viem": "catalog:",
@@ -51,8 +51,8 @@
     "@vitejs/plugin-react": "6.0.5",
     "tw-animate-css": "1.4.0",
     "typescript": "catalog:",
-    "vite": "8.2.0",
+    "vite": "8.2.1",
     "vite-plugin-node-polyfills-vite8": "0.25.4",
-    "wrangler": "4.118.0"
+    "wrangler": "4.122.0"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,25 +16,25 @@
     "@tanstack/react-query": "5.101.4",
     "starlight-auto-sidebar": "0.4.0",
     "starlight-changelogs": "0.5.1",
-    "starlight-links-validator": "0.25.2",
+    "starlight-links-validator": "0.25.3",
     "viem": "catalog:",
     "wagmi": "catalog:"
   },
   "devDependencies": {
     "@astrojs/markdown-remark": "7.2.2",
-    "@astrojs/starlight": "0.41.5",
+    "@astrojs/starlight": "0.41.7",
     "@hugomrdias/docs": "0.2.0",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "astro": "7.1.6",
+    "astro": "7.2.1",
     "astro-mermaid": "2.1.0",
     "expressive-code-twoslash": "0.6.1",
-    "mermaid": "11.16.0",
+    "mermaid": "11.16.1",
     "rehype-external-links": "3.0.0",
     "sharp": "0.35.3",
     "typedoc": "0.28.20",
     "typedoc-plugin-mdn-links": "5.1.1",
     "typedoc-plugin-missing-exports": "4.1.4",
-    "wrangler": "4.118.0"
+    "wrangler": "4.122.0"
   }
 }

--- a/docs/src/content/docs/developer-guides/migration-guide.md
+++ b/docs/src/content/docs/developer-guides/migration-guide.md
@@ -9,7 +9,7 @@ If you are coming from an earlier version of any of the Synapse packages, you wi
 
 ---
 
-## Unreleased
+## synapse-core 0.8.0
 
 ### Action: Migrate paginated reads to cursors and pages
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "catalog:",
-    "knip": "6.31.0",
+    "knip": "6.32.2",
     "markdownlint-cli2": "0.23.2",
     "typescript": "catalog:",
     "wireit": "0.14.13"

--- a/packages/synapse-core/README.md
+++ b/packages/synapse-core/README.md
@@ -26,7 +26,7 @@ Check the documentation [website](https://synapse.filecoin.services/)
 
 ## Contributing
 
-Read contributing  [guidelines](../../.github/CONTRIBUTING.md).
+Read contributing [guidelines](../../.github/CONTRIBUTING.md).
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/FilOzone/synapse-sdk)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
-  '@biomejs/biome': 2.5.6
+  '@biomejs/biome': 2.5.8
   '@types/mocha': ^10.0.10
   '@types/node': ^26.0.1
   '@types/react': ^19.2.16
@@ -53,3 +53,4 @@ trustPolicyExclude:
   # 3.3.1 (Jan 2025) predates langium adopting trusted publishing at 4.x.
   # Exact-pinned by @mermaid-js/parser; permanent while mermaid pins langium@3.
   - langium@3.3.1
+  - cytoscape@3.34.1


### PR DESCRIPTION
Merging stacked PRs didn't do the proper conventional commit for changelogs so this PR touches synapse-core to fix that.

This also updates dependencies and add the next synapse-core version to the migration guide instructions.