### PR TITLE
feat(synapse-core): add piece batcher with message-size addPieces limiter

### DIFF
--- a/docs/src/content/docs/developer-guides/storage/upload-pipeline.mdx
+++ b/docs/src/content/docs/developer-guides/storage/upload-pipeline.mdx
@@ -55,6 +55,43 @@ The result contains:
 - **`copies`** - array of successful copies, each with `providerId`, `dataSetId`, `pieceId`, `role` (`'primary'` or `'secondary'`), `retrievalUrl`, and `isNewDataSet`
 - **`failedAttempts`** - providers that were tried but did not produce a copy. The SDK retries failed secondaries with alternate providers, so a non-empty array often just means a provider was swapped out. These are diagnostic, check `complete` for the actual outcome.
 
+### Uploading Multiple Files
+
+Piece batching is enabled by default. Compatible uploads that run concurrently can share an on-chain transaction when they use the same provider and data set. Each provider maintains its own batch.
+
+Start the uploads together to give them an opportunity to join the same batch:
+
+```ts
+const results = await Promise.all(
+  files.map((file) => synapse.storage.upload(file))
+)
+```
+
+Sequential uploads cannot share a batch because each call waits for its own on-chain confirmation before the next call starts:
+
+```ts
+for (const file of files) {
+  await synapse.storage.upload(file)
+}
+```
+
+By default, the SDK submits a batch after a zero-delay window. You can instead hold compatible pieces until the transaction size limit is reached or you explicitly flush them:
+
+```ts
+const synapse = Synapse.create({
+  account: privateKeyToAccount("0x..."),
+  pieceBatching: { wait: { kind: "limiter" } },
+})
+
+const uploads = files.map((file) => synapse.storage.upload(file))
+await synapse.storage.flush()
+const results = await Promise.all(uploads)
+```
+
+`flush()` waits for accepted uploads and pulls to finish parking, then submits their pending batch windows. It does not report whether every upload was submitted or confirmed successfully; always await the individual upload promises for results and errors.
+
+Set `pieceBatching: false` when creating `Synapse` to disable batching. Use the [split operations](#split-operations) when you need manual control over provider selection, signing, or each store, pull, and commit phase.
+
 ### Upload with Metadata
 
 Attach metadata to organize uploads. The SDK reuses existing data sets when metadata matches, avoiding duplicate payment rails:

--- a/packages/synapse-core/src/errors/pdp.ts
+++ b/packages/synapse-core/src/errors/pdp.ts
@@ -1,8 +1,10 @@
 import type { Hash } from 'viem'
+import type { PieceCID } from '../piece/piece-cid.ts'
 import type { AddPiecesRejected } from '../sp/add-pieces.ts'
 import type { CreateDataSetRejected } from '../sp/create-dataset.ts'
 import { SIZE_CONSTANTS } from '../utils/constants.ts'
 import { decodePDPError } from '../utils/decode-pdp-errors.ts'
+import type { MetadataObject } from '../utils/metadata.ts'
 import { isSynapseError, SynapseError } from './base.ts'
 
 export class LocationHeaderError extends SynapseError {
@@ -130,6 +132,44 @@ export class AddPiecesError extends SynapseError {
 
   static override is(value: unknown): value is AddPiecesError {
     return isSynapseError(value) && value.name === 'AddPiecesError'
+  }
+}
+
+export class AddPiecesBatchTooLargeError extends SynapseError {
+  override name: 'AddPiecesBatchTooLargeError' = 'AddPiecesBatchTooLargeError'
+  readonly pieceCount: number
+
+  constructor(pieceCount: number) {
+    super(`Piece batch of ${pieceCount} does not fit in a single Filecoin message. Split into smaller batches.`)
+    this.pieceCount = pieceCount
+  }
+
+  static override is(value: unknown): value is AddPiecesBatchTooLargeError {
+    return isSynapseError(value) && value.name === 'AddPiecesBatchTooLargeError'
+  }
+}
+
+export class AddPiecesFlushError extends SynapseError {
+  override name: 'AddPiecesFlushError' = 'AddPiecesFlushError'
+  readonly pieceCid: PieceCID
+  readonly metadata?: MetadataObject
+  /** The window that failed. Same extraData / same tx attempt. */
+  readonly pieces: Array<{ pieceCid: PieceCID; metadata?: MetadataObject }>
+
+  constructor(options: {
+    pieceCid: PieceCID
+    metadata?: MetadataObject
+    pieces: Array<{ pieceCid: PieceCID; metadata?: MetadataObject }>
+    cause: Error
+  }) {
+    super('Failed to add pieces.', { cause: options.cause })
+    this.pieceCid = options.pieceCid
+    this.metadata = options.metadata
+    this.pieces = options.pieces
+  }
+
+  static override is(value: unknown): value is AddPiecesFlushError {
+    return isSynapseError(value) && value.name === 'AddPiecesFlushError'
   }
 }
 

--- a/packages/synapse-core/src/sp/add-pieces-fits.ts
+++ b/packages/synapse-core/src/sp/add-pieces-fits.ts
@@ -1,0 +1,139 @@
+import { encodeAbiParameters, encodeFunctionData, type Hex, size, toHex, zeroAddress } from 'viem'
+import { pdpVerifierAbi } from '../abis/generated.ts'
+import { AddPiecesBatchTooLargeError, InvalidUploadSizeError } from '../errors/pdp.ts'
+import { AtLeastOnePieceRequiredError } from '../errors/warm-storage.ts'
+import type { PieceCID } from '../piece/piece-cid.ts'
+import { signAddPiecesAbiParameters } from '../typed-data/sign-add-pieces.ts'
+import { signCreateDataSetAbiParameters } from '../typed-data/sign-create-dataset.ts'
+import { signcreateDataSetAndAddPiecesAbiParameters } from '../typed-data/sign-create-dataset-add-pieces.ts'
+import { SIZE_CONSTANTS } from '../utils/constants.ts'
+import { datasetMetadataObjectToEntry, type MetadataObject, pieceMetadataObjectToEntry } from '../utils/metadata.ts'
+import type { PdpDataSet } from '../warm-storage/types.ts'
+
+/** Dummy secp256k1 signature used only to size extraData. */
+const DUMMY_SIGNATURE = `0x${'00'.repeat(65)}` as Hex
+
+export type LimiterPiece = {
+  pieceCid: PieceCID
+  metadata?: MetadataObject
+}
+
+export type LimiterOptions =
+  | {
+      kind: 'addPieces'
+      dataSet?: PdpDataSet
+      pieces: LimiterPiece[]
+    }
+  | {
+      kind: 'createDataSetAndAddPieces'
+      metadata?: MetadataObject
+      cdn?: boolean
+      pieces: LimiterPiece[]
+    }
+
+/** `true` if `pieces` still fit in one addPieces / createAndAdd operation. */
+export type Limiter = (options: LimiterOptions) => boolean
+
+export namespace addPiecesFits {
+  export type OptionsType = LimiterOptions
+  export type OutputType = boolean
+}
+
+/**
+ * Whether a candidate piece list fits in one addPieces / createAndAdd message.
+ *
+ * Uses estimated encoded-params size (PieceCID bytes + dummy extraData) against
+ * {@link SIZE_CONSTANTS.MAX_ADD_PIECES_MESSAGE_SIZE} (64 KiB message cap minus
+ * overhead). Empty `pieces` does not fit.
+ *
+ * @param options - {@link addPiecesFits.OptionsType}
+ * @returns Whether the pieces fit {@link addPiecesFits.OutputType}
+ *
+ * @example
+ * ```ts
+ * import { addPiecesFits } from '@filoz/synapse-core/sp'
+ *
+ * const fits = addPiecesFits({
+ *   kind: 'addPieces',
+ *   dataSet,
+ *   pieces: [{ pieceCid }],
+ * })
+ * ```
+ */
+export function addPiecesFits(options: addPiecesFits.OptionsType): addPiecesFits.OutputType {
+  if (options.pieces.length < 1) {
+    return false
+  }
+  return estimateAddPiecesCalldataSize(options) <= SIZE_CONSTANTS.MAX_ADD_PIECES_MESSAGE_SIZE
+}
+
+/**
+ * Throw if a PieceCID's encoded raw size is outside Curio's upload bounds
+ * ({@link SIZE_CONSTANTS.MIN_UPLOAD_SIZE}–{@link SIZE_CONSTANTS.MAX_UPLOAD_SIZE}).
+ *
+ * @throws {@link InvalidUploadSizeError}
+ */
+export function assertPieceCidSize(pieceCid: PieceCID): void {
+  const pieceSize = pieceCid.size
+  if (pieceSize < SIZE_CONSTANTS.MIN_UPLOAD_SIZE || pieceSize > SIZE_CONSTANTS.MAX_UPLOAD_SIZE) {
+    throw new InvalidUploadSizeError(pieceSize)
+  }
+}
+
+/**
+ * Throw if `pieces` is empty, a PieceCID is outside Curio's size bounds, or the
+ * list does not fit in one addPieces / createAndAdd message.
+ *
+ * @param options - {@link LimiterOptions}
+ * @throws {@link AtLeastOnePieceRequiredError} when `pieces` is empty
+ * @throws {@link InvalidUploadSizeError} when a PieceCID size is below {@link SIZE_CONSTANTS.MIN_UPLOAD_SIZE} or above {@link SIZE_CONSTANTS.MAX_UPLOAD_SIZE}
+ * @throws {@link AddPiecesBatchTooLargeError} when the estimated message exceeds {@link SIZE_CONSTANTS.MAX_ADD_PIECES_MESSAGE_SIZE}
+ */
+export function assertAddPiecesFit(options: LimiterOptions): void {
+  if (options.pieces.length < 1) {
+    throw new AtLeastOnePieceRequiredError()
+  }
+  for (const piece of options.pieces) {
+    assertPieceCidSize(piece.pieceCid)
+  }
+  if (!addPiecesFits(options)) {
+    throw new AddPiecesBatchTooLargeError(options.pieces.length)
+  }
+}
+
+/**
+ * Estimated on-chain calldata size in bytes for the given piece list.
+ */
+export function estimateAddPiecesCalldataSize(options: LimiterOptions): number {
+  const extraData = dummyExtraData(options)
+  const pieceData = options.pieces.map((piece) => ({ data: toHex(piece.pieceCid.bytes) }))
+  const calldata = encodeFunctionData({
+    abi: pdpVerifierAbi,
+    functionName: 'addPieces',
+    args: [0n, zeroAddress, pieceData, extraData],
+  })
+  return size(calldata)
+}
+
+function dummyExtraData(options: LimiterOptions): Hex {
+  const addPiecesExtraData = dummyAddPiecesExtraData(options.pieces)
+  if (options.kind === 'addPieces') {
+    return addPiecesExtraData
+  }
+  const createEntries = datasetMetadataObjectToEntry(options.metadata, { cdn: options.cdn ?? false })
+  const createExtraData = encodeAbiParameters(signCreateDataSetAbiParameters, [
+    zeroAddress,
+    0n,
+    createEntries.map((entry) => entry.key),
+    createEntries.map((entry) => entry.value),
+    DUMMY_SIGNATURE,
+  ])
+  return encodeAbiParameters(signcreateDataSetAndAddPiecesAbiParameters, [createExtraData, addPiecesExtraData])
+}
+
+function dummyAddPiecesExtraData(pieces: LimiterPiece[]): Hex {
+  const metadataKV = pieces.map((piece) => pieceMetadataObjectToEntry(piece.metadata))
+  const keys = metadataKV.map((entries) => entries.map((entry) => entry.key))
+  const values = metadataKV.map((entries) => entries.map((entry) => entry.value))
+  return encodeAbiParameters(signAddPiecesAbiParameters, [0n, keys, values, DUMMY_SIGNATURE])
+}

--- a/packages/synapse-core/src/sp/add-pieces.ts
+++ b/packages/synapse-core/src/sp/add-pieces.ts
@@ -3,13 +3,15 @@ import type { ToString } from 'multiformats'
 import { type Account, type Chain, type Client, type Hex, isHex, type Transport } from 'viem'
 import * as z from 'zod'
 import { AddPiecesError, LocationHeaderError } from '../errors/index.ts'
+import type { AddPiecesBatchTooLargeError, InvalidUploadSizeError } from '../errors/pdp.ts'
 import { WaitForAddPiecesError, WaitForAddPiecesRejectedError } from '../errors/pdp.ts'
-import { AtLeastOnePieceRequiredError, TooManyPiecesError } from '../errors/warm-storage.ts'
+import type { AtLeastOnePieceRequiredError } from '../errors/warm-storage.ts'
 import type { PieceCID } from '../piece/piece-cid.ts'
 import { signAddPieces } from '../typed-data/sign-add-pieces.ts'
-import { RETRY_CONSTANTS, SIZE_CONSTANTS } from '../utils/constants.ts'
+import { RETRY_CONSTANTS } from '../utils/constants.ts'
 import { type MetadataObject, pieceMetadataObjectToEntry } from '../utils/metadata.ts'
 import { zHex, zNumberToBigInt } from '../utils/schemas.ts'
+import { assertAddPiecesFit } from './add-pieces-fits.ts'
 
 export namespace addPiecesApiRequest {
   export type OptionsType = {
@@ -114,24 +116,12 @@ export namespace addPieces {
   }
 
   export type OutputType = addPiecesApiRequest.OutputType
-  export type ErrorType = addPiecesApiRequest.ErrorType | signAddPieces.ErrorType
-}
-
-/**
- * Validate the piece count for an addPieces (or createDataSetAndAddPieces) batch,
- * failing early instead of reverting on-chain.
- *
- * @param pieceCount - Number of pieces in the batch
- * @throws AtLeastOnePieceRequiredError when not a positive integer
- * @throws TooManyPiecesError when above {@link SIZE_CONSTANTS.MAX_ADD_PIECES_BATCH_SIZE}
- */
-export function validateAddPiecesBatch(pieceCount: number): void {
-  if (!Number.isInteger(pieceCount) || pieceCount < 1) {
-    throw new AtLeastOnePieceRequiredError()
-  }
-  if (pieceCount > SIZE_CONSTANTS.MAX_ADD_PIECES_BATCH_SIZE) {
-    throw new TooManyPiecesError(pieceCount, SIZE_CONSTANTS.MAX_ADD_PIECES_BATCH_SIZE)
-  }
+  export type ErrorType =
+    | addPiecesApiRequest.ErrorType
+    | signAddPieces.ErrorType
+    | AtLeastOnePieceRequiredError
+    | AddPiecesBatchTooLargeError
+    | InvalidUploadSizeError
 }
 
 /**
@@ -148,7 +138,7 @@ export async function addPieces(
   client: Client<Transport, Chain, Account>,
   options: addPieces.OptionsType
 ): Promise<addPieces.OutputType> {
-  validateAddPiecesBatch(options.pieces.length)
+  assertAddPiecesFit({ kind: 'addPieces', pieces: options.pieces })
   const extraData =
     options.extraData ??
     (await signAddPieces(client, {

--- a/packages/synapse-core/src/sp/create-dataset-add-pieces.ts
+++ b/packages/synapse-core/src/sp/create-dataset-add-pieces.ts
@@ -4,16 +4,20 @@ import { type Account, type Address, type Chain, type Client, type Hex, isHex, t
 import { asChain } from '../chains.ts'
 import { CreateDataSetError, LocationHeaderError } from '../errors/index.ts'
 import type {
+  AddPiecesBatchTooLargeError,
+  InvalidUploadSizeError,
   WaitForAddPiecesError,
   WaitForAddPiecesRejectedError,
   WaitForCreateDataSetError,
   WaitForCreateDataSetRejectedError,
 } from '../errors/pdp.ts'
+import type { AtLeastOnePieceRequiredError } from '../errors/warm-storage.ts'
 import type { PieceCID } from '../piece/piece-cid.ts'
 import { signCreateDataSetAndAddPieces } from '../typed-data/sign-create-dataset-add-pieces.ts'
 import { RETRY_CONSTANTS } from '../utils/constants.ts'
 import { datasetMetadataObjectToEntry, type MetadataObject, pieceMetadataObjectToEntry } from '../utils/metadata.ts'
-import { validateAddPiecesBatch, waitForAddPieces } from './add-pieces.ts'
+import { waitForAddPieces } from './add-pieces.ts'
+import { assertAddPiecesFit } from './add-pieces-fits.ts'
 import { waitForCreateDataSet } from './create-dataset.ts'
 
 export namespace createDataSetAndAddPiecesApiRequest {
@@ -129,7 +133,12 @@ export type CreateDataSetAndAddPiecesOptions = {
 export namespace createDataSetAndAddPieces {
   export type OptionsType = CreateDataSetAndAddPiecesOptions
   export type ReturnType = createDataSetAndAddPiecesApiRequest.OutputType
-  export type ErrorType = createDataSetAndAddPiecesApiRequest.ErrorType | signCreateDataSetAndAddPieces.ErrorType
+  export type ErrorType =
+    | createDataSetAndAddPiecesApiRequest.ErrorType
+    | signCreateDataSetAndAddPieces.ErrorType
+    | AtLeastOnePieceRequiredError
+    | AddPiecesBatchTooLargeError
+    | InvalidUploadSizeError
 }
 
 /**
@@ -144,7 +153,12 @@ export async function createDataSetAndAddPieces(
   client: Client<Transport, Chain, Account>,
   options: CreateDataSetAndAddPiecesOptions
 ): Promise<createDataSetAndAddPieces.ReturnType> {
-  validateAddPiecesBatch(options.pieces.length)
+  assertAddPiecesFit({
+    kind: 'createDataSetAndAddPieces',
+    metadata: options.metadata,
+    cdn: options.cdn,
+    pieces: options.pieces,
+  })
   const chain = asChain(client.chain)
   const extraData =
     options.extraData ??

--- a/packages/synapse-core/src/sp/create-piece-batcher.ts
+++ b/packages/synapse-core/src/sp/create-piece-batcher.ts
@@ -1,0 +1,460 @@
+import type { Account, Address, Chain, Client, Hex, Transport } from 'viem'
+import { ValidationError } from '../errors/base.ts'
+import { AddPiecesFlushError } from '../errors/pdp.ts'
+import { PullError } from '../errors/pull.ts'
+import { DataSetNotFoundError } from '../errors/warm-storage.ts'
+import type { PieceCID } from '../piece/piece-cid.ts'
+import { signAddPieces } from '../typed-data/sign-add-pieces.ts'
+import { type MetadataObject, pieceMetadataObjectToEntry } from '../utils/metadata.ts'
+import { randU256 } from '../utils/rand.ts'
+import { isUint8Array } from '../utils/streams.ts'
+import { getPdpDataSet } from '../warm-storage/get-pdp-data-set.ts'
+import type { PdpDataSet } from '../warm-storage/types.ts'
+import { addPieces } from './add-pieces.ts'
+import {
+  addPiecesFits,
+  assertPieceCidSize,
+  type Limiter,
+  type LimiterOptions,
+  type LimiterPiece,
+} from './add-pieces-fits.ts'
+import { waitForCreateDataSet } from './create-dataset.ts'
+import { createDataSetAndAddPieces } from './create-dataset-add-pieces.ts'
+import { findPiece } from './find-piece.ts'
+import { waitForPullPieces } from './pull-pieces.ts'
+import { type UploadPieceStreamingData, uploadPieceStreaming } from './upload-streaming.ts'
+
+export type EnqueuePiece = LimiterPiece
+
+export type FlushResult = {
+  txHash: Hex
+  statusUrl: string
+  pieces: EnqueuePiece[]
+}
+
+export type PieceResult = FlushResult & {
+  pieceCid: PieceCID
+  batchIndex: number
+}
+
+/**
+ * When to flush a tumbling addPieces window (limiter overflow, `flush()`, and
+ * `close()` always flush regardless).
+ *
+ * - `delay`: wait `ms` after the first piece in the window (`ms: 0` is one macrotask).
+ * - `limiter`: no timer; sit until the next piece does not fit, or `flush`/`close`.
+ */
+export type PieceBatcherWait = { kind: 'delay'; ms: number } | { kind: 'limiter' }
+
+/**
+ * Called after the piece is on this SP, before it joins the addPieces window.
+ * The callback is awaited, so a thrown error keeps the piece out of the batch
+ * (retry with {@link PieceBatcher.enqueue}). {@link PieceBatcher.close} waits
+ * for it the same way it waits for park/pull I/O.
+ */
+export type OnParked = (piece: EnqueuePiece) => void | Promise<void>
+
+export type UploadInput = {
+  data: File | Uint8Array | ReadableStream<Uint8Array>
+  /** Known length for a stream (`File` uses `.size`). */
+  size?: number
+  metadata?: MetadataObject
+  pieceCid?: PieceCID
+  onParked?: OnParked
+  onProgress?: (bytesUploaded: number) => void
+  signal?: AbortSignal
+}
+
+export type PullInput = {
+  pieceCid: PieceCID
+  sourceUrl: string
+  metadata?: MetadataObject
+  onParked?: OnParked
+}
+
+type Slot = {
+  piece: EnqueuePiece
+  resolve: (result: PieceResult) => void
+  reject: (error: unknown) => void
+}
+
+export type PieceBatcher = {
+  /** Stream onto this SP, then join the addPieces window. */
+  upload: (input: UploadInput) => Promise<PieceResult>
+  /** Pull onto this SP (own extraData), then join the addPieces window. */
+  pull: (input: PullInput) => Promise<PieceResult>
+  /** Already on this SP. Join the addPieces window only. */
+  enqueue: (piece: EnqueuePiece) => Promise<PieceResult>
+  flush: () => Promise<FlushResult | undefined>
+  close: () => Promise<void>
+  readonly pending: readonly EnqueuePiece[]
+  readonly dataSet: PdpDataSet | undefined
+}
+
+export namespace createPieceBatcher {
+  export type OptionsType = {
+    dataSet: PdpDataSet | undefined
+    /** When to flush a window. Defaults to `{ kind: 'delay', ms: 0 }`. */
+    wait?: PieceBatcherWait
+    /** Defaults to {@link addPiecesFits}. */
+    limiter?: Limiter
+    /** Required when `dataSet` is undefined. */
+    serviceURL?: string
+    /** Required when `dataSet` is undefined. */
+    payee?: Address
+    payer?: Address
+    metadata?: MetadataObject
+    cdn?: boolean
+  }
+  export type ReturnType = PieceBatcher
+}
+
+/**
+ * Create a stateful piece batcher that parks/pulls immediately and coalesces addPieces.
+ *
+ * `upload` and `pull` run per-piece I/O right away (`upload` uses the
+ * streaming CommP-last protocol for bytes and streams). The tumbling window
+ * only batches the on-chain addPieces (or createDataSetAndAddPieces) call.
+ * Pull authorization uses `signAddPieces` for that one piece; flush signs a
+ * new extraData for the whole window.
+ *
+ * @param client - Wallet client used to sign and submit.
+ * @param options - {@link createPieceBatcher.OptionsType}
+ * @returns Batcher {@link createPieceBatcher.ReturnType}
+ *
+ * @example
+ * ```ts
+ * import { createPieceBatcher } from '@filoz/synapse-core/sp'
+ *
+ * const batcher = createPieceBatcher(client, { dataSet })
+ * await Promise.all([
+ *   batcher.upload({ data: fileA }),
+ *   batcher.pull({ pieceCid, sourceUrl }),
+ * ])
+ * await batcher.close()
+ * ```
+ */
+export function createPieceBatcher(
+  client: Client<Transport, Chain, Account>,
+  options: createPieceBatcher.OptionsType
+): createPieceBatcher.ReturnType {
+  const wait: PieceBatcherWait = options.wait ?? { kind: 'delay', ms: 0 }
+  if (wait.kind === 'delay' && !(wait.ms >= 0)) {
+    throw new ValidationError('`wait.ms` must be a non-negative number.')
+  }
+  const limiter = options.limiter ?? addPiecesFits
+  const datasetMetadata = options.metadata
+  const cdn = options.cdn
+  const payee = options.payee
+  const payer = options.payer
+  const createClientDataSetId = randU256()
+
+  let dataSet = options.dataSet
+  let closed = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let windowSlots: Slot[] = []
+  let mutex: Promise<void> = Promise.resolve()
+  const inFlight = new Set<Promise<unknown>>()
+  let scheduled = 0
+  let scheduledIdle = Promise.resolve()
+  let resolveScheduledIdle: () => void = () => undefined
+
+  function serviceURL(): string {
+    if (dataSet != null) {
+      return dataSet.provider.pdp.serviceURL
+    }
+    if (options.serviceURL == null) {
+      throw new ValidationError('`serviceURL` is required when dataSet is undefined.')
+    }
+    return options.serviceURL
+  }
+
+  function limiterOptions(pieces: LimiterPiece[]): LimiterOptions {
+    if (dataSet != null) {
+      return { kind: 'addPieces', dataSet, pieces }
+    }
+    return { kind: 'createDataSetAndAddPieces', metadata: datasetMetadata, cdn, pieces }
+  }
+
+  function fits(pieces: LimiterPiece[]): boolean {
+    return limiter(limiterOptions(pieces))
+  }
+
+  function lock<T>(fn: () => Promise<T>): Promise<T> {
+    const run = mutex.then(fn, fn)
+    mutex = run.then(
+      () => undefined,
+      () => undefined
+    )
+    return run
+  }
+
+  function track<T>(promise: Promise<T>): Promise<T> {
+    inFlight.add(promise)
+    return promise.finally(() => {
+      inFlight.delete(promise)
+    })
+  }
+
+  function beginSchedule(): void {
+    if (scheduled === 0) {
+      scheduledIdle = new Promise<void>((resolve) => {
+        resolveScheduledIdle = () => {
+          resolve()
+        }
+      })
+    }
+    scheduled++
+  }
+
+  function endSchedule(): void {
+    scheduled--
+    if (scheduled === 0) {
+      resolveScheduledIdle()
+    }
+  }
+
+  function assertOpen(): void {
+    if (closed) {
+      throw new ValidationError('Piece batcher is closed.')
+    }
+  }
+
+  async function flushWindowInternal(): Promise<FlushResult | undefined> {
+    if (timer != null) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+    if (windowSlots.length === 0) {
+      return undefined
+    }
+    const batch = windowSlots
+    windowSlots = []
+    const pieces = batch.map((slot) => slot.piece)
+
+    try {
+      const submitted =
+        dataSet == null
+          ? await flushCreate(pieces)
+          : await addPieces(client, {
+              serviceURL: serviceURL(),
+              dataSetId: dataSet.dataSetId,
+              clientDataSetId: dataSet.clientDataSetId,
+              pieces,
+            })
+
+      const result: FlushResult = {
+        txHash: submitted.txHash,
+        statusUrl: submitted.statusUrl,
+        pieces,
+      }
+      for (const [batchIndex, slot] of batch.entries()) {
+        slot.resolve({
+          ...result,
+          pieceCid: slot.piece.pieceCid,
+          batchIndex,
+        })
+      }
+      return result
+    } catch (error) {
+      const cause = error instanceof Error ? error : new Error(String(error))
+      for (const slot of batch) {
+        slot.reject(
+          new AddPiecesFlushError({
+            pieceCid: slot.piece.pieceCid,
+            metadata: slot.piece.metadata,
+            pieces,
+            cause,
+          })
+        )
+      }
+      return undefined
+    }
+  }
+
+  async function flushCreate(pieces: EnqueuePiece[]): Promise<{ txHash: Hex; statusUrl: string }> {
+    if (payee == null) {
+      throw new ValidationError('`payee` is required when dataSet is undefined.')
+    }
+    const submitted = await createDataSetAndAddPieces(client, {
+      serviceURL: serviceURL(),
+      payee,
+      payer,
+      metadata: datasetMetadata,
+      cdn,
+      pieces,
+      clientDataSetId: createClientDataSetId,
+    })
+    const created = await waitForCreateDataSet({ statusUrl: submitted.statusUrl })
+    const resolved = await getPdpDataSet(client, { dataSetId: created.dataSetId })
+    if (resolved == null) {
+      throw new DataSetNotFoundError(created.dataSetId)
+    }
+    dataSet = resolved
+    return submitted
+  }
+
+  function startTimer(): void {
+    if (wait.kind === 'limiter' || timer != null) {
+      return
+    }
+    timer = setTimeout(() => {
+      timer = undefined
+      void lock(() => flushWindowInternal())
+    }, wait.ms)
+  }
+
+  function internalEnqueue(incoming: EnqueuePiece): Promise<PieceResult> {
+    assertPieceCidSize(incoming.pieceCid)
+    beginSchedule()
+    return new Promise((resolve, reject) => {
+      void lock(async () => {
+        try {
+          if (windowSlots.length > 0 && !fits([...windowSlots.map((slot) => slot.piece), incoming])) {
+            await flushWindowInternal()
+          }
+          if (!fits([incoming])) {
+            throw new ValidationError('Piece does not fit in a single addPieces operation.')
+          }
+          const slot: Slot = { piece: incoming, resolve, reject }
+          windowSlots.push(slot)
+          if (windowSlots.length === 1) {
+            startTimer()
+          }
+        } catch (error) {
+          reject(error)
+        } finally {
+          endSchedule()
+        }
+      })
+    })
+  }
+
+  async function parkAndEnqueue(park: () => Promise<EnqueuePiece>, onParked?: OnParked): Promise<PieceResult> {
+    assertOpen()
+    const parked = await track(
+      (async () => {
+        const piece = await park()
+        assertPieceCidSize(piece.pieceCid)
+        await onParked?.(piece)
+        return piece
+      })()
+    )
+    return internalEnqueue(parked)
+  }
+
+  async function enqueue(piece: EnqueuePiece): Promise<PieceResult> {
+    assertOpen()
+    return internalEnqueue(piece)
+  }
+
+  async function upload(input: UploadInput): Promise<PieceResult> {
+    let data: UploadPieceStreamingData
+    let size = input.size
+    if (isUint8Array(input.data)) {
+      data = input.data
+      size = input.data.byteLength
+    } else if (input.data instanceof Blob) {
+      data = input.data.stream()
+      size = input.data.size
+    } else {
+      data = input.data
+    }
+    return parkAndEnqueue(async () => {
+      if (input.pieceCid != null) {
+        assertPieceCidSize(input.pieceCid)
+      }
+      const uploaded = await uploadPieceStreaming({
+        serviceURL: serviceURL(),
+        data,
+        size,
+        pieceCid: input.pieceCid,
+        onProgress: input.onProgress,
+        signal: input.signal,
+      })
+      await findPiece({
+        serviceURL: serviceURL(),
+        pieceCid: uploaded.pieceCid,
+        poll: true,
+        signal: input.signal,
+      })
+      return { pieceCid: uploaded.pieceCid, metadata: input.metadata }
+    }, input.onParked)
+  }
+
+  async function pull(input: PullInput): Promise<PieceResult> {
+    return parkAndEnqueue(async () => {
+      assertPieceCidSize(input.pieceCid)
+      const signingPieces = [
+        {
+          pieceCid: input.pieceCid,
+          metadata: pieceMetadataObjectToEntry(input.metadata),
+        },
+      ]
+      const extraData = await signAddPieces(client, {
+        clientDataSetId: dataSet == null ? createClientDataSetId : dataSet.clientDataSetId,
+        pieces: signingPieces,
+      })
+      const pullPiece = {
+        pieceCid: input.pieceCid,
+        sourceUrl: input.sourceUrl,
+        metadata: input.metadata,
+      }
+      const pullResult =
+        dataSet == null
+          ? await waitForPullPieces(client, {
+              serviceURL: serviceURL(),
+              pieces: [pullPiece],
+              extraData,
+              payee: requirePayee(),
+              payer,
+              cdn,
+              metadata: datasetMetadata,
+            })
+          : await waitForPullPieces(client, {
+              serviceURL: serviceURL(),
+              pieces: [pullPiece],
+              extraData,
+              dataSetId: dataSet.dataSetId,
+              clientDataSetId: dataSet.clientDataSetId,
+            })
+      if (pullResult.status === 'failed') {
+        throw new PullError('Pull failed.')
+      }
+      return { pieceCid: input.pieceCid, metadata: input.metadata }
+    }, input.onParked)
+  }
+
+  function requirePayee(): Address {
+    if (payee == null) {
+      throw new ValidationError('`payee` is required when dataSet is undefined.')
+    }
+    return payee
+  }
+
+  async function flush(): Promise<FlushResult | undefined> {
+    return lock(() => flushWindowInternal())
+  }
+
+  async function close(): Promise<void> {
+    closed = true
+    await Promise.allSettled([...inFlight])
+    await Promise.resolve()
+    await scheduledIdle
+    await lock(() => flushWindowInternal())
+  }
+
+  return {
+    upload,
+    pull,
+    enqueue,
+    flush,
+    close,
+    get pending() {
+      return windowSlots.map((slot) => slot.piece)
+    },
+    get dataSet() {
+      return dataSet
+    },
+  }
+}

--- a/packages/synapse-core/src/sp/create-piece-batcher.ts
+++ b/packages/synapse-core/src/sp/create-piece-batcher.ts
@@ -41,7 +41,8 @@ export type PieceResult = FlushResult & {
  * When to flush a tumbling addPieces window (limiter overflow, `flush()`, and
  * `close()` always flush regardless).
  *
- * - `delay`: wait `ms` after the first piece in the window (`ms: 0` is one macrotask).
+ * - `delay`: wait `ms` once the window has a piece and no upload/pull is still
+ *   parking (`ms: 0` is one macrotask). New parking work restarts the delay.
  * - `limiter`: no timer; sit until the next piece does not fit, or `flush`/`close`.
  */
 export type PieceBatcherWait = { kind: 'delay'; ms: number } | { kind: 'limiter' }
@@ -152,6 +153,7 @@ export function createPieceBatcher(
   let dataSet = options.dataSet
   let closed = false
   let timer: ReturnType<typeof setTimeout> | undefined
+  let timerToken: object | undefined
   let windowSlots: Slot[] = []
   let mutex: Promise<void> = Promise.resolve()
   const inFlight = new Set<Promise<unknown>>()
@@ -190,9 +192,13 @@ export function createPieceBatcher(
   }
 
   function track<T>(promise: Promise<T>): Promise<T> {
+    cancelTimer()
     inFlight.add(promise)
     return promise.finally(() => {
       inFlight.delete(promise)
+      if (inFlight.size === 0) {
+        startTimer()
+      }
     })
   }
 
@@ -221,10 +227,7 @@ export function createPieceBatcher(
   }
 
   async function flushWindowInternal(): Promise<FlushResult | undefined> {
-    if (timer != null) {
-      clearTimeout(timer)
-      timer = undefined
-    }
+    cancelTimer()
     if (windowSlots.length === 0) {
       return undefined
     }
@@ -294,13 +297,32 @@ export function createPieceBatcher(
     return submitted
   }
 
+  function cancelTimer(): void {
+    timerToken = undefined
+    if (timer != null) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+  }
+
   function startTimer(): void {
-    if (wait.kind === 'limiter' || timer != null) {
+    if (wait.kind === 'limiter' || timerToken != null || windowSlots.length === 0 || inFlight.size > 0) {
       return
     }
+    const token = {}
+    timerToken = token
     timer = setTimeout(() => {
+      if (timerToken !== token) {
+        return
+      }
       timer = undefined
-      void lock(() => flushWindowInternal())
+      void lock(async () => {
+        if (timerToken !== token || inFlight.size > 0) {
+          return
+        }
+        timerToken = undefined
+        await flushWindowInternal()
+      })
     }, wait.ms)
   }
 
@@ -318,9 +340,7 @@ export function createPieceBatcher(
           }
           const slot: Slot = { piece: incoming, resolve, reject }
           windowSlots.push(slot)
-          if (windowSlots.length === 1) {
-            startTimer()
-          }
+          startTimer()
         } catch (error) {
           reject(error)
         } finally {

--- a/packages/synapse-core/src/sp/create-piece-batcher.ts
+++ b/packages/synapse-core/src/sp/create-piece-batcher.ts
@@ -24,17 +24,28 @@ import { findPiece } from './find-piece.ts'
 import { waitForPullPieces } from './pull-pieces.ts'
 import { type UploadPieceStreamingData, uploadPieceStreaming } from './upload-streaming.ts'
 
-export type EnqueuePiece = LimiterPiece
+export type EnqueuePiece = LimiterPiece & {
+  /** Raw byte size when the piece was parked by `upload()`. */
+  size?: number
+}
 
 export type FlushResult = {
   txHash: Hex
+  confirmedTxHash?: Hex
   statusUrl: string
+  dataSetId: bigint
+  clientDataSetId: bigint
+  isNewDataSet: boolean
   pieces: EnqueuePiece[]
 }
 
 export type PieceResult = FlushResult & {
   pieceCid: PieceCID
   batchIndex: number
+}
+
+export type UploadResult = PieceResult & {
+  size: number
 }
 
 /**
@@ -56,7 +67,7 @@ export type PieceBatcherWait = { kind: 'delay'; ms: number } | { kind: 'limiter'
 export type OnParked = (piece: EnqueuePiece) => void | Promise<void>
 
 export type UploadInput = {
-  data: File | Uint8Array | ReadableStream<Uint8Array>
+  data: File | UploadPieceStreamingData
   /** Known length for a stream (`File` uses `.size`). */
   size?: number
   metadata?: MetadataObject
@@ -71,6 +82,8 @@ export type PullInput = {
   sourceUrl: string
   metadata?: MetadataObject
   onParked?: OnParked
+  onStatus?: (response: waitForPullPieces.ReturnType) => void
+  signal?: AbortSignal
 }
 
 type Slot = {
@@ -81,7 +94,7 @@ type Slot = {
 
 export type PieceBatcher = {
   /** Stream onto this SP, then join the addPieces window. */
-  upload: (input: UploadInput) => Promise<PieceResult>
+  upload: (input: UploadInput) => Promise<UploadResult>
   /** Pull onto this SP (own extraData), then join the addPieces window. */
   pull: (input: PullInput) => Promise<PieceResult>
   /** Already on this SP. Join the addPieces window only. */
@@ -236,19 +249,36 @@ export function createPieceBatcher(
     const pieces = batch.map((slot) => slot.piece)
 
     try {
-      const submitted =
-        dataSet == null
-          ? await flushCreate(pieces)
-          : await addPieces(client, {
-              serviceURL: serviceURL(),
-              dataSetId: dataSet.dataSetId,
-              clientDataSetId: dataSet.clientDataSetId,
-              pieces,
-            })
+      const isNewDataSet = dataSet == null
+      let submitted: {
+        txHash: Hex
+        confirmedTxHash?: Hex
+        statusUrl: string
+        dataSetId: bigint
+        clientDataSetId: bigint
+      }
+      if (dataSet == null) {
+        submitted = await flushCreate(pieces)
+      } else {
+        submitted = {
+          ...(await addPieces(client, {
+            serviceURL: serviceURL(),
+            dataSetId: dataSet.dataSetId,
+            clientDataSetId: dataSet.clientDataSetId,
+            pieces,
+          })),
+          dataSetId: dataSet.dataSetId,
+          clientDataSetId: dataSet.clientDataSetId,
+        }
+      }
 
       const result: FlushResult = {
         txHash: submitted.txHash,
+        ...(submitted.confirmedTxHash == null ? {} : { confirmedTxHash: submitted.confirmedTxHash }),
         statusUrl: submitted.statusUrl,
+        dataSetId: submitted.dataSetId,
+        clientDataSetId: submitted.clientDataSetId,
+        isNewDataSet,
         pieces,
       }
       for (const [batchIndex, slot] of batch.entries()) {
@@ -275,7 +305,13 @@ export function createPieceBatcher(
     }
   }
 
-  async function flushCreate(pieces: EnqueuePiece[]): Promise<{ txHash: Hex; statusUrl: string }> {
+  async function flushCreate(pieces: EnqueuePiece[]): Promise<{
+    txHash: Hex
+    confirmedTxHash?: Hex
+    statusUrl: string
+    dataSetId: bigint
+    clientDataSetId: bigint
+  }> {
     if (payee == null) {
       throw new ValidationError('`payee` is required when dataSet is undefined.')
     }
@@ -294,7 +330,16 @@ export function createPieceBatcher(
       throw new DataSetNotFoundError(created.dataSetId)
     }
     dataSet = resolved
-    return submitted
+    return {
+      txHash: submitted.txHash,
+      ...(created.confirmedTxHash == null ? {} : { confirmedTxHash: created.confirmedTxHash }),
+      statusUrl: new URL(
+        `/pdp/data-sets/${created.dataSetId}/pieces/added/${submitted.txHash}`,
+        serviceURL()
+      ).toString(),
+      dataSetId: created.dataSetId,
+      clientDataSetId: createClientDataSetId,
+    }
   }
 
   function cancelTimer(): void {
@@ -368,7 +413,7 @@ export function createPieceBatcher(
     return internalEnqueue(piece)
   }
 
-  async function upload(input: UploadInput): Promise<PieceResult> {
+  async function upload(input: UploadInput): Promise<UploadResult> {
     let data: UploadPieceStreamingData
     let size = input.size
     if (isUint8Array(input.data)) {
@@ -380,7 +425,8 @@ export function createPieceBatcher(
     } else {
       data = input.data
     }
-    return parkAndEnqueue(async () => {
+    let uploadedSize: number | undefined
+    const result = await parkAndEnqueue(async () => {
       if (input.pieceCid != null) {
         assertPieceCidSize(input.pieceCid)
       }
@@ -392,14 +438,19 @@ export function createPieceBatcher(
         onProgress: input.onProgress,
         signal: input.signal,
       })
+      uploadedSize = uploaded.size
       await findPiece({
         serviceURL: serviceURL(),
         pieceCid: uploaded.pieceCid,
         poll: true,
         signal: input.signal,
       })
-      return { pieceCid: uploaded.pieceCid, metadata: input.metadata }
+      return { pieceCid: uploaded.pieceCid, metadata: input.metadata, size: uploaded.size }
     }, input.onParked)
+    if (uploadedSize == null) {
+      throw new ValidationError('Piece upload completed without a size.')
+    }
+    return { ...result, size: uploadedSize }
   }
 
   async function pull(input: PullInput): Promise<PieceResult> {
@@ -430,6 +481,8 @@ export function createPieceBatcher(
               payer,
               cdn,
               metadata: datasetMetadata,
+              signal: input.signal,
+              onStatus: input.onStatus,
             })
           : await waitForPullPieces(client, {
               serviceURL: serviceURL(),
@@ -437,6 +490,8 @@ export function createPieceBatcher(
               extraData,
               dataSetId: dataSet.dataSetId,
               clientDataSetId: dataSet.clientDataSetId,
+              signal: input.signal,
+              onStatus: input.onStatus,
             })
       if (pullResult.status === 'failed') {
         throw new PullError('Pull failed.')
@@ -453,15 +508,15 @@ export function createPieceBatcher(
   }
 
   async function flush(): Promise<FlushResult | undefined> {
+    await Promise.allSettled([...inFlight])
+    await Promise.resolve()
+    await scheduledIdle
     return lock(() => flushWindowInternal())
   }
 
   async function close(): Promise<void> {
     closed = true
-    await Promise.allSettled([...inFlight])
-    await Promise.resolve()
-    await scheduledIdle
-    await lock(() => flushWindowInternal())
+    await flush()
   }
 
   return {

--- a/packages/synapse-core/src/sp/index.ts
+++ b/packages/synapse-core/src/sp/index.ts
@@ -11,8 +11,10 @@
 
 export { AbortError, NetworkError, TimeoutError } from 'iso-web/http'
 export * from './add-pieces.ts'
+export * from './add-pieces-fits.ts'
 export * from './create-dataset.ts'
 export * from './create-dataset-add-pieces.ts'
+export * from './create-piece-batcher.ts'
 export * from './find-piece.ts'
 export * from './get-data-set.ts'
 export * from './ping.ts'

--- a/packages/synapse-core/src/utils/constants.ts
+++ b/packages/synapse-core/src/utils/constants.ts
@@ -92,12 +92,21 @@ export const SIZE_CONSTANTS = {
   DEFAULT_UPLOAD_BATCH_SIZE: 32,
 
   /**
-   * Maximum pieces per addPieces (or createDataSetAndAddPieces) call.
+   * Heuristic pieces-per-addPieces used only for upload-fee previews.
    *
-   * On-chain limitations fail batch sizes above 41; we constrain to 40 here to
-   * catch those failures early and surface informative errors.
+   * Action validation uses `MAX_ADD_PIECES_MESSAGE_SIZE` via `addPiecesFits`,
+   * not this count.
    */
   MAX_ADD_PIECES_BATCH_SIZE: 40,
+
+  /**
+   * Payload budget (bytes) for one addPieces / createAndAdd Filecoin message.
+   *
+   * Filecoin messages are capped at 64 KiB. 288 bytes are reserved for message
+   * overhead (from, to, nonce, gas, method, …), leaving this much for encoded
+   * params. Used by the default piece-batcher limiter.
+   */
+  MAX_ADD_PIECES_MESSAGE_SIZE: 64 * 1024 - 288,
 
   /**
    * Maximum pieces per schedulePieceDeletions call accepted by the Curio PDP API.

--- a/packages/synapse-core/src/warm-storage/calculate-upload-fees.ts
+++ b/packages/synapse-core/src/warm-storage/calculate-upload-fees.ts
@@ -23,10 +23,13 @@ export namespace calculateUploadFees {
  * datasets only) and add-pieces. Schedule-removals, terminate, and delete are
  * post-upload lifecycle operations and are not part of an upload cost preview.
  *
- * The number of addPieces operations is derived from `pieceCount` and the
- * `MAX_ADD_PIECES_BATCH_SIZE` batch limit: a single addPieces call cannot
- * exceed the limit, so `pieceCount` pieces span `ceil(pieceCount / limit)`
- * calls, each charged the base fee.
+ * The number of addPieces operations is derived from `pieceCount` and a
+ * pieces-per-call heuristic (`MAX_ADD_PIECES_BATCH_SIZE`): each call is
+ * charged the base fee. Actual batches are limited by message size via
+ * `addPiecesFits`, so this is a fee preview, not an action cap.
+ *
+ * TODO: Review in a follow-up and update fee/pricing calculations to match
+ * message-size batching instead of this count heuristic.
  *
  * @param params - {@link calculateUploadFees.ParamsType}
  * @returns {@link calculateUploadFees.OutputType}

--- a/packages/synapse-core/test/add-pieces-fits.test.ts
+++ b/packages/synapse-core/test/add-pieces-fits.test.ts
@@ -1,0 +1,124 @@
+import assert from 'assert'
+import { ADDRESSES } from '../src/mocks/jsonrpc/constants.ts'
+import * as Piece from '../src/piece/index.ts'
+import { addPiecesFits, estimateAddPiecesCalldataSize } from '../src/sp/add-pieces-fits.ts'
+import type { PdpDataSet } from '../src/warm-storage/types.ts'
+
+const pieceCid = Piece.from('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+
+function createDataSet(): PdpDataSet {
+  return {
+    pdpRailId: 1n,
+    cacheMissRailId: 0n,
+    cdnRailId: 0n,
+    payer: ADDRESSES.client1,
+    payee: ADDRESSES.payee1,
+    serviceProvider: ADDRESSES.serviceProvider1,
+    commissionBps: 100n,
+    clientDataSetId: 0n,
+    pdpEndEpoch: 0n,
+    providerId: 1n,
+    dataSetId: 1n,
+    live: true,
+    managed: true,
+    cdn: false,
+    metadata: Object.create(null),
+    hasActivePieces: true,
+    provider: {
+      id: 1n,
+      serviceProvider: ADDRESSES.serviceProvider1,
+      payee: ADDRESSES.payee1,
+      isActive: true,
+      name: 'provider-1',
+      description: 'test provider',
+      pdp: {
+        serviceURL: 'https://pdp.example.com',
+        minPieceSizeInBytes: 127n,
+        maxPieceSizeInBytes: 1024n * 1024n * 1024n,
+        storagePricePerTibPerDay: 1n,
+        minProvingPeriodInEpochs: 1n,
+        location: 'US',
+        paymentTokenAddress: ADDRESSES.calibration.usdfcToken,
+        ipniPiece: false,
+        ipniIpfs: false,
+      },
+    },
+  }
+}
+
+describe('addPiecesFits', () => {
+  const dataSet = createDataSet()
+
+  it('should return false when empty', () => {
+    assert.equal(
+      addPiecesFits({
+        kind: 'addPieces',
+        dataSet,
+        pieces: [],
+      }),
+      false
+    )
+  })
+
+  it('should return true for a single small piece', () => {
+    assert.equal(
+      addPiecesFits({
+        kind: 'addPieces',
+        dataSet,
+        pieces: [{ pieceCid }],
+      }),
+      true
+    )
+  })
+
+  it('should accept more than the old 40-piece count cap when pieces are small', () => {
+    const pieces = Array.from({ length: 41 }, () => ({ pieceCid }))
+    assert.equal(addPiecesFits({ kind: 'addPieces', pieces }), true)
+  })
+
+  it('should treat createDataSetAndAddPieces as larger than addPieces', () => {
+    const pieces = [{ pieceCid, metadata: { name: 'a', type: 'b' } }]
+    const addSize = estimateAddPiecesCalldataSize({ kind: 'addPieces', dataSet, pieces })
+    const createSize = estimateAddPiecesCalldataSize({
+      kind: 'createDataSetAndAddPieces',
+      metadata: { withCDN: '' },
+      cdn: true,
+      pieces,
+    })
+    assert.ok(createSize > addSize)
+    assert.equal(addPiecesFits({ kind: 'createDataSetAndAddPieces', pieces }), true)
+  })
+
+  it('should eventually reject a list of max-metadata pieces', () => {
+    const metadata = {
+      aaa: 'x'.repeat(96),
+      bbb: 'y'.repeat(96),
+      ccc: 'z'.repeat(96),
+    }
+    let count = 1
+    while (
+      count < 10_000 &&
+      addPiecesFits({
+        kind: 'addPieces',
+        pieces: Array.from({ length: count }, () => ({ pieceCid, metadata })),
+      })
+    ) {
+      count++
+    }
+    assert.equal(
+      addPiecesFits({
+        kind: 'addPieces',
+        pieces: Array.from({ length: count }, () => ({ pieceCid, metadata })),
+      }),
+      false
+    )
+    assert.ok(count > 1)
+    assert.ok(count < 10_000)
+  })
+
+  it('should support a custom count limiter', () => {
+    const limiter = ({ pieces }: { pieces: unknown[] }) => pieces.length <= 8
+    assert.equal(limiter({ pieces: Array.from({ length: 8 }) }), true)
+    assert.equal(limiter({ pieces: Array.from({ length: 9 }) }), false)
+  })
+})

--- a/packages/synapse-core/test/add-pieces.test.ts
+++ b/packages/synapse-core/test/add-pieces.test.ts
@@ -1,26 +1,72 @@
 import assert from 'assert'
-import { AtLeastOnePieceRequiredError, TooManyPiecesError } from '../src/errors/warm-storage.ts'
-import { validateAddPiecesBatch } from '../src/sp/add-pieces.ts'
+import { AddPiecesBatchTooLargeError, InvalidUploadSizeError } from '../src/errors/pdp.ts'
+import { AtLeastOnePieceRequiredError } from '../src/errors/warm-storage.ts'
+import * as Piece from '../src/piece/index.ts'
+import * as Digest from '../src/piece/internal/digest.ts'
+import { PieceCID } from '../src/piece/piece-cid.ts'
+import { addPiecesFits, assertAddPiecesFit } from '../src/sp/add-pieces-fits.ts'
 import { SIZE_CONSTANTS } from '../src/utils/constants.ts'
 
-describe('validateAddPiecesBatch', () => {
-  const max = SIZE_CONSTANTS.MAX_ADD_PIECES_BATCH_SIZE
+const pieceCid = Piece.from('bafkzcibcaabffs4jcd4iheeo5wisbmurjb7l4xgpmzgyzrenebvjjhsbwgx4smy')
+const tooSmallPieceCid = Piece.from('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
 
+function pieceCidWithRawSize(rawSize: number): PieceCID {
+  const height = Piece.heightFor(rawSize < Piece.MIN_SIZE ? Piece.MIN_SIZE : rawSize)
+  const root = new Uint8Array(32)
+  const probe = PieceCID._fromDigest(Digest.fromFields({ padding: 0n, height, root }))
+  return PieceCID._fromDigest(Digest.fromFields({ padding: BigInt(probe.size - rawSize), height, root }))
+}
+
+const maxMetadata = {
+  aaa: 'x'.repeat(96),
+  bbb: 'y'.repeat(96),
+  ccc: 'z'.repeat(96),
+}
+
+function oversizedBatch() {
+  const next = { pieceCid, metadata: maxMetadata }
+  const pieces = [next]
+  while (addPiecesFits({ kind: 'addPieces', pieces: [...pieces, next] })) {
+    pieces.push(next)
+  }
+  pieces.push(next)
+  return pieces
+}
+
+describe('assertAddPiecesFit', () => {
   it('should throw when empty', () => {
-    assert.throws(() => validateAddPiecesBatch(0), AtLeastOnePieceRequiredError)
+    assert.throws(() => assertAddPiecesFit({ kind: 'addPieces', pieces: [] }), AtLeastOnePieceRequiredError)
   })
 
-  it('should throw for non-positive or non-integer counts', () => {
-    for (const bad of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
-      assert.throws(() => validateAddPiecesBatch(bad), AtLeastOnePieceRequiredError)
-    }
+  it('should accept a single small piece', () => {
+    assert.doesNotThrow(() => assertAddPiecesFit({ kind: 'addPieces', pieces: [{ pieceCid }] }))
   })
 
-  it('should accept a count at the maximum', () => {
-    assert.doesNotThrow(() => validateAddPiecesBatch(max))
+  it('should accept more than the old 40-piece count cap when pieces are small', () => {
+    const pieces = Array.from({ length: 41 }, () => ({ pieceCid }))
+    assert.doesNotThrow(() => assertAddPiecesFit({ kind: 'addPieces', pieces }))
   })
 
-  it('should throw when above the maximum', () => {
-    assert.throws(() => validateAddPiecesBatch(max + 1), TooManyPiecesError)
+  it('should throw when a PieceCID is below MIN_UPLOAD_SIZE', () => {
+    assert.throws(
+      () => assertAddPiecesFit({ kind: 'addPieces', pieces: [{ pieceCid: tooSmallPieceCid }] }),
+      InvalidUploadSizeError
+    )
+  })
+
+  it('should throw when a PieceCID is above MAX_UPLOAD_SIZE', () => {
+    const tooLarge = pieceCidWithRawSize(SIZE_CONSTANTS.MAX_UPLOAD_SIZE + 1)
+    assert.equal(tooLarge.size, SIZE_CONSTANTS.MAX_UPLOAD_SIZE + 1)
+    assert.throws(
+      () => assertAddPiecesFit({ kind: 'addPieces', pieces: [{ pieceCid: tooLarge }] }),
+      InvalidUploadSizeError
+    )
+  })
+
+  it('should throw when the estimated message is too large', () => {
+    assert.throws(
+      () => assertAddPiecesFit({ kind: 'addPieces', pieces: oversizedBatch() }),
+      AddPiecesBatchTooLargeError
+    )
   })
 })

--- a/packages/synapse-core/test/create-piece-batcher.test.ts
+++ b/packages/synapse-core/test/create-piece-batcher.test.ts
@@ -186,6 +186,55 @@ describe('createPieceBatcher', () => {
     assert.equal(a.txHash, b.txHash)
   })
 
+  it('should start the delay after all in-flight parking settles', async () => {
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    server.use(
+      ...parkHandlers(),
+      addPiecesCaptureHandler((body) => bodies.push(body))
+    )
+
+    let resolveFirstParked: () => void = () => undefined
+    const firstParked = new Promise<void>((resolve) => {
+      resolveFirstParked = resolve
+    })
+    let resolveSecondParked: () => void = () => undefined
+    const secondParked = new Promise<void>((resolve) => {
+      resolveSecondParked = resolve
+    })
+    let releaseSecond: () => void = () => undefined
+    const holdSecond = new Promise<void>((resolve) => {
+      releaseSecond = resolve
+    })
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet() })
+    const first = batcher.upload({
+      data: new Uint8Array(127).fill(1),
+      pieceCid: pieceCidA,
+      onParked: resolveFirstParked,
+    })
+    const second = batcher.upload({
+      data: new Uint8Array(127).fill(2),
+      pieceCid: pieceCidB,
+      onParked: async () => {
+        resolveSecondParked()
+        await holdSecond
+      },
+    })
+
+    await Promise.all([firstParked, secondParked])
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    assert.equal(bodies.length, 0)
+    assert.equal(batcher.pending.length, 1)
+
+    releaseSecond()
+    const [firstResult, secondResult] = await Promise.all([first, second])
+    await batcher.close()
+
+    assert.equal(bodies.length, 1)
+    assert.equal(bodies[0]?.pieces.length, 2)
+    assert.equal(firstResult.txHash, secondResult.txHash)
+  })
+
   it('should not flush on a timer when wait is limiter', async () => {
     const bodies: addPiecesApiRequest.RequestBody[] = []
     server.use(addPiecesCaptureHandler((body) => bodies.push(body)))

--- a/packages/synapse-core/test/create-piece-batcher.test.ts
+++ b/packages/synapse-core/test/create-piece-batcher.test.ts
@@ -1,0 +1,506 @@
+import assert from 'assert'
+import { setup } from 'iso-web/msw'
+import { HttpResponse, http } from 'msw'
+import { createWalletClient, decodeAbiParameters, http as viemHttp } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import * as Chains from '../src/chains.ts'
+import { ValidationError } from '../src/errors/base.ts'
+import { AddPiecesFlushError, InvalidUploadSizeError } from '../src/errors/pdp.ts'
+import { ADDRESSES, JSONRPC, PRIVATE_KEYS, presets } from '../src/mocks/jsonrpc/index.ts'
+import {
+  createAndAddPiecesHandler,
+  createPullResponse,
+  dataSetCreationStatusHandler,
+  findAnyPieceHandler,
+  pullPiecesWithCaptureHandler,
+  streamingUploadHandlers,
+} from '../src/mocks/pdp.ts'
+import * as Piece from '../src/piece/index.ts'
+import * as Digest from '../src/piece/internal/digest.ts'
+import { PieceCID } from '../src/piece/piece-cid.ts'
+import type { addPiecesApiRequest } from '../src/sp/add-pieces.ts'
+import { createPieceBatcher, type EnqueuePiece } from '../src/sp/create-piece-batcher.ts'
+import * as TypedData from '../src/typed-data/index.ts'
+import { SIZE_CONSTANTS } from '../src/utils/constants.ts'
+import type { PdpDataSet } from '../src/warm-storage/types.ts'
+
+const account = privateKeyToAccount(PRIVATE_KEYS.key1)
+const client = createWalletClient({
+  account,
+  chain: Chains.calibration,
+  transport: viemHttp(),
+})
+
+const pieceCidA = Piece.from('bafkzcibcaabffs4jcd4iheeo5wisbmurjb7l4xgpmzgyzrenebvjjhsbwgx4smy')
+const pieceCidB = Piece.from('bafkzcibeqcad6efnpwn62p5vvs5x3nh3j7xkzfgb3xtitcdm2hulmty3xx4tl3wace')
+const tooSmallPieceCid = Piece.from('bafkzcibcd4bdomn3tgwgrh3g532zopskstnbrd2n3sxfqbze7rxt7vqn7veigmy')
+
+function pieceCidWithRawSize(rawSize: number): PieceCID {
+  const height = Piece.heightFor(rawSize < Piece.MIN_SIZE ? Piece.MIN_SIZE : rawSize)
+  const root = new Uint8Array(32)
+  const probe = PieceCID._fromDigest(Digest.fromFields({ padding: 0n, height, root }))
+  return PieceCID._fromDigest(Digest.fromFields({ padding: BigInt(probe.size - rawSize), height, root }))
+}
+const mockTxHash = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890' as const
+const mockTxHash2 = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as const
+const pdpBase = 'https://pdp.example.com'
+
+function createDataSet(): PdpDataSet {
+  return {
+    pdpRailId: 1n,
+    cacheMissRailId: 0n,
+    cdnRailId: 0n,
+    payer: ADDRESSES.client1,
+    payee: ADDRESSES.payee1,
+    serviceProvider: ADDRESSES.serviceProvider1,
+    commissionBps: 100n,
+    clientDataSetId: 0n,
+    pdpEndEpoch: 0n,
+    providerId: 1n,
+    dataSetId: 1n,
+    live: true,
+    managed: true,
+    cdn: false,
+    metadata: Object.create(null),
+    hasActivePieces: true,
+    provider: {
+      id: 1n,
+      serviceProvider: ADDRESSES.serviceProvider1,
+      payee: ADDRESSES.payee1,
+      isActive: true,
+      name: 'provider-1',
+      description: 'test provider',
+      pdp: {
+        serviceURL: pdpBase,
+        minPieceSizeInBytes: 127n,
+        maxPieceSizeInBytes: 1024n * 1024n * 1024n,
+        storagePricePerTibPerDay: 1n,
+        minProvingPeriodInEpochs: 1n,
+        location: 'US',
+        paymentTokenAddress: ADDRESSES.calibration.usdfcToken,
+        ipniPiece: false,
+        ipniIpfs: false,
+      },
+    },
+  }
+}
+
+function parkHandlers() {
+  return [...streamingUploadHandlers({ baseUrl: pdpBase }), findAnyPieceHandler(true, { baseUrl: pdpBase })]
+}
+
+function addPiecesCaptureHandler(
+  onBody: (body: addPiecesApiRequest.RequestBody) => void,
+  txHash: `0x${string}` = mockTxHash
+) {
+  return http.post<{ id: string }, addPiecesApiRequest.RequestBody>(
+    `${pdpBase}/pdp/data-sets/:id/pieces`,
+    async ({ request, params }) => {
+      const body = await request.json()
+      onBody(body)
+      return new HttpResponse(null, {
+        status: 201,
+        headers: {
+          Location: `/pdp/data-sets/${params.id}/pieces/added/${txHash}`,
+        },
+      })
+    }
+  )
+}
+
+describe('createPieceBatcher', () => {
+  const server = setup()
+
+  before(async () => {
+    await server.start()
+  })
+
+  after(() => {
+    server.stop()
+  })
+
+  beforeEach(() => {
+    server.resetHandlers()
+  })
+
+  it('should batch two uploads in one addPieces window', async () => {
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    server.use(
+      ...parkHandlers(),
+      addPiecesCaptureHandler((body) => bodies.push(body))
+    )
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    const aP = batcher.upload({ data: new Uint8Array(127).fill(1), pieceCid: pieceCidA, metadata: { name: 'a' } })
+    const bP = batcher.upload({ data: new Uint8Array(127).fill(2), pieceCid: pieceCidB, metadata: { name: 'b' } })
+    await batcher.close()
+    const [a, b] = await Promise.all([aP, bP])
+
+    assert.equal(bodies.length, 1)
+    assert.equal(bodies[0]?.pieces.length, 2)
+    assert.equal(a.txHash, b.txHash)
+    assert.equal(a.pieces.length, 2)
+    assert.equal(a.batchIndex + b.batchIndex, 1)
+  })
+
+  it('should stream an upload into the same addPieces window', async () => {
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    server.use(
+      ...parkHandlers(),
+      addPiecesCaptureHandler((body) => bodies.push(body))
+    )
+
+    const data = new Uint8Array(127).fill(1)
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    const streamedP = batcher.upload({
+      data: new Blob([data]).stream(),
+      size: data.byteLength,
+      pieceCid: pieceCidA,
+      metadata: { name: 'a' },
+    })
+    const uploadedP = batcher.upload({
+      data: new Uint8Array(127).fill(2),
+      pieceCid: pieceCidB,
+      metadata: { name: 'b' },
+    })
+    await batcher.close()
+    const [streamed, uploaded] = await Promise.all([streamedP, uploadedP])
+
+    assert.equal(bodies.length, 1)
+    assert.equal(bodies[0]?.pieces.length, 2)
+    assert.equal(streamed.txHash, uploaded.txHash)
+  })
+
+  it('should flush after one macrotask when wait is delay 0', async () => {
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    server.use(addPiecesCaptureHandler((body) => bodies.push(body)))
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet() })
+    const aP = batcher.enqueue({ pieceCid: pieceCidA })
+    const bP = batcher.enqueue({ pieceCid: pieceCidB })
+    const [a, b] = await Promise.all([aP, bP])
+    await batcher.close()
+
+    assert.equal(bodies.length, 1)
+    assert.equal(bodies[0]?.pieces.length, 2)
+    assert.equal(a.txHash, b.txHash)
+  })
+
+  it('should not flush on a timer when wait is limiter', async () => {
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    server.use(addPiecesCaptureHandler((body) => bodies.push(body)))
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    const pending = batcher.enqueue({ pieceCid: pieceCidA })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    assert.equal(bodies.length, 0)
+    assert.equal(batcher.pending.length, 1)
+    await batcher.close()
+    await pending
+    assert.equal(bodies.length, 1)
+  })
+
+  it('should flush the current window when the limiter rejects the next piece', async () => {
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    const hashes = [mockTxHash, mockTxHash2]
+    server.use(
+      ...parkHandlers(),
+      http.post<{ id: string }, addPiecesApiRequest.RequestBody>(
+        `${pdpBase}/pdp/data-sets/:id/pieces`,
+        async ({ request, params }) => {
+          const body = await request.json()
+          bodies.push(body)
+          const txHash = hashes[bodies.length - 1] ?? mockTxHash
+          return new HttpResponse(null, {
+            status: 201,
+            headers: {
+              Location: `/pdp/data-sets/${params.id}/pieces/added/${txHash}`,
+            },
+          })
+        }
+      )
+    )
+
+    const batcher = createPieceBatcher(client, {
+      dataSet: createDataSet(),
+      wait: { kind: 'limiter' },
+      limiter: ({ pieces }) => pieces.length <= 1,
+    })
+    const first = batcher.enqueue({ pieceCid: pieceCidA })
+    const second = batcher.enqueue({ pieceCid: pieceCidB })
+    await batcher.close()
+    const [a, b] = await Promise.all([first, second])
+
+    assert.equal(bodies.length, 2)
+    assert.equal(bodies[0]?.pieces.length, 1)
+    assert.equal(bodies[1]?.pieces.length, 1)
+    assert.equal(a.txHash, mockTxHash)
+    assert.equal(b.txHash, mockTxHash2)
+  })
+
+  it('should mix upload and pull in one window', async () => {
+    const addBodies: addPiecesApiRequest.RequestBody[] = []
+    let pullExtraData: string | undefined
+    server.use(
+      ...parkHandlers(),
+      pullPiecesWithCaptureHandler(
+        createPullResponse('complete', [{ pieceCid: pieceCidB.toString() }]),
+        (req) => {
+          pullExtraData = req.extraData
+        },
+        { baseUrl: pdpBase }
+      ),
+      addPiecesCaptureHandler((body) => addBodies.push(body))
+    )
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    const uploadedP = batcher.upload({ data: new Uint8Array(127).fill(1), pieceCid: pieceCidA })
+    const pulledP = batcher.pull({
+      pieceCid: pieceCidB,
+      sourceUrl: `${pdpBase}/piece/${pieceCidB.toString()}`,
+    })
+    await batcher.close()
+    const [uploaded, pulled] = await Promise.all([uploadedP, pulledP])
+
+    assert.ok(pullExtraData)
+    const pullDecoded = decodeAbiParameters(TypedData.signAddPiecesAbiParameters, pullExtraData as `0x${string}`)
+    assert.equal(pullDecoded[1].length, 1)
+
+    assert.equal(addBodies.length, 1)
+    assert.equal(addBodies[0]?.pieces.length, 2)
+    const flushDecoded = decodeAbiParameters(
+      TypedData.signAddPiecesAbiParameters,
+      addBodies[0]?.extraData as `0x${string}`
+    )
+    assert.equal(flushDecoded[1].length, 2)
+    assert.equal(uploaded.txHash, pulled.txHash)
+  })
+
+  it('should call onParked after park and before addPieces', async () => {
+    const parked: string[] = []
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    let resolveParked: (() => void) | undefined
+    const bothParked = new Promise<void>((resolve) => {
+      resolveParked = () => {
+        resolve()
+      }
+    })
+    server.use(
+      ...parkHandlers(),
+      pullPiecesWithCaptureHandler(
+        createPullResponse('complete', [{ pieceCid: pieceCidB.toString() }]),
+        () => undefined,
+        {
+          baseUrl: pdpBase,
+        }
+      ),
+      addPiecesCaptureHandler((body) => bodies.push(body))
+    )
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    function onParked(prefix: string) {
+      return (piece: EnqueuePiece) => {
+        assert.equal(bodies.length, 0)
+        parked.push(`${prefix}:${piece.pieceCid.toString()}:${piece.metadata?.name}`)
+        if (parked.length === 2) {
+          resolveParked?.()
+        }
+      }
+    }
+    const uploadedP = batcher.upload({
+      data: new Uint8Array(127).fill(1),
+      pieceCid: pieceCidA,
+      metadata: { name: 'a' },
+      onParked: onParked('upload'),
+    })
+    const pulledP = batcher.pull({
+      pieceCid: pieceCidB,
+      sourceUrl: `${pdpBase}/piece/${pieceCidB.toString()}`,
+      metadata: { name: 'b' },
+      onParked: onParked('pull'),
+    })
+    await bothParked
+    assert.equal(bodies.length, 0)
+    assert.deepEqual(parked.sort(), [`pull:${pieceCidB.toString()}:b`, `upload:${pieceCidA.toString()}:a`])
+    await batcher.close()
+    const [uploaded, pulled] = await Promise.all([uploadedP, pulledP])
+    assert.equal(bodies.length, 1)
+    assert.equal(uploaded.txHash, pulled.txHash)
+  })
+
+  it('should not enqueue when onParked throws', async () => {
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    server.use(
+      ...parkHandlers(),
+      addPiecesCaptureHandler((body) => bodies.push(body))
+    )
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    await assert.rejects(
+      () =>
+        batcher.upload({
+          data: new Uint8Array(127).fill(1),
+          pieceCid: pieceCidA,
+          onParked: () => {
+            throw new Error('nope')
+          },
+        }),
+      { message: 'nope' }
+    )
+    await batcher.close()
+    assert.equal(bodies.length, 0)
+  })
+
+  it('should not poison sibling uploads when one park fails', async () => {
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    server.use(
+      http.post<{ uuid: string }, { pieceCid: string }>(`${pdpBase}/pdp/piece/uploads/:uuid`, async ({ request }) => {
+        const body = await request.json()
+        if (body.pieceCid === pieceCidA.toString()) {
+          return HttpResponse.text('boom', { status: 500 })
+        }
+        return HttpResponse.json({ pieceCid: body.pieceCid }, { status: 200 })
+      }),
+      ...parkHandlers(),
+      addPiecesCaptureHandler((body) => bodies.push(body))
+    )
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    const failed = batcher.upload({ data: new Uint8Array(127).fill(1), pieceCid: pieceCidA })
+    const ok = batcher.upload({ data: new Uint8Array(127).fill(2), pieceCid: pieceCidB })
+    await assert.rejects(failed)
+    await batcher.close()
+    const result = await ok
+
+    assert.equal(bodies.length, 1)
+    assert.equal(bodies[0]?.pieces.length, 1)
+    assert.equal(result.pieceCid.toString(), pieceCidB.toString())
+  })
+
+  it('should reject a failed flush as AddPiecesFlushError and allow enqueue retry', async () => {
+    let attempts = 0
+    server.use(
+      http.post<{ id: string }, addPiecesApiRequest.RequestBody>(
+        `${pdpBase}/pdp/data-sets/:id/pieces`,
+        async ({ request, params }) => {
+          attempts++
+          if (attempts === 1) {
+            return HttpResponse.text('nope', { status: 400 })
+          }
+          await request.json()
+          return new HttpResponse(null, {
+            status: 201,
+            headers: {
+              Location: `/pdp/data-sets/${params.id}/pieces/added/${mockTxHash}`,
+            },
+          })
+        }
+      )
+    )
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    const pending = batcher.enqueue({ pieceCid: pieceCidA, metadata: { name: 'a' } })
+    await batcher.flush()
+    const error = await pending.then(
+      () => undefined,
+      (err: unknown) => err
+    )
+    assert.ok(AddPiecesFlushError.is(error))
+    if (!AddPiecesFlushError.is(error)) {
+      return
+    }
+    assert.equal(error.pieceCid.toString(), pieceCidA.toString())
+    assert.equal(error.metadata?.name, 'a')
+
+    const retriedP = batcher.enqueue({ pieceCid: error.pieceCid, metadata: error.metadata })
+    await batcher.close()
+    const retried = await retriedP
+    assert.equal(retried.txHash, mockTxHash)
+    assert.equal(attempts, 2)
+  })
+
+  it('should throw when a piece cannot sit in a batch alone', async () => {
+    const batcher = createPieceBatcher(client, {
+      dataSet: createDataSet(),
+      limiter: () => false,
+    })
+    await assert.rejects(() => batcher.enqueue({ pieceCid: pieceCidA }), ValidationError)
+    await batcher.close()
+  })
+
+  it('should reject upload, pull, and enqueue when PieceCID size is outside Curio upload bounds', async () => {
+    const tooLarge = pieceCidWithRawSize(SIZE_CONSTANTS.MAX_UPLOAD_SIZE + 1)
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    await assert.rejects(() => batcher.enqueue({ pieceCid: tooSmallPieceCid }), InvalidUploadSizeError)
+    await assert.rejects(() => batcher.enqueue({ pieceCid: tooLarge }), InvalidUploadSizeError)
+    await assert.rejects(
+      () => batcher.pull({ pieceCid: tooSmallPieceCid, sourceUrl: `${pdpBase}/piece/${tooSmallPieceCid.toString()}` }),
+      InvalidUploadSizeError
+    )
+    await assert.rejects(
+      () => batcher.upload({ data: new Uint8Array(127).fill(1), pieceCid: tooLarge }),
+      InvalidUploadSizeError
+    )
+    await assert.rejects(
+      () =>
+        batcher.upload({
+          data: new Blob([new Uint8Array(127).fill(1)]).stream(),
+          pieceCid: tooLarge,
+        }),
+      InvalidUploadSizeError
+    )
+    await batcher.close()
+  })
+
+  it('should flush leftover pieces on close and reject further work', async () => {
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    server.use(addPiecesCaptureHandler((body) => bodies.push(body)))
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    const pending = batcher.enqueue({ pieceCid: pieceCidA })
+    await batcher.close()
+    const result = await pending
+    assert.equal(bodies.length, 1)
+    assert.equal(result.pieceCid.toString(), pieceCidA.toString())
+    await assert.rejects(() => batcher.enqueue({ pieceCid: pieceCidB }), ValidationError)
+  })
+
+  it('should create a data set on the first flush then switch to addPieces', async () => {
+    const addBodies: addPiecesApiRequest.RequestBody[] = []
+    server.use(
+      JSONRPC(presets.basic),
+      createAndAddPiecesHandler(mockTxHash, { baseUrl: pdpBase }),
+      dataSetCreationStatusHandler(
+        mockTxHash,
+        {
+          createMessageHash: mockTxHash,
+          dataSetCreated: true,
+          service: 'warm',
+          txStatus: 'confirmed',
+          ok: true,
+          dataSetId: 1,
+        },
+        { baseUrl: pdpBase }
+      ),
+      addPiecesCaptureHandler((body) => addBodies.push(body), mockTxHash2)
+    )
+
+    const batcher = createPieceBatcher(client, {
+      dataSet: undefined,
+      serviceURL: pdpBase,
+      payee: ADDRESSES.payee1,
+      wait: { kind: 'limiter' },
+      limiter: ({ pieces }) => pieces.length <= 1,
+    })
+    const first = batcher.enqueue({ pieceCid: pieceCidA })
+    const second = batcher.enqueue({ pieceCid: pieceCidB })
+    await batcher.close()
+    const [created, added] = await Promise.all([first, second])
+
+    assert.ok(batcher.dataSet)
+    assert.equal(batcher.dataSet?.dataSetId, 1n)
+    assert.equal(created.txHash, mockTxHash)
+    assert.equal(added.txHash, mockTxHash2)
+    assert.equal(addBodies.length, 1)
+  })
+})

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -144,6 +144,19 @@ export class StorageContext {
     return this._dataSetId
   }
 
+  private assertPiecesFitMessage(pieces: Array<{ pieceCid: PieceCID; metadata?: MetadataObject }>): void {
+    SP.assertAddPiecesFit(
+      this._dataSetId
+        ? { kind: 'addPieces', pieces }
+        : {
+            kind: 'createDataSetAndAddPieces',
+            metadata: this._dataSetMetadata,
+            cdn: this._withCDN,
+            pieces,
+          }
+    )
+  }
+
   /**
    * Get the client data set nonce ("clientDataSetId"), either from cache or by fetching from the chain
    * @returns The client data set nonce
@@ -790,7 +803,7 @@ export class StorageContext {
    * @returns Signed extraData hex to pass to pull() or commit()
    */
   async presignForCommit(pieces: Array<{ pieceCid: PieceCID; pieceMetadata?: MetadataObject }>): Promise<Hex> {
-    SP.validateAddPiecesBatch(pieces.length)
+    this.assertPiecesFitMessage(pieces.map((p) => ({ pieceCid: p.pieceCid, metadata: p.pieceMetadata })))
     const signingPieces = pieces.map((p) => ({
       pieceCid: p.pieceCid,
       metadata: pieceMetadataObjectToEntry(p.pieceMetadata),
@@ -828,7 +841,7 @@ export class StorageContext {
 
     // The SP estimateGas-validates the eventual addPieces, so an oversized batch
     // fails there too; reject early for a clear error on non-presigned paths.
-    SP.validateAddPiecesBatch(pieces.length)
+    this.assertPiecesFitMessage(pieces.map((pieceCid) => ({ pieceCid })))
 
     const getSourceUrl = (pieceCid: PieceCID): string => {
       if (typeof from === 'string') {
@@ -912,8 +925,8 @@ export class StorageContext {
   async commit(options: CommitOptions): Promise<CommitResult> {
     const { pieces, extraData } = options
 
-    // Validate batch size and metadata early, before any chain reads or signing
-    SP.validateAddPiecesBatch(pieces.length)
+    // Validate message size and metadata early, before any chain reads or signing
+    this.assertPiecesFitMessage(pieces.map((p) => ({ pieceCid: p.pieceCid, metadata: p.pieceMetadata })))
     for (const piece of pieces) {
       if (piece.pieceMetadata) {
         pieceMetadataObjectToEntry(piece.pieceMetadata)

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -48,6 +48,7 @@ import {
 } from '@filoz/synapse-core/utils'
 import {
   fetchProviderSelectionInput,
+  getPdpDataSet,
   metadataMatches,
   type ResolvedLocation,
   selectProviders,
@@ -80,6 +81,7 @@ import type {
 import { createError, SIZE_CONSTANTS } from '../utils/index.ts'
 import { combineMetadata } from '../utils/metadata.ts'
 import type { WarmStorageService } from '../warm-storage/index.ts'
+import { type BatchedUploadResult, getPieceBatchingService } from './piece-batching.ts'
 import { terminateServiceFlow } from './terminate.ts'
 
 const NO_REMAINING_PROVIDERS_ERROR_MESSAGE = 'No approved service providers available'
@@ -142,6 +144,25 @@ export class StorageContext {
   // Getter for data set ID
   get dataSetId(): bigint | undefined {
     return this._dataSetId
+  }
+
+  /** @internal Synchronize state after a shared piece batcher creates or resolves a data set. */
+  syncBatcherDataSet(dataSetId: bigint, clientDataSetId: bigint): void {
+    this._dataSetId = dataSetId
+    this._clientDataSetId = clientDataSetId
+  }
+
+  /** @internal Resolve the minimal data-set state required by a piece batcher. */
+  async getBatcherDataSet(): Promise<SP.PieceBatcher['dataSet']> {
+    if (this._dataSetId == null) {
+      return undefined
+    }
+    const dataSet = await getPdpDataSet(this._readClient, { dataSetId: this._dataSetId })
+    if (dataSet == null) {
+      throw createError('StorageContext', 'getBatcherDataSet', 'Data set not found')
+    }
+    this._clientDataSetId = dataSet.clientDataSetId
+    return dataSet
   }
 
   private assertPiecesFitMessage(pieces: Array<{ pieceCid: PieceCID; metadata?: MetadataObject }>): void {
@@ -1021,6 +1042,57 @@ export class StorageContext {
    * @returns Upload result with pieceCid, size, and a single-element copies array
    */
   async upload(data: UploadPieceStreamingData, options?: UploadOptions): Promise<UploadResult> {
+    const batching = getPieceBatchingService(this._synapse)
+    if (batching != null) {
+      let parked = false
+      const task = batching.upload(this, {
+        data,
+        pieceCid: options?.pieceCid,
+        metadata: options?.pieceMetadata,
+        signal: options?.signal,
+        onProgress: options?.onProgress,
+        onParked: (piece) => {
+          parked = true
+          options?.onStored?.(this._provider.id, piece.pieceCid)
+        },
+        onSubmitted: (submitted) =>
+          options?.onPiecesAdded?.(submitted.txHash, this._provider.id, [{ pieceCid: submitted.pieceCid }]),
+      })
+
+      let result: BatchedUploadResult
+      try {
+        result = await task.committed
+      } catch (error) {
+        throw createError(
+          'StorageContext',
+          parked ? 'commit' : 'store',
+          parked ? 'Failed to commit pieces on-chain' : 'Failed to store piece on service provider',
+          error
+        )
+      }
+
+      options?.onPiecesConfirmed?.(result.dataSetId, this._provider.id, [
+        { pieceId: result.pieceId, pieceCid: result.pieceCid },
+      ])
+      return {
+        pieceCid: result.pieceCid,
+        size: result.size,
+        requestedCopies: 1,
+        complete: true,
+        copies: [
+          {
+            providerId: this._provider.id,
+            dataSetId: result.dataSetId,
+            pieceId: result.pieceId,
+            role: 'primary',
+            retrievalUrl: this.getPieceUrl(result.pieceCid),
+            isNewDataSet: result.isNewDataSet,
+          },
+        ],
+        failedAttempts: [],
+      }
+    }
+
     // Store phase
     const storeResult = await this.store(data, {
       pieceCid: options?.pieceCid,

--- a/packages/synapse-sdk/src/storage/manager.ts
+++ b/packages/synapse-sdk/src/storage/manager.ts
@@ -70,6 +70,12 @@ import type {
 import { combineMetadata, createError, SIZE_CONSTANTS, TIME_CONSTANTS } from '../utils/index.ts'
 import type { WarmStorageService } from '../warm-storage/index.ts'
 import { StorageContext } from './context.ts'
+import {
+  type BatchedCommitResult,
+  type BatchingHold,
+  getPieceBatchingService,
+  type PieceBatchingService,
+} from './piece-batching.ts'
 import { terminateServiceFlow } from './terminate.ts'
 
 // Multi-copy upload constants
@@ -192,9 +198,14 @@ export class StorageManager {
    * to determine overall success. Don't use `failedAttempts.length` as a failure
    * signal as `failedAttempts` exists as a diagnostic for intermediate failures.
    *
+   * Batching is enabled by default. Compatible concurrent calls can share
+   * on-chain transactions, while sequentially awaiting each call prevents those
+   * uploads from joining the same batch.
+   *
    * For large files, prefer streaming to minimize memory usage.
    *
-   * For uploading multiple files, use the split operations API directly:
+   * For manual control over providers, signing, or individual phases, use the
+   * split operations API directly:
    * createContexts() -> store() -> presignForCommit() -> pull() -> commit()
    *
    * @param data - Raw bytes (Uint8Array) or ReadableStream to upload
@@ -204,6 +215,11 @@ export class StorageManager {
    * @throws CommitError if all commit attempts fail (data stored but not on-chain)
    */
   async upload(data: UploadPieceStreamingData, options?: StorageManagerUploadOptions): Promise<UploadResult> {
+    const batching = getPieceBatchingService(this._synapse)
+    if (batching != null) {
+      return this._uploadBatched(data, options, batching, batching.hold())
+    }
+
     const { contexts, explicitProviders } = await this._resolveUploadContexts(options)
     const [primary, ...secondaries] = contexts
 
@@ -379,6 +395,259 @@ export class StorageManager {
       copies,
       failedAttempts,
     }
+  }
+
+  /**
+   * Submit all piece-batch windows currently accepted by this Synapse instance.
+   *
+   * Waits for in-progress uploads and pulls to finish parking before submitting
+   * their pending windows. Resolving does not mean every upload was submitted or
+   * confirmed successfully; failures are reported by the individual upload
+   * promises, which callers must also await. This is a no-op when batching is
+   * disabled.
+   */
+  async flush(): Promise<void> {
+    await getPieceBatchingService(this._synapse)?.flush()
+  }
+
+  private async _uploadBatched(
+    data: UploadPieceStreamingData,
+    options: StorageManagerUploadOptions | undefined,
+    batching: PieceBatchingService,
+    hold: BatchingHold
+  ): Promise<UploadResult> {
+    let resolved: { contexts: StorageContext[]; explicitProviders: boolean }
+    try {
+      resolved = await this._resolveUploadContexts(options)
+    } catch (error) {
+      hold.release()
+      throw error
+    }
+    const { contexts, explicitProviders } = resolved
+    const [primary, ...secondaries] = contexts
+    const usedProviderIds = new Set(contexts.map((context) => context.provider.id))
+    const failedAttempts: FailedAttempt[] = []
+    const secondaryOperations: Array<{ context: StorageContext; committed: Promise<BatchedCommitResult> }> = []
+    let primaryParked = false
+    let storedPieceCid: PieceCID | undefined
+    let storedSize: number | undefined
+
+    const primaryTask = batching.upload(primary, {
+      data,
+      pieceCid: options?.pieceCid,
+      metadata: options?.pieceMetadata,
+      signal: options?.signal,
+      onProgress: options?.callbacks?.onProgress,
+      onSubmitted: (submitted) =>
+        safeInvoke(options?.callbacks?.onPiecesAdded, submitted.txHash, primary.provider.id, [
+          { pieceCid: submitted.pieceCid },
+        ]),
+      onParked: async (piece) => {
+        primaryParked = true
+        storedPieceCid = piece.pieceCid
+        storedSize = piece.size
+        safeInvoke(options?.callbacks?.onStored, primary.provider.id, piece.pieceCid)
+
+        for (const secondary of secondaries) {
+          const outcome = await this._parkBatchedSecondary(primary, secondary, piece.pieceCid, {
+            batching,
+            explicitProviders,
+            usedProviderIds,
+            failedAttempts,
+            signal: options?.signal,
+            withCDN: options?.withCDN,
+            metadata: options?.metadata,
+            pieceMetadata: options?.pieceMetadata,
+            callbacks: options?.callbacks,
+          })
+          if (outcome != null) {
+            secondaryOperations.push(outcome)
+          }
+        }
+      },
+    })
+    hold.release()
+
+    let primaryResult: BatchedCommitResult | undefined
+    let primaryError: Error | undefined
+    try {
+      primaryResult = await primaryTask.committed
+    } catch (error) {
+      if (error instanceof UserRejectedRequestError) {
+        throw error
+      }
+      if (!primaryParked) {
+        throw new StoreError(
+          `Failed to store piece on service provider ${primary.provider.id} (${primary.provider.pdp.serviceURL})`,
+          {
+            cause: error instanceof Error ? error : undefined,
+            providerId: primary.provider.id,
+            endpoint: primary.provider.pdp.serviceURL,
+          }
+        )
+      }
+      primaryError = error instanceof Error ? error : new Error(String(error))
+    }
+
+    const secondarySettled = await Promise.allSettled(
+      secondaryOperations.map(async (operation) => ({
+        context: operation.context,
+        result: await operation.committed,
+      }))
+    )
+
+    const copies: CopyResult[] = []
+    if (primaryResult == null) {
+      failedAttempts.push({
+        providerId: primary.provider.id,
+        role: 'primary',
+        error: 'Commit failed',
+        explicit: explicitProviders,
+      })
+    } else {
+      copies.push({
+        providerId: primary.provider.id,
+        dataSetId: primaryResult.dataSetId,
+        pieceId: primaryResult.pieceId,
+        role: 'primary',
+        retrievalUrl: primary.getPieceUrl(primaryResult.pieceCid),
+        isNewDataSet: primaryResult.isNewDataSet,
+      })
+      safeInvoke(options?.callbacks?.onPiecesConfirmed, primaryResult.dataSetId, primary.provider.id, [
+        { pieceId: primaryResult.pieceId, pieceCid: primaryResult.pieceCid },
+      ])
+    }
+
+    for (const [index, settled] of secondarySettled.entries()) {
+      const operation = secondaryOperations[index]
+      if (settled.status === 'fulfilled') {
+        const { context, result } = settled.value
+        copies.push({
+          providerId: context.provider.id,
+          dataSetId: result.dataSetId,
+          pieceId: result.pieceId,
+          role: 'secondary',
+          retrievalUrl: context.getPieceUrl(result.pieceCid),
+          isNewDataSet: result.isNewDataSet,
+        })
+        safeInvoke(options?.callbacks?.onPiecesConfirmed, result.dataSetId, context.provider.id, [
+          { pieceId: result.pieceId, pieceCid: result.pieceCid },
+        ])
+      } else {
+        failedAttempts.push({
+          providerId: operation.context.provider.id,
+          role: 'secondary',
+          error: 'Commit failed',
+          explicit: explicitProviders,
+        })
+      }
+    }
+
+    if (copies.length === 0) {
+      throw new CommitError(
+        `Failed to commit on primary provider ${primary.provider.id} (${primary.provider.pdp.serviceURL}) - data is stored but not on-chain`,
+        {
+          cause: primaryError,
+          providerId: primary.provider.id,
+          endpoint: primary.provider.pdp.serviceURL,
+        }
+      )
+    }
+    if (storedPieceCid == null || storedSize == null) {
+      throw createError('StorageManager', 'upload', 'Primary upload completed without parked piece information')
+    }
+
+    return {
+      pieceCid: storedPieceCid,
+      size: storedSize,
+      requestedCopies: contexts.length,
+      complete: copies.length >= contexts.length,
+      copies,
+      failedAttempts,
+    }
+  }
+
+  private async _parkBatchedSecondary(
+    primary: StorageContext,
+    initialSecondary: StorageContext,
+    pieceCid: PieceCID,
+    options: {
+      batching: PieceBatchingService
+      explicitProviders: boolean
+      usedProviderIds: Set<bigint>
+      failedAttempts: FailedAttempt[]
+      signal?: AbortSignal
+      withCDN?: boolean
+      metadata?: Record<string, string>
+      pieceMetadata?: Record<string, string>
+      callbacks?: Partial<CombinedCallbacks>
+    }
+  ): Promise<{ context: StorageContext; committed: Promise<BatchedCommitResult> } | undefined> {
+    let context = initialSecondary
+    let attempts = 0
+
+    while (attempts < MAX_SECONDARY_ATTEMPTS) {
+      const providerId = context.provider.id
+      const task = options.batching.pull(context, {
+        pieceCid,
+        sourceUrl: primary.getPieceUrl(pieceCid),
+        metadata: options.pieceMetadata,
+        signal: options.signal,
+        onStatus: (response) => {
+          const status = response.pieces.find((piece) => piece.pieceCid === pieceCid.toString())?.status
+          if (status != null) {
+            safeInvoke(options.callbacks?.onPullProgress, providerId, pieceCid, status)
+          }
+        },
+        onParked: () => safeInvoke(options.callbacks?.onCopyComplete, providerId, pieceCid),
+        onSubmitted: (submitted) =>
+          safeInvoke(options.callbacks?.onPiecesAdded, submitted.txHash, providerId, [
+            { pieceCid: submitted.pieceCid },
+          ]),
+      })
+
+      try {
+        await task.parked
+        return { context, committed: task.committed }
+      } catch (error) {
+        void task.committed.catch(() => undefined)
+        if (error instanceof UserRejectedRequestError) {
+          throw error
+        }
+        const message = error instanceof Error ? error.message : String(error)
+        options.failedAttempts.push({
+          providerId,
+          role: 'secondary',
+          error: message,
+          explicit: options.explicitProviders,
+        })
+        safeInvoke(
+          options.callbacks?.onCopyFailed,
+          providerId,
+          pieceCid,
+          error instanceof Error ? error : new Error(message)
+        )
+      }
+
+      attempts++
+      if (options.explicitProviders || attempts >= MAX_SECONDARY_ATTEMPTS) {
+        break
+      }
+      try {
+        const [replacement] = await this.createContexts({
+          withCDN: options.withCDN,
+          copies: 1,
+          metadata: options.metadata,
+          callbacks: options.callbacks,
+          excludeProviderIds: [...options.usedProviderIds],
+        })
+        context = replacement
+        options.usedProviderIds.add(replacement.provider.id)
+      } catch {
+        break
+      }
+    }
+    return undefined
   }
 
   /**

--- a/packages/synapse-sdk/src/storage/piece-batching.ts
+++ b/packages/synapse-sdk/src/storage/piece-batching.ts
@@ -1,0 +1,251 @@
+import * as SP from '@filoz/synapse-core/sp'
+import type { Hex } from 'viem'
+import type { Synapse } from '../synapse.ts'
+import type { PieceBatchingOptions, PieceCID } from '../types.ts'
+import type { StorageContext } from './context.ts'
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+}
+
+export type BatchedCommitResult = {
+  pieceCid: PieceCID
+  txHash: Hex
+  confirmedTxHash?: Hex
+  dataSetId: bigint
+  pieceId: bigint
+  isNewDataSet: boolean
+}
+
+export type BatchedUploadResult = BatchedCommitResult & {
+  size: number
+}
+
+export type BatchedTask<T> = {
+  parked: Promise<SP.EnqueuePiece>
+  committed: Promise<T>
+}
+
+export type BatchingHold = {
+  release: () => void
+}
+
+type Entry = {
+  batcher: SP.PieceBatcher
+  providerId: bigint
+  contexts: Set<StorageContext>
+  confirmations: Map<string, Promise<SP.waitForAddPieces.OutputType>>
+}
+
+type TaskCallbacks = {
+  onParked?: SP.OnParked
+  onSubmitted?: (result: SP.PieceResult) => void
+}
+
+export type UploadTaskInput = Omit<SP.UploadInput, 'onParked'> & TaskCallbacks
+export type PullTaskInput = Omit<SP.PullInput, 'onParked'> & TaskCallbacks
+
+const services = new WeakMap<Synapse, PieceBatchingService>()
+
+export function registerPieceBatchingService(synapse: Synapse, service: PieceBatchingService): void {
+  services.set(synapse, service)
+}
+
+export function getPieceBatchingService(synapse: Synapse): PieceBatchingService | undefined {
+  return services.get(synapse)
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => undefined
+  let reject: (error: unknown) => void = () => undefined
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function metadataKey(metadata: Record<string, string>): string {
+  return JSON.stringify(Object.entries(metadata).sort(([a], [b]) => a.localeCompare(b)))
+}
+
+export class PieceBatchingService {
+  private readonly synapse: Synapse
+  private readonly options: PieceBatchingOptions
+  private readonly entries = new Map<string, Promise<Entry>>()
+  private readonly pendingReady = new Set<Promise<void>>()
+
+  constructor(synapse: Synapse, options: PieceBatchingOptions) {
+    this.synapse = synapse
+    this.options = options
+  }
+
+  upload(context: StorageContext, input: UploadTaskInput): BatchedTask<BatchedUploadResult> {
+    return this.task(context, input, async (entry, onParked) => {
+      const { onSubmitted, ...batchInput } = input
+      const result = await entry.batcher.upload({ ...batchInput, onParked })
+      onSubmitted?.(result)
+      const committed = await this.confirm(entry, result)
+      return { ...committed, size: result.size }
+    })
+  }
+
+  pull(context: StorageContext, input: PullTaskInput): BatchedTask<BatchedCommitResult> {
+    return this.task(context, input, async (entry, onParked) => {
+      const { onSubmitted, ...batchInput } = input
+      const result = await entry.batcher.pull({ ...batchInput, onParked })
+      onSubmitted?.(result)
+      return this.confirm(entry, result)
+    })
+  }
+
+  hold(): BatchingHold {
+    const ready = deferred<void>()
+    this.trackReady(ready)
+    return { release: () => ready.resolve() }
+  }
+
+  async flush(): Promise<void> {
+    while (this.pendingReady.size > 0) {
+      await Promise.allSettled([...this.pendingReady])
+    }
+    const entries = await Promise.allSettled([...new Set(this.entries.values())])
+    await Promise.all(entries.flatMap((entry) => (entry.status === 'fulfilled' ? [entry.value.batcher.flush()] : [])))
+  }
+
+  private task<T>(
+    context: StorageContext,
+    input: TaskCallbacks,
+    run: (entry: Entry, onParked: SP.OnParked) => Promise<T>
+  ): BatchedTask<T> {
+    const parked = deferred<SP.EnqueuePiece>()
+    void parked.promise.catch(() => undefined)
+    const ready = deferred<void>()
+    this.trackReady(ready)
+
+    let didPark = false
+    const committed = (async () => {
+      try {
+        const entry = await this.entry(context)
+        return await run(entry, async (piece) => {
+          didPark = true
+          parked.resolve(piece)
+          try {
+            await input.onParked?.(piece)
+          } finally {
+            ready.resolve()
+          }
+        })
+      } catch (error) {
+        if (!didPark) {
+          parked.reject(error)
+          ready.resolve()
+        }
+        throw error
+      }
+    })()
+    void committed.catch(() => undefined)
+
+    return { parked: parked.promise, committed }
+  }
+
+  private trackReady(ready: Deferred<void>): void {
+    this.pendingReady.add(ready.promise)
+    void ready.promise.finally(() => {
+      this.pendingReady.delete(ready.promise)
+    })
+  }
+
+  private entry(context: StorageContext): Promise<Entry> {
+    const key = this.key(context)
+    const existing = this.entries.get(key)
+    if (existing != null) {
+      return existing.then((entry) => {
+        const dataSet = entry.batcher.dataSet
+        if (dataSet == null) {
+          entry.contexts.add(context)
+        } else {
+          context.syncBatcherDataSet(dataSet.dataSetId, dataSet.clientDataSetId)
+        }
+        return entry
+      })
+    }
+
+    const created = this.createEntry(context)
+    this.entries.set(key, created)
+    void created.catch(() => {
+      if (this.entries.get(key) === created) {
+        this.entries.delete(key)
+      }
+    })
+    return created
+  }
+
+  private async createEntry(context: StorageContext): Promise<Entry> {
+    const dataSet = await context.getBatcherDataSet()
+
+    return {
+      batcher: SP.createPieceBatcher(this.synapse.sessionClient ?? this.synapse.client, {
+        dataSet,
+        wait: this.options.wait,
+        serviceURL: context.provider.pdp.serviceURL,
+        payee: context.provider.serviceProvider,
+        payer: this.synapse.client.account.address,
+        metadata: context.dataSetMetadata,
+        cdn: context.withCDN,
+      }),
+      providerId: context.provider.id,
+      contexts: dataSet == null ? new Set([context]) : new Set(),
+      confirmations: new Map(),
+    }
+  }
+
+  private async confirm(entry: Entry, result: SP.PieceResult): Promise<BatchedCommitResult> {
+    const dataSet = entry.batcher.dataSet
+    if (dataSet != null) {
+      for (const context of entry.contexts) {
+        context.syncBatcherDataSet(dataSet.dataSetId, dataSet.clientDataSetId)
+      }
+      entry.contexts.clear()
+      this.entries.set(this.existingKey(entry.providerId, dataSet.dataSetId), Promise.resolve(entry))
+    }
+
+    let confirmation = entry.confirmations.get(result.statusUrl)
+    if (confirmation == null) {
+      confirmation = SP.waitForAddPieces({ statusUrl: result.statusUrl })
+      entry.confirmations.set(result.statusUrl, confirmation)
+      void confirmation.then(
+        () => entry.confirmations.delete(result.statusUrl),
+        () => entry.confirmations.delete(result.statusUrl)
+      )
+    }
+    const confirmed = await confirmation
+    const pieceId = confirmed.confirmedPieceIds[result.batchIndex]
+    if (pieceId == null) {
+      throw new Error(`Provider confirmed no piece ID at batch index ${result.batchIndex}`)
+    }
+
+    const confirmedTxHash = result.confirmedTxHash ?? confirmed.confirmedTxHash
+    return {
+      pieceCid: result.pieceCid,
+      txHash: result.txHash,
+      ...(confirmedTxHash == null ? {} : { confirmedTxHash }),
+      dataSetId: result.dataSetId,
+      pieceId,
+      isNewDataSet: result.isNewDataSet,
+    }
+  }
+
+  private key(context: StorageContext): string {
+    if (context.dataSetId != null) {
+      return this.existingKey(context.provider.id, context.dataSetId)
+    }
+    return `new:${context.provider.id}:${context.withCDN}:${metadataKey(context.dataSetMetadata)}`
+  }
+
+  private existingKey(providerId: bigint, dataSetId: bigint): string {
+    return `existing:${providerId}:${dataSetId}`
+  }
+}

--- a/packages/synapse-sdk/src/synapse.ts
+++ b/packages/synapse-sdk/src/synapse.ts
@@ -16,6 +16,7 @@ import { FilBeamService } from './filbeam/index.ts'
 import { PaymentsService } from './payments/index.ts'
 import { SPRegistryService } from './sp-registry/index.ts'
 import { StorageManager } from './storage/manager.ts'
+import { PieceBatchingService, registerPieceBatchingService } from './storage/piece-batching.ts'
 import type { PDPProvider, SynapseFromClientOptions, SynapseOptions } from './types.ts'
 import { DEFAULT_CHAIN } from './utils/constants.ts'
 import { WarmStorageService } from './warm-storage/index.ts'
@@ -84,6 +85,7 @@ export class Synapse {
       withCDN: options.withCDN,
       source: options.source,
       sessionClient: options.sessionKey?.client,
+      pieceBatching: options.pieceBatching,
     })
   }
 
@@ -100,6 +102,10 @@ export class Synapse {
     this._filbeamService = new FilBeamService(this._chain)
     this._warmStorageService = new WarmStorageService({ client: this._client, readClient: this._readClient })
     this._payments = new PaymentsService({ client: this._client })
+
+    if (options.pieceBatching !== false) {
+      registerPieceBatchingService(this, new PieceBatchingService(this, options.pieceBatching ?? {}))
+    }
 
     // Initialize StorageManager
     this._storageManager = new StorageManager({

--- a/packages/synapse-sdk/src/test/session-keys.test.ts
+++ b/packages/synapse-sdk/src/test/session-keys.test.ts
@@ -45,6 +45,7 @@ describe('Synapse', () => {
     })
 
     it('should create dataset with session key', async () => {
+      let createdClientDataSetId = 0n
       server.use(
         Mocks.JSONRPC({
           ...Mocks.presets.basic,
@@ -52,6 +53,39 @@ describe('Synapse', () => {
           warmStorageView: {
             ...Mocks.presets.basic.warmStorageView,
             getApprovedProviders: () => [[1n]],
+            getDataSet: ([dataSetId]) => [
+              dataSetId === 123n
+                ? {
+                    cacheMissRailId: 0n,
+                    cdnRailId: 0n,
+                    clientDataSetId: createdClientDataSetId,
+                    commissionBps: 100n,
+                    dataSetId,
+                    payee: Mocks.ADDRESSES.serviceProvider1,
+                    payer: Mocks.ADDRESSES.client1,
+                    pdpEndEpoch: 0n,
+                    pdpRailId: 1n,
+                    providerId: 1n,
+                    pendingOneTimePayments: 0n,
+                    lifecycleReserveBalance: 0n,
+                    serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                  }
+                : {
+                    cacheMissRailId: 0n,
+                    cdnRailId: 0n,
+                    clientDataSetId: 0n,
+                    commissionBps: 0n,
+                    dataSetId,
+                    payee: Mocks.ADDRESSES.zero,
+                    payer: Mocks.ADDRESSES.zero,
+                    pdpEndEpoch: 0n,
+                    pdpRailId: 0n,
+                    providerId: 0n,
+                    pendingOneTimePayments: 0n,
+                    lifecycleReserveBalance: 0n,
+                    serviceProvider: Mocks.ADDRESSES.zero,
+                  },
+            ],
           },
         }),
         ...Mocks.pdp.streamingUploadHandlers(),
@@ -80,6 +114,7 @@ describe('Synapse', () => {
 
           const actualPayer = createDataSetDecoded[0]
           const clientDataSetId = createDataSetDecoded[1]
+          createdClientDataSetId = clientDataSetId
           const signature = createDataSetDecoded[4]
 
           const actualSigner = await recoverTypedDataAddress({
@@ -199,7 +234,7 @@ describe('Synapse', () => {
         privateKey: Mocks.PRIVATE_KEYS.key2,
         root: client.account,
       })
-      const synapse = new Synapse({ client, source: null, sessionClient: sessionKey.client })
+      const synapse = new Synapse({ client, source: null, sessionClient: sessionKey.client, pieceBatching: false })
       const firstData = new Uint8Array(127).fill(1) // 127 bytes
       const context = await synapse.storage.getDefaultContext()
       const result = await context.upload(firstData)

--- a/packages/synapse-sdk/src/test/storage-upload.test.ts
+++ b/packages/synapse-sdk/src/test/storage-upload.test.ts
@@ -58,13 +58,11 @@ describe('Storage Upload', () => {
       http.get<{ id: string; txHash: string }>(
         `https://pdp.example.com/pdp/data-sets/:id/pieces/added/:txHash`,
         ({ params }) => {
-          // Extract the piece ID from the last character of the txHash
-          const pieceId = Number.parseInt(params.txHash.slice(-1), 10)
           const response = {
             addMessageOk: true,
-            confirmedPieceIds: [pieceId],
+            confirmedPieceIds: [0, 1, 2],
             dataSetId: parseInt(params.id, 10),
-            pieceCount: 1,
+            pieceCount: 3,
             piecesAdded: true,
             txHash: params.txHash,
             txStatus: 'confirmed',
@@ -153,7 +151,7 @@ describe('Storage Upload', () => {
         }
       )
     )
-    const synapse = new Synapse({ client, source: null })
+    const synapse = new Synapse({ client, source: null, pieceBatching: false })
     const context = await synapse.storage.createContext({
       withCDN: true,
       metadata: {
@@ -179,6 +177,98 @@ describe('Storage Upload', () => {
       [...resultPieceIds].sort((a, b) => Number(a - b)),
       [0n, 1n, 2n],
       'The set of assigned piece IDs should be {0, 1, 2}'
+    )
+  })
+
+  it('should expose flush for limiter-based batching', async () => {
+    let addPiecesCalls = 0
+    const txHash = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef123456'
+    server.use(
+      Mocks.JSONRPC({
+        ...Mocks.presets.basic,
+        debug: false,
+        warmStorageView: {
+          ...Mocks.presets.basic.warmStorageView,
+          getDataSet: ([dataSetId]) => [
+            dataSetId === 123n
+              ? {
+                  cacheMissRailId: 0n,
+                  cdnRailId: 0n,
+                  clientDataSetId: 0n,
+                  commissionBps: 100n,
+                  dataSetId,
+                  payee: Mocks.ADDRESSES.serviceProvider1,
+                  payer: Mocks.ADDRESSES.client1,
+                  pdpEndEpoch: 0n,
+                  pdpRailId: 1n,
+                  providerId: 1n,
+                  pendingOneTimePayments: 0n,
+                  lifecycleReserveBalance: 0n,
+                  serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                }
+              : {
+                  cacheMissRailId: 0n,
+                  cdnRailId: 0n,
+                  clientDataSetId: 0n,
+                  commissionBps: 0n,
+                  dataSetId,
+                  payee: Mocks.ADDRESSES.zero,
+                  payer: Mocks.ADDRESSES.zero,
+                  pdpEndEpoch: 0n,
+                  pdpRailId: 0n,
+                  providerId: 0n,
+                  pendingOneTimePayments: 0n,
+                  lifecycleReserveBalance: 0n,
+                  serviceProvider: Mocks.ADDRESSES.zero,
+                },
+          ],
+        },
+      }),
+      Mocks.PING(),
+      ...Mocks.pdp.streamingUploadHandlers(),
+      Mocks.pdp.findAnyPieceHandler(true),
+      http.post(`https://pdp.example.com/pdp/data-sets/create-and-add`, () => {
+        addPiecesCalls++
+        return new HttpResponse(null, {
+          status: 201,
+          headers: {
+            Location: `/pdp/data-sets/created/${txHash}`,
+          },
+        })
+      }),
+      Mocks.pdp.dataSetCreationStatusHandler(txHash, {
+        createMessageHash: txHash,
+        dataSetCreated: true,
+        service: 'test-service',
+        txStatus: 'confirmed',
+        ok: true,
+        dataSetId: 123,
+      }),
+      Mocks.pdp.pieceAdditionStatusHandler(123, txHash, {
+        addMessageOk: true,
+        confirmedPieceIds: [10, 11],
+        dataSetId: 123,
+        pieceCount: 2,
+        piecesAdded: true,
+        txHash,
+        txStatus: 'confirmed',
+      })
+    )
+    const synapse = new Synapse({
+      client,
+      source: null,
+      pieceBatching: { wait: { kind: 'limiter' } },
+    })
+    const context = await synapse.storage.createContext({ withCDN: true })
+
+    const uploads = [context.upload(new Uint8Array(127).fill(1)), context.upload(new Uint8Array(128).fill(2))]
+    await synapse.storage.flush()
+    const results = await Promise.all(uploads)
+
+    assert.strictEqual(addPiecesCalls, 1, 'flush should submit both parked pieces in one batch')
+    assert.deepEqual(
+      results.map((result) => result.copies[0].pieceId),
+      [10n, 11n]
     )
   })
 

--- a/packages/synapse-sdk/src/test/storage.test.ts
+++ b/packages/synapse-sdk/src/test/storage.test.ts
@@ -1,10 +1,10 @@
 import type { AccountClient } from '@filoz/synapse-core'
 import { calibration } from '@filoz/synapse-core/chains'
-import { TooManyPiecesError } from '@filoz/synapse-core/errors'
+import { AddPiecesBatchTooLargeError } from '@filoz/synapse-core/errors'
 import * as Mocks from '@filoz/synapse-core/mocks'
 import * as Piece from '@filoz/synapse-core/piece'
 import { calculate, calculate as calculatePieceCID } from '@filoz/synapse-core/piece'
-import { NetworkError } from '@filoz/synapse-core/sp'
+import { addPiecesFits, NetworkError } from '@filoz/synapse-core/sp'
 import { assert } from 'chai'
 import { setup } from 'iso-web/msw'
 import { HttpResponse, http } from 'msw'
@@ -1170,8 +1170,27 @@ describe('StorageService', () => {
     })
   })
 
-  describe('addPieces batch limit', () => {
-    const tooMany = SIZE_CONSTANTS.MAX_ADD_PIECES_BATCH_SIZE + 1
+  describe('addPieces message size', () => {
+    const maxMetadata = {
+      aaa: 'x'.repeat(96),
+      bbb: 'y'.repeat(96),
+      ccc: 'z'.repeat(96),
+    }
+
+    function oversizedPieces(pieceCid: Piece.PieceCID) {
+      const next = { pieceCid, pieceMetadata: maxMetadata }
+      const pieces = [next]
+      while (
+        addPiecesFits({
+          kind: 'addPieces',
+          pieces: [...pieces, { pieceCid, metadata: maxMetadata }],
+        })
+      ) {
+        pieces.push(next)
+      }
+      pieces.push(next)
+      return pieces
+    }
 
     async function makeContext() {
       server.use(Mocks.JSONRPC({ ...Mocks.presets.basic }), Mocks.PING())
@@ -1180,39 +1199,42 @@ describe('StorageService', () => {
       return StorageContext.create({ synapse, warmStorageService })
     }
 
-    it('presignForCommit rejects batches above the limit', async () => {
+    it('presignForCommit rejects batches that exceed the message budget', async () => {
       const service = await makeContext()
       const pieceCid = await calculate(new Uint8Array(127).fill(1))
-      const pieces = Array.from({ length: tooMany }, () => ({ pieceCid }))
       try {
-        await service.presignForCommit(pieces)
+        await service.presignForCommit(oversizedPieces(pieceCid))
         assert.fail('Should have thrown')
       } catch (error) {
-        assert.instanceOf(error, TooManyPiecesError)
+        assert.instanceOf(error, AddPiecesBatchTooLargeError)
       }
     })
 
-    it('commit rejects batches above the limit', async () => {
+    it('commit rejects batches that exceed the message budget', async () => {
       const service = await makeContext()
       const pieceCid = await calculate(new Uint8Array(127).fill(1))
-      const pieces = Array.from({ length: tooMany }, () => ({ pieceCid }))
       try {
-        await service.commit({ pieces })
+        await service.commit({ pieces: oversizedPieces(pieceCid) })
         assert.fail('Should have thrown')
       } catch (error) {
-        assert.instanceOf(error, TooManyPiecesError)
+        assert.instanceOf(error, AddPiecesBatchTooLargeError)
       }
     })
 
-    it('pull rejects batches above the limit', async () => {
+    it('pull rejects batches that exceed the message budget', async () => {
       const service = await makeContext()
       const pieceCid = await calculate(new Uint8Array(127).fill(1))
-      const pieces = Array.from({ length: tooMany }, () => pieceCid)
+      const next = { pieceCid }
+      const limiterPieces = [next]
+      while (addPiecesFits({ kind: 'addPieces', pieces: [...limiterPieces, next] })) {
+        limiterPieces.push(next)
+      }
+      limiterPieces.push(next)
       try {
-        await service.pull({ pieces, from: 'https://pdp.example.com' })
+        await service.pull({ pieces: limiterPieces.map((p) => p.pieceCid), from: 'https://pdp.example.com' })
         assert.fail('Should have thrown')
       } catch (error) {
-        assert.instanceOf(error, TooManyPiecesError)
+        assert.instanceOf(error, AddPiecesBatchTooLargeError)
       }
     })
   })

--- a/packages/synapse-sdk/src/test/synapse.test.ts
+++ b/packages/synapse-sdk/src/test/synapse.test.ts
@@ -816,6 +816,51 @@ describe('Synapse', () => {
       const FAKE_TX_HASH = '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
       const DATA_SET_ID = 7
       beforeEach(async () => {
+        server.use(
+          Mocks.JSONRPC({
+            ...Mocks.presets.basic,
+            serviceRegistry: Mocks.mockServiceProviderRegistry([Mocks.PROVIDERS.provider1, Mocks.PROVIDERS.provider2]),
+            endorsements: {
+              getProviderIds: () => [endorsedProviderIds],
+            },
+            warmStorageView: {
+              ...Mocks.presets.basic.warmStorageView,
+              getDataSet: ([dataSetId]) => [
+                dataSetId === BigInt(DATA_SET_ID)
+                  ? {
+                      cacheMissRailId: 0n,
+                      cdnRailId: 0n,
+                      clientDataSetId: 0n,
+                      commissionBps: 100n,
+                      dataSetId,
+                      payee: Mocks.ADDRESSES.serviceProvider1,
+                      payer: Mocks.ADDRESSES.client1,
+                      pdpEndEpoch: 0n,
+                      pdpRailId: 1n,
+                      providerId: 1n,
+                      pendingOneTimePayments: 0n,
+                      lifecycleReserveBalance: 0n,
+                      serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                    }
+                  : {
+                      cacheMissRailId: 0n,
+                      cdnRailId: 0n,
+                      clientDataSetId: 0n,
+                      commissionBps: 0n,
+                      dataSetId,
+                      payee: Mocks.ADDRESSES.zero,
+                      payer: Mocks.ADDRESSES.zero,
+                      pdpEndEpoch: 0n,
+                      pdpRailId: 0n,
+                      providerId: 0n,
+                      pendingOneTimePayments: 0n,
+                      lifecycleReserveBalance: 0n,
+                      serviceProvider: Mocks.ADDRESSES.zero,
+                    },
+              ],
+            },
+          })
+        )
         contexts = await synapse.storage.createContexts({
           providerIds: [1n, 2n],
         })

--- a/packages/synapse-sdk/src/types.ts
+++ b/packages/synapse-sdk/src/types.ts
@@ -8,7 +8,7 @@
 import type { FilecoinChain } from '@filoz/synapse-core/chains'
 import type { PieceCID } from '@filoz/synapse-core/piece'
 import type { Permission, SessionKey, SessionKeyAccount } from '@filoz/synapse-core/session-key'
-import type { pullPiecesApiRequest } from '@filoz/synapse-core/sp'
+import type { PieceBatcherWait, pullPiecesApiRequest } from '@filoz/synapse-core/sp'
 import type { PDPProvider } from '@filoz/synapse-core/sp-registry'
 import type { MetadataObject } from '@filoz/synapse-core/utils'
 import type { getPriceList, getUploadCosts } from '@filoz/synapse-core/warm-storage'
@@ -17,7 +17,7 @@ import type { Synapse } from './synapse.ts'
 import type { WarmStorageService } from './warm-storage/service.ts'
 
 // Re-export PieceCID, PDPProvider, and PullStatus types
-export type { PDPProvider, PieceCID }
+export type { PDPProvider, PieceBatcherWait, PieceCID }
 export type PullStatus = pullPiecesApiRequest.PullStatus
 export type PrivateKey = string
 export type TokenAmount = bigint
@@ -81,6 +81,12 @@ export interface PrepareResult {
  */
 export type FilecoinNetworkType = 'mainnet' | 'calibration' | 'devnet'
 
+/** Configuration for automatic addPieces batching. */
+export interface PieceBatchingOptions {
+  /** Defaults to `{ kind: 'delay', ms: 0 }`. */
+  wait?: PieceBatcherWait
+}
+
 /**
  * Token identifier for balance queries
  */
@@ -132,6 +138,9 @@ export interface SynapseOptions {
   /** Whether to use CDN for retrievals (default: false) */
   withCDN?: boolean
 
+  /** Automatic addPieces batching. Enabled by default; pass `false` to disable. */
+  pieceBatching?: false | PieceBatchingOptions
+
   /**
    * Application identifier for namespace isolation. When set to a non-empty string, datasets
    * are tagged with this value and only datasets with a matching source are reused. Set to
@@ -158,6 +167,9 @@ export interface SynapseFromClientOptions {
 
   /** Whether to use CDN for retrievals (default: false) */
   withCDN?: boolean
+
+  /** Automatic addPieces batching. Enabled by default; pass `false` to disable. */
+  pieceBatching?: false | PieceBatchingOptions
 
   /**
    * Application identifier for namespace isolation. When set to a non-empty string, datasets


### PR DESCRIPTION
## Summary
- Add `createPieceBatcher` to park/pull pieces immediately and coalesce on-chain `addPieces` / `createDataSetAndAddPieces` with a tumbling window.
- Replace the 40-piece count cap with a Filecoin message-size limiter (`addPiecesFits`) and Curio PieceCID size bounds (`MIN_UPLOAD_SIZE` / `MAX_UPLOAD_SIZE`).
- Wire the same message-size check into synapse-sdk `presignForCommit` / `pull` / `commit`. One-shot `upload()` is unchanged.

## How it works

Park and pull run **per piece, immediately**. The tumbling window only batches the on-chain call:

```
upload / pull / enqueue ──► piece on this SP
                              │
                              ▼
                    tumbling addPieces window
                              │
              delay elapsed, limiter overflow,
              flush(), or close()
                              │
                              ▼
         addPieces  or  createDataSetAndAddPieces
```

- **Existing data set:** each flush submits `addPieces` (tx hash + status URL; callers poll if they need confirmation).
- **No data set:** first flush uses `createDataSetAndAddPieces` (waits until the set exists, then caches it). Later windows use `addPieces`.
- **Wait:** default `{ kind: 'delay', ms: 0 }` starts the timer only once the window has a piece and no `upload` / `pull` is still parking. New parking restarts the delay, so concurrent operations coalesce despite size or provider-latency differences. `ms: 0` flushes on the next macrotask after parking settles. `{ kind: 'limiter' }` sits until the next piece does not fit, or `flush` / `close`.
- **Overflow:** if `pending + incoming` does not fit, the current window flushes and the incoming piece starts the next one. A piece that cannot sit in a batch alone is rejected.
- **Pull auth:** `pull` signs extraData for **that one piece** so Curio can `estimateGas`. Flush signs a new extraData for the whole window.
- **Failures:** a failed park/pull never enters the window (siblings continue; retry `upload` / `pull`). A failed flush rejects every slot with `AddPiecesFlushError`; retry with `enqueue`.
- **`onParked`:** runs after the piece is on this SP and before it joins the window. Throw to keep it out of the batch.

## Public interfaces

Import from `@filoz/synapse-core/sp` (and errors from `@filoz/synapse-core/errors`).

```ts
function createPieceBatcher(
  client: Client<Transport, Chain, Account>,
  options: createPieceBatcher.OptionsType
): PieceBatcher

type createPieceBatcher.OptionsType = {
  dataSet: PdpDataSet | undefined
  wait?: PieceBatcherWait              // default { kind: 'delay', ms: 0 }
  limiter?: Limiter                    // default addPiecesFits
  serviceURL?: string                  // required when dataSet is undefined
  payee?: Address                      // required when dataSet is undefined
  payer?: Address
  metadata?: MetadataObject
  cdn?: boolean
}

type PieceBatcherWait =
  | { kind: 'delay'; ms: number }
  | { kind: 'limiter' }

type PieceBatcher = {
  upload: (input: UploadInput) => Promise<PieceResult>
  pull: (input: PullInput) => Promise<PieceResult>
  enqueue: (piece: EnqueuePiece) => Promise<PieceResult>
  flush: () => Promise<FlushResult | undefined>
  close: () => Promise<void>
  readonly pending: readonly EnqueuePiece[]
  readonly dataSet: PdpDataSet | undefined
}

type UploadInput = {
  data: File | Uint8Array | ReadableStream<Uint8Array>
  size?: number                        // for streams; File uses .size
  metadata?: MetadataObject
  pieceCid?: PieceCID
  onParked?: OnParked
  onProgress?: (bytesUploaded: number) => void
  signal?: AbortSignal
}

type PullInput = {
  pieceCid: PieceCID
  sourceUrl: string
  metadata?: MetadataObject
  onParked?: OnParked
}

type EnqueuePiece = { pieceCid: PieceCID; metadata?: MetadataObject }
type FlushResult = { txHash: Hex; statusUrl: string; pieces: EnqueuePiece[] }
type PieceResult = FlushResult & { pieceCid: PieceCID; batchIndex: number }
type OnParked = (piece: EnqueuePiece) => void | Promise<void>
```

Limiter (also used by synapse-sdk `presignForCommit` / `pull` / `commit`):

```ts
function addPiecesFits(options: LimiterOptions): boolean
function assertAddPiecesFit(options: LimiterOptions): void
function assertPieceCidSize(pieceCid: PieceCID): void
function estimateAddPiecesCalldataSize(options: LimiterOptions): number

type Limiter = (options: LimiterOptions) => boolean
type LimiterOptions =
  | { kind: 'addPieces'; dataSet?: PdpDataSet; pieces: LimiterPiece[] }
  | { kind: 'createDataSetAndAddPieces'; metadata?: MetadataObject; cdn?: boolean; pieces: LimiterPiece[] }
```

Budget is `SIZE_CONSTANTS.MAX_ADD_PIECES_MESSAGE_SIZE` (64 KiB minus overhead), estimated from encoded `addPieces` calldata with dummy extraData. PieceCID raw size must be within Curio's `MIN_UPLOAD_SIZE`–`MAX_UPLOAD_SIZE`. `MAX_ADD_PIECES_BATCH_SIZE` (40) remains a fee-preview heuristic only.

## Examples

**Existing data set — coalesced uploads**

```ts
import { createPieceBatcher } from '@filoz/synapse-core/sp'

const batcher = createPieceBatcher(client, { dataSet })

const [a, b] = await Promise.all([
  batcher.upload({ data: fileA }),
  batcher.upload({ data: fileB }),
])
// a.txHash === b.txHash when they landed in the same window

await batcher.close()
```

**Create a data set on first flush**

```ts
const batcher = createPieceBatcher(client, {
  dataSet: undefined,
  serviceURL: provider.pdp.serviceURL,
  payee: provider.serviceProvider,
  payer: client.account.address,
  cdn: false,
})

await batcher.upload({ data: firstFile })
await batcher.close()
// batcher.dataSet is now the created set; later windows use addPieces
```

**Mix upload and SP-to-SP pull**

```ts
await Promise.all([
  batcher.upload({ data: localFile }),
  batcher.pull({
    pieceCid,
    sourceUrl: `https://primary.example/pdp/piece/${pieceCid}`,
  }),
])
await batcher.close()
```

**`onParked`, then retry a failed flush with `enqueue`**

```ts
import { AddPiecesFlushError } from '@filoz/synapse-core/errors'

try {
  await batcher.upload({
    data: file,
    onParked: ({ pieceCid }) => {
      // piece is on this SP; not yet in an addPieces window
    },
  })
} catch (error) {
  if (AddPiecesFlushError.is(error)) {
    await batcher.enqueue({ pieceCid: error.pieceCid, metadata: error.metadata })
  } else {
    throw error
  }
}
```

**Limiter-only wait (tests / explicit flush)**

```ts
const batcher = createPieceBatcher(client, {
  dataSet,
  wait: { kind: 'limiter' },
})

const p1 = batcher.upload({ data: fileA })
const p2 = batcher.upload({ data: fileB })
await batcher.flush() // or close()
await Promise.all([p1, p2])
```

## Test plan
- [x] `pnpm run lint:fix` from `packages/synapse-core`
- [x] `pnpm test` from `packages/synapse-core` (857 passing)
- [x] Confirm `delay: 0` waits for all in-flight parking and coalesces different-latency uploads
- [x] `pnpm test` in `packages/synapse-sdk` (storage message-size tests)
- [x] Confirm `upload()` still accepts `File` / `Uint8Array` / `ReadableStream` and flushes on close
- [x] Confirm a PieceCID below min or above max upload size is rejected before park/pull

