### PR TITLE
feat(synapse-sdk): batch storage uploads by default

### DIFF
--- a/docs/src/content/docs/developer-guides/storage/upload-pipeline.mdx
+++ b/docs/src/content/docs/developer-guides/storage/upload-pipeline.mdx
@@ -55,6 +55,43 @@ The result contains:
 - **`copies`** - array of successful copies, each with `providerId`, `dataSetId`, `pieceId`, `role` (`'primary'` or `'secondary'`), `retrievalUrl`, and `isNewDataSet`
 - **`failedAttempts`** - providers that were tried but did not produce a copy. The SDK retries failed secondaries with alternate providers, so a non-empty array often just means a provider was swapped out. These are diagnostic, check `complete` for the actual outcome.
 
+### Uploading Multiple Files
+
+Piece batching is enabled by default. Compatible uploads that run concurrently can share an on-chain transaction when they use the same provider and data set. Each provider maintains its own batch.
+
+Start the uploads together to give them an opportunity to join the same batch:
+
+```ts
+const results = await Promise.all(
+  files.map((file) => synapse.storage.upload(file))
+)
+```
+
+Sequential uploads cannot share a batch because each call waits for its own on-chain confirmation before the next call starts:
+
+```ts
+for (const file of files) {
+  await synapse.storage.upload(file)
+}
+```
+
+By default, the SDK submits a batch after a zero-delay window. You can instead hold compatible pieces until the transaction size limit is reached or you explicitly flush them:
+
+```ts
+const synapse = Synapse.create({
+  account: privateKeyToAccount("0x..."),
+  pieceBatching: { wait: { kind: "limiter" } },
+})
+
+const uploads = files.map((file) => synapse.storage.upload(file))
+await synapse.storage.flush()
+const results = await Promise.all(uploads)
+```
+
+`flush()` waits for accepted uploads and pulls to finish parking, then submits their pending batch windows. It does not report whether every upload was submitted or confirmed successfully; always await the individual upload promises for results and errors.
+
+Set `pieceBatching: false` when creating `Synapse` to disable batching. Use the [split operations](#split-operations) when you need manual control over provider selection, signing, or each store, pull, and commit phase.
+
 ### Upload with Metadata
 
 Attach metadata to organize uploads. The SDK reuses existing data sets when metadata matches, avoiding duplicate payment rails:

--- a/packages/synapse-core/src/sp/create-piece-batcher.ts
+++ b/packages/synapse-core/src/sp/create-piece-batcher.ts
@@ -24,17 +24,28 @@ import { findPiece } from './find-piece.ts'
 import { waitForPullPieces } from './pull-pieces.ts'
 import { type UploadPieceStreamingData, uploadPieceStreaming } from './upload-streaming.ts'
 
-export type EnqueuePiece = LimiterPiece
+export type EnqueuePiece = LimiterPiece & {
+  /** Raw byte size when the piece was parked by `upload()`. */
+  size?: number
+}
 
 export type FlushResult = {
   txHash: Hex
+  confirmedTxHash?: Hex
   statusUrl: string
+  dataSetId: bigint
+  clientDataSetId: bigint
+  isNewDataSet: boolean
   pieces: EnqueuePiece[]
 }
 
 export type PieceResult = FlushResult & {
   pieceCid: PieceCID
   batchIndex: number
+}
+
+export type UploadResult = PieceResult & {
+  size: number
 }
 
 /**
@@ -56,7 +67,7 @@ export type PieceBatcherWait = { kind: 'delay'; ms: number } | { kind: 'limiter'
 export type OnParked = (piece: EnqueuePiece) => void | Promise<void>
 
 export type UploadInput = {
-  data: File | Uint8Array | ReadableStream<Uint8Array>
+  data: File | UploadPieceStreamingData
   /** Known length for a stream (`File` uses `.size`). */
   size?: number
   metadata?: MetadataObject
@@ -71,6 +82,8 @@ export type PullInput = {
   sourceUrl: string
   metadata?: MetadataObject
   onParked?: OnParked
+  onStatus?: (response: waitForPullPieces.ReturnType) => void
+  signal?: AbortSignal
 }
 
 type Slot = {
@@ -81,7 +94,7 @@ type Slot = {
 
 export type PieceBatcher = {
   /** Stream onto this SP, then join the addPieces window. */
-  upload: (input: UploadInput) => Promise<PieceResult>
+  upload: (input: UploadInput) => Promise<UploadResult>
   /** Pull onto this SP (own extraData), then join the addPieces window. */
   pull: (input: PullInput) => Promise<PieceResult>
   /** Already on this SP. Join the addPieces window only. */
@@ -236,19 +249,36 @@ export function createPieceBatcher(
     const pieces = batch.map((slot) => slot.piece)
 
     try {
-      const submitted =
-        dataSet == null
-          ? await flushCreate(pieces)
-          : await addPieces(client, {
-              serviceURL: serviceURL(),
-              dataSetId: dataSet.dataSetId,
-              clientDataSetId: dataSet.clientDataSetId,
-              pieces,
-            })
+      const isNewDataSet = dataSet == null
+      let submitted: {
+        txHash: Hex
+        confirmedTxHash?: Hex
+        statusUrl: string
+        dataSetId: bigint
+        clientDataSetId: bigint
+      }
+      if (dataSet == null) {
+        submitted = await flushCreate(pieces)
+      } else {
+        submitted = {
+          ...(await addPieces(client, {
+            serviceURL: serviceURL(),
+            dataSetId: dataSet.dataSetId,
+            clientDataSetId: dataSet.clientDataSetId,
+            pieces,
+          })),
+          dataSetId: dataSet.dataSetId,
+          clientDataSetId: dataSet.clientDataSetId,
+        }
+      }
 
       const result: FlushResult = {
         txHash: submitted.txHash,
+        ...(submitted.confirmedTxHash == null ? {} : { confirmedTxHash: submitted.confirmedTxHash }),
         statusUrl: submitted.statusUrl,
+        dataSetId: submitted.dataSetId,
+        clientDataSetId: submitted.clientDataSetId,
+        isNewDataSet,
         pieces,
       }
       for (const [batchIndex, slot] of batch.entries()) {
@@ -275,7 +305,13 @@ export function createPieceBatcher(
     }
   }
 
-  async function flushCreate(pieces: EnqueuePiece[]): Promise<{ txHash: Hex; statusUrl: string }> {
+  async function flushCreate(pieces: EnqueuePiece[]): Promise<{
+    txHash: Hex
+    confirmedTxHash?: Hex
+    statusUrl: string
+    dataSetId: bigint
+    clientDataSetId: bigint
+  }> {
     if (payee == null) {
       throw new ValidationError('`payee` is required when dataSet is undefined.')
     }
@@ -294,7 +330,16 @@ export function createPieceBatcher(
       throw new DataSetNotFoundError(created.dataSetId)
     }
     dataSet = resolved
-    return submitted
+    return {
+      txHash: submitted.txHash,
+      ...(created.confirmedTxHash == null ? {} : { confirmedTxHash: created.confirmedTxHash }),
+      statusUrl: new URL(
+        `/pdp/data-sets/${created.dataSetId}/pieces/added/${submitted.txHash}`,
+        serviceURL()
+      ).toString(),
+      dataSetId: created.dataSetId,
+      clientDataSetId: createClientDataSetId,
+    }
   }
 
   function cancelTimer(): void {
@@ -368,7 +413,7 @@ export function createPieceBatcher(
     return internalEnqueue(piece)
   }
 
-  async function upload(input: UploadInput): Promise<PieceResult> {
+  async function upload(input: UploadInput): Promise<UploadResult> {
     let data: UploadPieceStreamingData
     let size = input.size
     if (isUint8Array(input.data)) {
@@ -380,7 +425,8 @@ export function createPieceBatcher(
     } else {
       data = input.data
     }
-    return parkAndEnqueue(async () => {
+    let uploadedSize: number | undefined
+    const result = await parkAndEnqueue(async () => {
       if (input.pieceCid != null) {
         assertPieceCidSize(input.pieceCid)
       }
@@ -392,14 +438,19 @@ export function createPieceBatcher(
         onProgress: input.onProgress,
         signal: input.signal,
       })
+      uploadedSize = uploaded.size
       await findPiece({
         serviceURL: serviceURL(),
         pieceCid: uploaded.pieceCid,
         poll: true,
         signal: input.signal,
       })
-      return { pieceCid: uploaded.pieceCid, metadata: input.metadata }
+      return { pieceCid: uploaded.pieceCid, metadata: input.metadata, size: uploaded.size }
     }, input.onParked)
+    if (uploadedSize == null) {
+      throw new ValidationError('Piece upload completed without a size.')
+    }
+    return { ...result, size: uploadedSize }
   }
 
   async function pull(input: PullInput): Promise<PieceResult> {
@@ -430,6 +481,8 @@ export function createPieceBatcher(
               payer,
               cdn,
               metadata: datasetMetadata,
+              signal: input.signal,
+              onStatus: input.onStatus,
             })
           : await waitForPullPieces(client, {
               serviceURL: serviceURL(),
@@ -437,6 +490,8 @@ export function createPieceBatcher(
               extraData,
               dataSetId: dataSet.dataSetId,
               clientDataSetId: dataSet.clientDataSetId,
+              signal: input.signal,
+              onStatus: input.onStatus,
             })
       if (pullResult.status === 'failed') {
         throw new PullError('Pull failed.')
@@ -453,15 +508,15 @@ export function createPieceBatcher(
   }
 
   async function flush(): Promise<FlushResult | undefined> {
+    await Promise.allSettled([...inFlight])
+    await Promise.resolve()
+    await scheduledIdle
     return lock(() => flushWindowInternal())
   }
 
   async function close(): Promise<void> {
     closed = true
-    await Promise.allSettled([...inFlight])
-    await Promise.resolve()
-    await scheduledIdle
-    await lock(() => flushWindowInternal())
+    await flush()
   }
 
   return {

--- a/packages/synapse-core/test/create-piece-batcher.test.ts
+++ b/packages/synapse-core/test/create-piece-batcher.test.ts
@@ -287,6 +287,28 @@ describe('createPieceBatcher', () => {
     assert.equal(b.txHash, mockTxHash2)
   })
 
+  it('should pass the active data set to a custom limiter', async () => {
+    server.use(addPiecesCaptureHandler(() => undefined))
+    let observedDataSet: PdpDataSet | undefined
+    const batcher = createPieceBatcher(client, {
+      dataSet: createDataSet(),
+      wait: { kind: 'limiter' },
+      limiter: (options) => {
+        if (options.kind !== 'addPieces') {
+          return false
+        }
+        observedDataSet = options.dataSet
+        return options.dataSet?.dataSetId === 1n
+      },
+    })
+
+    const pending = batcher.enqueue({ pieceCid: pieceCidA })
+    await batcher.close()
+    await pending
+
+    assert.equal(observedDataSet?.dataSetId, 1n)
+  })
+
   it('should mix upload and pull in one window', async () => {
     const addBodies: addPiecesApiRequest.RequestBody[] = []
     let pullExtraData: string | undefined
@@ -548,6 +570,7 @@ describe('createPieceBatcher', () => {
 
     assert.ok(batcher.dataSet)
     assert.equal(batcher.dataSet?.dataSetId, 1n)
+    assert.equal(batcher.dataSet?.provider.id, 1n)
     assert.equal(created.txHash, mockTxHash)
     assert.equal(added.txHash, mockTxHash2)
     assert.equal(addBodies.length, 1)

--- a/packages/synapse-core/test/create-piece-batcher.test.ts
+++ b/packages/synapse-core/test/create-piece-batcher.test.ts
@@ -287,28 +287,6 @@ describe('createPieceBatcher', () => {
     assert.equal(b.txHash, mockTxHash2)
   })
 
-  it('should pass the active data set to a custom limiter', async () => {
-    server.use(addPiecesCaptureHandler(() => undefined))
-    let observedDataSet: PdpDataSet | undefined
-    const batcher = createPieceBatcher(client, {
-      dataSet: createDataSet(),
-      wait: { kind: 'limiter' },
-      limiter: (options) => {
-        if (options.kind !== 'addPieces') {
-          return false
-        }
-        observedDataSet = options.dataSet
-        return options.dataSet?.dataSetId === 1n
-      },
-    })
-
-    const pending = batcher.enqueue({ pieceCid: pieceCidA })
-    await batcher.close()
-    await pending
-
-    assert.equal(observedDataSet?.dataSetId, 1n)
-  })
-
   it('should mix upload and pull in one window', async () => {
     const addBodies: addPiecesApiRequest.RequestBody[] = []
     let pullExtraData: string | undefined
@@ -570,7 +548,6 @@ describe('createPieceBatcher', () => {
 
     assert.ok(batcher.dataSet)
     assert.equal(batcher.dataSet?.dataSetId, 1n)
-    assert.equal(batcher.dataSet?.provider.id, 1n)
     assert.equal(created.txHash, mockTxHash)
     assert.equal(added.txHash, mockTxHash2)
     assert.equal(addBodies.length, 1)

--- a/packages/synapse-sdk/src/storage/context.ts
+++ b/packages/synapse-sdk/src/storage/context.ts
@@ -48,6 +48,7 @@ import {
 } from '@filoz/synapse-core/utils'
 import {
   fetchProviderSelectionInput,
+  getPdpDataSet,
   metadataMatches,
   type ResolvedLocation,
   selectProviders,
@@ -80,6 +81,7 @@ import type {
 import { createError, SIZE_CONSTANTS } from '../utils/index.ts'
 import { combineMetadata } from '../utils/metadata.ts'
 import type { WarmStorageService } from '../warm-storage/index.ts'
+import { type BatchedUploadResult, getPieceBatchingService } from './piece-batching.ts'
 import { terminateServiceFlow } from './terminate.ts'
 
 const NO_REMAINING_PROVIDERS_ERROR_MESSAGE = 'No approved service providers available'
@@ -142,6 +144,25 @@ export class StorageContext {
   // Getter for data set ID
   get dataSetId(): bigint | undefined {
     return this._dataSetId
+  }
+
+  /** @internal Synchronize state after a shared piece batcher creates or resolves a data set. */
+  syncBatcherDataSet(dataSetId: bigint, clientDataSetId: bigint): void {
+    this._dataSetId = dataSetId
+    this._clientDataSetId = clientDataSetId
+  }
+
+  /** @internal Resolve the minimal data-set state required by a piece batcher. */
+  async getBatcherDataSet(): Promise<SP.PieceBatcher['dataSet']> {
+    if (this._dataSetId == null) {
+      return undefined
+    }
+    const dataSet = await getPdpDataSet(this._readClient, { dataSetId: this._dataSetId })
+    if (dataSet == null) {
+      throw createError('StorageContext', 'getBatcherDataSet', 'Data set not found')
+    }
+    this._clientDataSetId = dataSet.clientDataSetId
+    return dataSet
   }
 
   private assertPiecesFitMessage(pieces: Array<{ pieceCid: PieceCID; metadata?: MetadataObject }>): void {
@@ -1021,6 +1042,57 @@ export class StorageContext {
    * @returns Upload result with pieceCid, size, and a single-element copies array
    */
   async upload(data: UploadPieceStreamingData, options?: UploadOptions): Promise<UploadResult> {
+    const batching = getPieceBatchingService(this._synapse)
+    if (batching != null) {
+      let parked = false
+      const task = batching.upload(this, {
+        data,
+        pieceCid: options?.pieceCid,
+        metadata: options?.pieceMetadata,
+        signal: options?.signal,
+        onProgress: options?.onProgress,
+        onParked: (piece) => {
+          parked = true
+          options?.onStored?.(this._provider.id, piece.pieceCid)
+        },
+        onSubmitted: (submitted) =>
+          options?.onPiecesAdded?.(submitted.txHash, this._provider.id, [{ pieceCid: submitted.pieceCid }]),
+      })
+
+      let result: BatchedUploadResult
+      try {
+        result = await task.committed
+      } catch (error) {
+        throw createError(
+          'StorageContext',
+          parked ? 'commit' : 'store',
+          parked ? 'Failed to commit pieces on-chain' : 'Failed to store piece on service provider',
+          error
+        )
+      }
+
+      options?.onPiecesConfirmed?.(result.dataSetId, this._provider.id, [
+        { pieceId: result.pieceId, pieceCid: result.pieceCid },
+      ])
+      return {
+        pieceCid: result.pieceCid,
+        size: result.size,
+        requestedCopies: 1,
+        complete: true,
+        copies: [
+          {
+            providerId: this._provider.id,
+            dataSetId: result.dataSetId,
+            pieceId: result.pieceId,
+            role: 'primary',
+            retrievalUrl: this.getPieceUrl(result.pieceCid),
+            isNewDataSet: result.isNewDataSet,
+          },
+        ],
+        failedAttempts: [],
+      }
+    }
+
     // Store phase
     const storeResult = await this.store(data, {
       pieceCid: options?.pieceCid,

--- a/packages/synapse-sdk/src/storage/manager.ts
+++ b/packages/synapse-sdk/src/storage/manager.ts
@@ -70,6 +70,12 @@ import type {
 import { combineMetadata, createError, SIZE_CONSTANTS, TIME_CONSTANTS } from '../utils/index.ts'
 import type { WarmStorageService } from '../warm-storage/index.ts'
 import { StorageContext } from './context.ts'
+import {
+  type BatchedCommitResult,
+  type BatchingHold,
+  getPieceBatchingService,
+  type PieceBatchingService,
+} from './piece-batching.ts'
 import { terminateServiceFlow } from './terminate.ts'
 
 // Multi-copy upload constants
@@ -204,6 +210,11 @@ export class StorageManager {
    * @throws CommitError if all commit attempts fail (data stored but not on-chain)
    */
   async upload(data: UploadPieceStreamingData, options?: StorageManagerUploadOptions): Promise<UploadResult> {
+    const batching = getPieceBatchingService(this._synapse)
+    if (batching != null) {
+      return this._uploadBatched(data, options, batching, batching.hold())
+    }
+
     const { contexts, explicitProviders } = await this._resolveUploadContexts(options)
     const [primary, ...secondaries] = contexts
 
@@ -379,6 +390,251 @@ export class StorageManager {
       copies,
       failedAttempts,
     }
+  }
+
+  /** Flush all piece windows currently accepted by this Synapse instance. */
+  async flush(): Promise<void> {
+    await getPieceBatchingService(this._synapse)?.flush()
+  }
+
+  private async _uploadBatched(
+    data: UploadPieceStreamingData,
+    options: StorageManagerUploadOptions | undefined,
+    batching: PieceBatchingService,
+    hold: BatchingHold
+  ): Promise<UploadResult> {
+    let resolved: { contexts: StorageContext[]; explicitProviders: boolean }
+    try {
+      resolved = await this._resolveUploadContexts(options)
+    } catch (error) {
+      hold.release()
+      throw error
+    }
+    const { contexts, explicitProviders } = resolved
+    const [primary, ...secondaries] = contexts
+    const usedProviderIds = new Set(contexts.map((context) => context.provider.id))
+    const failedAttempts: FailedAttempt[] = []
+    const secondaryOperations: Array<{ context: StorageContext; committed: Promise<BatchedCommitResult> }> = []
+    let primaryParked = false
+    let storedPieceCid: PieceCID | undefined
+    let storedSize: number | undefined
+
+    const primaryTask = batching.upload(primary, {
+      data,
+      pieceCid: options?.pieceCid,
+      metadata: options?.pieceMetadata,
+      signal: options?.signal,
+      onProgress: options?.callbacks?.onProgress,
+      onSubmitted: (submitted) =>
+        safeInvoke(options?.callbacks?.onPiecesAdded, submitted.txHash, primary.provider.id, [
+          { pieceCid: submitted.pieceCid },
+        ]),
+      onParked: async (piece) => {
+        primaryParked = true
+        storedPieceCid = piece.pieceCid
+        storedSize = piece.size
+        safeInvoke(options?.callbacks?.onStored, primary.provider.id, piece.pieceCid)
+
+        for (const secondary of secondaries) {
+          const outcome = await this._parkBatchedSecondary(primary, secondary, piece.pieceCid, {
+            batching,
+            explicitProviders,
+            usedProviderIds,
+            failedAttempts,
+            signal: options?.signal,
+            withCDN: options?.withCDN,
+            metadata: options?.metadata,
+            pieceMetadata: options?.pieceMetadata,
+            callbacks: options?.callbacks,
+          })
+          if (outcome != null) {
+            secondaryOperations.push(outcome)
+          }
+        }
+      },
+    })
+    hold.release()
+
+    let primaryResult: BatchedCommitResult | undefined
+    let primaryError: Error | undefined
+    try {
+      primaryResult = await primaryTask.committed
+    } catch (error) {
+      if (error instanceof UserRejectedRequestError) {
+        throw error
+      }
+      if (!primaryParked) {
+        throw new StoreError(
+          `Failed to store piece on service provider ${primary.provider.id} (${primary.provider.pdp.serviceURL})`,
+          {
+            cause: error instanceof Error ? error : undefined,
+            providerId: primary.provider.id,
+            endpoint: primary.provider.pdp.serviceURL,
+          }
+        )
+      }
+      primaryError = error instanceof Error ? error : new Error(String(error))
+    }
+
+    const secondarySettled = await Promise.allSettled(
+      secondaryOperations.map(async (operation) => ({
+        context: operation.context,
+        result: await operation.committed,
+      }))
+    )
+
+    const copies: CopyResult[] = []
+    if (primaryResult == null) {
+      failedAttempts.push({
+        providerId: primary.provider.id,
+        role: 'primary',
+        error: 'Commit failed',
+        explicit: explicitProviders,
+      })
+    } else {
+      copies.push({
+        providerId: primary.provider.id,
+        dataSetId: primaryResult.dataSetId,
+        pieceId: primaryResult.pieceId,
+        role: 'primary',
+        retrievalUrl: primary.getPieceUrl(primaryResult.pieceCid),
+        isNewDataSet: primaryResult.isNewDataSet,
+      })
+      safeInvoke(options?.callbacks?.onPiecesConfirmed, primaryResult.dataSetId, primary.provider.id, [
+        { pieceId: primaryResult.pieceId, pieceCid: primaryResult.pieceCid },
+      ])
+    }
+
+    for (const [index, settled] of secondarySettled.entries()) {
+      const operation = secondaryOperations[index]
+      if (settled.status === 'fulfilled') {
+        const { context, result } = settled.value
+        copies.push({
+          providerId: context.provider.id,
+          dataSetId: result.dataSetId,
+          pieceId: result.pieceId,
+          role: 'secondary',
+          retrievalUrl: context.getPieceUrl(result.pieceCid),
+          isNewDataSet: result.isNewDataSet,
+        })
+        safeInvoke(options?.callbacks?.onPiecesConfirmed, result.dataSetId, context.provider.id, [
+          { pieceId: result.pieceId, pieceCid: result.pieceCid },
+        ])
+      } else {
+        failedAttempts.push({
+          providerId: operation.context.provider.id,
+          role: 'secondary',
+          error: 'Commit failed',
+          explicit: explicitProviders,
+        })
+      }
+    }
+
+    if (copies.length === 0) {
+      throw new CommitError(
+        `Failed to commit on primary provider ${primary.provider.id} (${primary.provider.pdp.serviceURL}) - data is stored but not on-chain`,
+        {
+          cause: primaryError,
+          providerId: primary.provider.id,
+          endpoint: primary.provider.pdp.serviceURL,
+        }
+      )
+    }
+    if (storedPieceCid == null || storedSize == null) {
+      throw createError('StorageManager', 'upload', 'Primary upload completed without parked piece information')
+    }
+
+    return {
+      pieceCid: storedPieceCid,
+      size: storedSize,
+      requestedCopies: contexts.length,
+      complete: copies.length >= contexts.length,
+      copies,
+      failedAttempts,
+    }
+  }
+
+  private async _parkBatchedSecondary(
+    primary: StorageContext,
+    initialSecondary: StorageContext,
+    pieceCid: PieceCID,
+    options: {
+      batching: PieceBatchingService
+      explicitProviders: boolean
+      usedProviderIds: Set<bigint>
+      failedAttempts: FailedAttempt[]
+      signal?: AbortSignal
+      withCDN?: boolean
+      metadata?: Record<string, string>
+      pieceMetadata?: Record<string, string>
+      callbacks?: Partial<CombinedCallbacks>
+    }
+  ): Promise<{ context: StorageContext; committed: Promise<BatchedCommitResult> } | undefined> {
+    let context = initialSecondary
+    let attempts = 0
+
+    while (attempts < MAX_SECONDARY_ATTEMPTS) {
+      const providerId = context.provider.id
+      const task = options.batching.pull(context, {
+        pieceCid,
+        sourceUrl: primary.getPieceUrl(pieceCid),
+        metadata: options.pieceMetadata,
+        signal: options.signal,
+        onStatus: (response) => {
+          const status = response.pieces.find((piece) => piece.pieceCid === pieceCid.toString())?.status
+          if (status != null) {
+            safeInvoke(options.callbacks?.onPullProgress, providerId, pieceCid, status)
+          }
+        },
+        onParked: () => safeInvoke(options.callbacks?.onCopyComplete, providerId, pieceCid),
+        onSubmitted: (submitted) =>
+          safeInvoke(options.callbacks?.onPiecesAdded, submitted.txHash, providerId, [
+            { pieceCid: submitted.pieceCid },
+          ]),
+      })
+
+      try {
+        await task.parked
+        return { context, committed: task.committed }
+      } catch (error) {
+        void task.committed.catch(() => undefined)
+        if (error instanceof UserRejectedRequestError) {
+          throw error
+        }
+        const message = error instanceof Error ? error.message : String(error)
+        options.failedAttempts.push({
+          providerId,
+          role: 'secondary',
+          error: message,
+          explicit: options.explicitProviders,
+        })
+        safeInvoke(
+          options.callbacks?.onCopyFailed,
+          providerId,
+          pieceCid,
+          error instanceof Error ? error : new Error(message)
+        )
+      }
+
+      attempts++
+      if (options.explicitProviders || attempts >= MAX_SECONDARY_ATTEMPTS) {
+        break
+      }
+      try {
+        const [replacement] = await this.createContexts({
+          withCDN: options.withCDN,
+          copies: 1,
+          metadata: options.metadata,
+          callbacks: options.callbacks,
+          excludeProviderIds: [...options.usedProviderIds],
+        })
+        context = replacement
+        options.usedProviderIds.add(replacement.provider.id)
+      } catch {
+        break
+      }
+    }
+    return undefined
   }
 
   /**

--- a/packages/synapse-sdk/src/storage/manager.ts
+++ b/packages/synapse-sdk/src/storage/manager.ts
@@ -198,9 +198,14 @@ export class StorageManager {
    * to determine overall success. Don't use `failedAttempts.length` as a failure
    * signal as `failedAttempts` exists as a diagnostic for intermediate failures.
    *
+   * Batching is enabled by default. Compatible concurrent calls can share
+   * on-chain transactions, while sequentially awaiting each call prevents those
+   * uploads from joining the same batch.
+   *
    * For large files, prefer streaming to minimize memory usage.
    *
-   * For uploading multiple files, use the split operations API directly:
+   * For manual control over providers, signing, or individual phases, use the
+   * split operations API directly:
    * createContexts() -> store() -> presignForCommit() -> pull() -> commit()
    *
    * @param data - Raw bytes (Uint8Array) or ReadableStream to upload
@@ -392,7 +397,15 @@ export class StorageManager {
     }
   }
 
-  /** Flush all piece windows currently accepted by this Synapse instance. */
+  /**
+   * Submit all piece-batch windows currently accepted by this Synapse instance.
+   *
+   * Waits for in-progress uploads and pulls to finish parking before submitting
+   * their pending windows. Resolving does not mean every upload was submitted or
+   * confirmed successfully; failures are reported by the individual upload
+   * promises, which callers must also await. This is a no-op when batching is
+   * disabled.
+   */
   async flush(): Promise<void> {
     await getPieceBatchingService(this._synapse)?.flush()
   }

--- a/packages/synapse-sdk/src/storage/piece-batching.ts
+++ b/packages/synapse-sdk/src/storage/piece-batching.ts
@@ -1,0 +1,251 @@
+import * as SP from '@filoz/synapse-core/sp'
+import type { Hex } from 'viem'
+import type { Synapse } from '../synapse.ts'
+import type { PieceBatchingOptions, PieceCID } from '../types.ts'
+import type { StorageContext } from './context.ts'
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+}
+
+export type BatchedCommitResult = {
+  pieceCid: PieceCID
+  txHash: Hex
+  confirmedTxHash?: Hex
+  dataSetId: bigint
+  pieceId: bigint
+  isNewDataSet: boolean
+}
+
+export type BatchedUploadResult = BatchedCommitResult & {
+  size: number
+}
+
+export type BatchedTask<T> = {
+  parked: Promise<SP.EnqueuePiece>
+  committed: Promise<T>
+}
+
+export type BatchingHold = {
+  release: () => void
+}
+
+type Entry = {
+  batcher: SP.PieceBatcher
+  providerId: bigint
+  contexts: Set<StorageContext>
+  confirmations: Map<string, Promise<SP.waitForAddPieces.OutputType>>
+}
+
+type TaskCallbacks = {
+  onParked?: SP.OnParked
+  onSubmitted?: (result: SP.PieceResult) => void
+}
+
+export type UploadTaskInput = Omit<SP.UploadInput, 'onParked'> & TaskCallbacks
+export type PullTaskInput = Omit<SP.PullInput, 'onParked'> & TaskCallbacks
+
+const services = new WeakMap<Synapse, PieceBatchingService>()
+
+export function registerPieceBatchingService(synapse: Synapse, service: PieceBatchingService): void {
+  services.set(synapse, service)
+}
+
+export function getPieceBatchingService(synapse: Synapse): PieceBatchingService | undefined {
+  return services.get(synapse)
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => undefined
+  let reject: (error: unknown) => void = () => undefined
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function metadataKey(metadata: Record<string, string>): string {
+  return JSON.stringify(Object.entries(metadata).sort(([a], [b]) => a.localeCompare(b)))
+}
+
+export class PieceBatchingService {
+  private readonly synapse: Synapse
+  private readonly options: PieceBatchingOptions
+  private readonly entries = new Map<string, Promise<Entry>>()
+  private readonly pendingReady = new Set<Promise<void>>()
+
+  constructor(synapse: Synapse, options: PieceBatchingOptions) {
+    this.synapse = synapse
+    this.options = options
+  }
+
+  upload(context: StorageContext, input: UploadTaskInput): BatchedTask<BatchedUploadResult> {
+    return this.task(context, input, async (entry, onParked) => {
+      const { onSubmitted, ...batchInput } = input
+      const result = await entry.batcher.upload({ ...batchInput, onParked })
+      onSubmitted?.(result)
+      const committed = await this.confirm(entry, result)
+      return { ...committed, size: result.size }
+    })
+  }
+
+  pull(context: StorageContext, input: PullTaskInput): BatchedTask<BatchedCommitResult> {
+    return this.task(context, input, async (entry, onParked) => {
+      const { onSubmitted, ...batchInput } = input
+      const result = await entry.batcher.pull({ ...batchInput, onParked })
+      onSubmitted?.(result)
+      return this.confirm(entry, result)
+    })
+  }
+
+  hold(): BatchingHold {
+    const ready = deferred<void>()
+    this.trackReady(ready)
+    return { release: () => ready.resolve() }
+  }
+
+  async flush(): Promise<void> {
+    while (this.pendingReady.size > 0) {
+      await Promise.allSettled([...this.pendingReady])
+    }
+    const entries = await Promise.allSettled([...new Set(this.entries.values())])
+    await Promise.all(entries.flatMap((entry) => (entry.status === 'fulfilled' ? [entry.value.batcher.flush()] : [])))
+  }
+
+  private task<T>(
+    context: StorageContext,
+    input: TaskCallbacks,
+    run: (entry: Entry, onParked: SP.OnParked) => Promise<T>
+  ): BatchedTask<T> {
+    const parked = deferred<SP.EnqueuePiece>()
+    void parked.promise.catch(() => undefined)
+    const ready = deferred<void>()
+    this.trackReady(ready)
+
+    let didPark = false
+    const committed = (async () => {
+      try {
+        const entry = await this.entry(context)
+        return await run(entry, async (piece) => {
+          didPark = true
+          parked.resolve(piece)
+          try {
+            await input.onParked?.(piece)
+          } finally {
+            ready.resolve()
+          }
+        })
+      } catch (error) {
+        if (!didPark) {
+          parked.reject(error)
+          ready.resolve()
+        }
+        throw error
+      }
+    })()
+    void committed.catch(() => undefined)
+
+    return { parked: parked.promise, committed }
+  }
+
+  private trackReady(ready: Deferred<void>): void {
+    this.pendingReady.add(ready.promise)
+    void ready.promise.finally(() => {
+      this.pendingReady.delete(ready.promise)
+    })
+  }
+
+  private entry(context: StorageContext): Promise<Entry> {
+    const key = this.key(context)
+    const existing = this.entries.get(key)
+    if (existing != null) {
+      void existing.then((entry) => {
+        const dataSet = entry.batcher.dataSet
+        if (dataSet == null) {
+          entry.contexts.add(context)
+        } else {
+          context.syncBatcherDataSet(dataSet.dataSetId, dataSet.clientDataSetId)
+        }
+      })
+      return existing
+    }
+
+    const created = this.createEntry(context)
+    this.entries.set(key, created)
+    void created.catch(() => {
+      if (this.entries.get(key) === created) {
+        this.entries.delete(key)
+      }
+    })
+    return created
+  }
+
+  private async createEntry(context: StorageContext): Promise<Entry> {
+    const dataSet = await context.getBatcherDataSet()
+
+    return {
+      batcher: SP.createPieceBatcher(this.synapse.sessionClient ?? this.synapse.client, {
+        dataSet,
+        wait: this.options.wait,
+        serviceURL: context.provider.pdp.serviceURL,
+        payee: context.provider.serviceProvider,
+        payer: this.synapse.client.account.address,
+        metadata: context.dataSetMetadata,
+        cdn: context.withCDN,
+      }),
+      providerId: context.provider.id,
+      contexts: dataSet == null ? new Set([context]) : new Set(),
+      confirmations: new Map(),
+    }
+  }
+
+  private async confirm(entry: Entry, result: SP.PieceResult): Promise<BatchedCommitResult> {
+    const dataSet = entry.batcher.dataSet
+    if (dataSet != null) {
+      for (const context of entry.contexts) {
+        context.syncBatcherDataSet(dataSet.dataSetId, dataSet.clientDataSetId)
+      }
+      entry.contexts.clear()
+      this.entries.set(this.existingKey(entry.providerId, dataSet.dataSetId), Promise.resolve(entry))
+    }
+
+    let confirmation = entry.confirmations.get(result.statusUrl)
+    if (confirmation == null) {
+      confirmation = SP.waitForAddPieces({ statusUrl: result.statusUrl })
+      entry.confirmations.set(result.statusUrl, confirmation)
+      void confirmation.then(
+        () => entry.confirmations.delete(result.statusUrl),
+        () => entry.confirmations.delete(result.statusUrl)
+      )
+    }
+    const confirmed = await confirmation
+    const pieceId = confirmed.confirmedPieceIds[result.batchIndex]
+    if (pieceId == null) {
+      throw new Error(`Provider confirmed no piece ID at batch index ${result.batchIndex}`)
+    }
+
+    const confirmedTxHash = result.confirmedTxHash ?? confirmed.confirmedTxHash
+    return {
+      pieceCid: result.pieceCid,
+      txHash: result.txHash,
+      ...(confirmedTxHash == null ? {} : { confirmedTxHash }),
+      dataSetId: result.dataSetId,
+      pieceId,
+      isNewDataSet: result.isNewDataSet,
+    }
+  }
+
+  private key(context: StorageContext): string {
+    if (context.dataSetId != null) {
+      return this.existingKey(context.provider.id, context.dataSetId)
+    }
+    return `new:${context.provider.id}:${context.withCDN}:${metadataKey(context.dataSetMetadata)}`
+  }
+
+  private existingKey(providerId: bigint, dataSetId: bigint): string {
+    return `existing:${providerId}:${dataSetId}`
+  }
+}

--- a/packages/synapse-sdk/src/storage/piece-batching.ts
+++ b/packages/synapse-sdk/src/storage/piece-batching.ts
@@ -162,15 +162,15 @@ export class PieceBatchingService {
     const key = this.key(context)
     const existing = this.entries.get(key)
     if (existing != null) {
-      void existing.then((entry) => {
+      return existing.then((entry) => {
         const dataSet = entry.batcher.dataSet
         if (dataSet == null) {
           entry.contexts.add(context)
         } else {
           context.syncBatcherDataSet(dataSet.dataSetId, dataSet.clientDataSetId)
         }
+        return entry
       })
-      return existing
     }
 
     const created = this.createEntry(context)

--- a/packages/synapse-sdk/src/synapse.ts
+++ b/packages/synapse-sdk/src/synapse.ts
@@ -16,6 +16,7 @@ import { FilBeamService } from './filbeam/index.ts'
 import { PaymentsService } from './payments/index.ts'
 import { SPRegistryService } from './sp-registry/index.ts'
 import { StorageManager } from './storage/manager.ts'
+import { PieceBatchingService, registerPieceBatchingService } from './storage/piece-batching.ts'
 import type { PDPProvider, SynapseFromClientOptions, SynapseOptions } from './types.ts'
 import { DEFAULT_CHAIN } from './utils/constants.ts'
 import { WarmStorageService } from './warm-storage/index.ts'
@@ -84,6 +85,7 @@ export class Synapse {
       withCDN: options.withCDN,
       source: options.source,
       sessionClient: options.sessionKey?.client,
+      pieceBatching: options.pieceBatching,
     })
   }
 
@@ -100,6 +102,10 @@ export class Synapse {
     this._filbeamService = new FilBeamService(this._chain)
     this._warmStorageService = new WarmStorageService({ client: this._client, readClient: this._readClient })
     this._payments = new PaymentsService({ client: this._client })
+
+    if (options.pieceBatching !== false) {
+      registerPieceBatchingService(this, new PieceBatchingService(this, options.pieceBatching ?? {}))
+    }
 
     // Initialize StorageManager
     this._storageManager = new StorageManager({

--- a/packages/synapse-sdk/src/test/session-keys.test.ts
+++ b/packages/synapse-sdk/src/test/session-keys.test.ts
@@ -45,6 +45,7 @@ describe('Synapse', () => {
     })
 
     it('should create dataset with session key', async () => {
+      let createdClientDataSetId = 0n
       server.use(
         Mocks.JSONRPC({
           ...Mocks.presets.basic,
@@ -52,6 +53,39 @@ describe('Synapse', () => {
           warmStorageView: {
             ...Mocks.presets.basic.warmStorageView,
             getApprovedProviders: () => [[1n]],
+            getDataSet: ([dataSetId]) => [
+              dataSetId === 123n
+                ? {
+                    cacheMissRailId: 0n,
+                    cdnRailId: 0n,
+                    clientDataSetId: createdClientDataSetId,
+                    commissionBps: 100n,
+                    dataSetId,
+                    payee: Mocks.ADDRESSES.serviceProvider1,
+                    payer: Mocks.ADDRESSES.client1,
+                    pdpEndEpoch: 0n,
+                    pdpRailId: 1n,
+                    providerId: 1n,
+                    pendingOneTimePayments: 0n,
+                    lifecycleReserveBalance: 0n,
+                    serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                  }
+                : {
+                    cacheMissRailId: 0n,
+                    cdnRailId: 0n,
+                    clientDataSetId: 0n,
+                    commissionBps: 0n,
+                    dataSetId,
+                    payee: Mocks.ADDRESSES.zero,
+                    payer: Mocks.ADDRESSES.zero,
+                    pdpEndEpoch: 0n,
+                    pdpRailId: 0n,
+                    providerId: 0n,
+                    pendingOneTimePayments: 0n,
+                    lifecycleReserveBalance: 0n,
+                    serviceProvider: Mocks.ADDRESSES.zero,
+                  },
+            ],
           },
         }),
         ...Mocks.pdp.streamingUploadHandlers(),
@@ -80,6 +114,7 @@ describe('Synapse', () => {
 
           const actualPayer = createDataSetDecoded[0]
           const clientDataSetId = createDataSetDecoded[1]
+          createdClientDataSetId = clientDataSetId
           const signature = createDataSetDecoded[4]
 
           const actualSigner = await recoverTypedDataAddress({
@@ -199,7 +234,7 @@ describe('Synapse', () => {
         privateKey: Mocks.PRIVATE_KEYS.key2,
         root: client.account,
       })
-      const synapse = new Synapse({ client, source: null, sessionClient: sessionKey.client })
+      const synapse = new Synapse({ client, source: null, sessionClient: sessionKey.client, pieceBatching: false })
       const firstData = new Uint8Array(127).fill(1) // 127 bytes
       const context = await synapse.storage.getDefaultContext()
       const result = await context.upload(firstData)

--- a/packages/synapse-sdk/src/test/storage-upload.test.ts
+++ b/packages/synapse-sdk/src/test/storage-upload.test.ts
@@ -12,8 +12,6 @@ import { setup } from 'iso-web/msw'
 import { HttpResponse, http } from 'msw'
 import { createWalletClient, http as viemHttp } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import type { StorageContext } from '../storage/context.ts'
-import { PieceBatchingService } from '../storage/piece-batching.ts'
 import { Synapse } from '../synapse.ts'
 import type { PieceCID } from '../types.ts'
 import { SIZE_CONSTANTS } from '../utils/constants.ts'
@@ -180,37 +178,6 @@ describe('Storage Upload', () => {
       [0n, 1n, 2n],
       'The set of assigned piece IDs should be {0, 1, 2}'
     )
-  })
-
-  it('should reject concurrent uploads cleanly when shared batch entry creation fails', async () => {
-    const expected = new Error('entry creation failed')
-    let rejectEntry: (error: Error) => void = () => undefined
-    const entryFailure = new Promise<never>((_resolve, reject) => {
-      rejectEntry = reject
-    })
-    const context = {
-      dataSetId: 1n,
-      provider: { id: 1n },
-      getBatcherDataSet: () => entryFailure,
-    } as unknown as StorageContext
-    const batching = new PieceBatchingService(new Synapse({ client, source: null }), {})
-
-    const uploads = [
-      batching.upload(context, { data: new Uint8Array(127) }).committed,
-      batching.upload(context, { data: new Uint8Array(128) }).committed,
-    ]
-    rejectEntry(expected)
-
-    const results = await Promise.allSettled(uploads)
-    assert.deepEqual(
-      results.map((result) => result.status),
-      ['rejected', 'rejected']
-    )
-    for (const result of results) {
-      if (result.status === 'rejected') {
-        assert.strictEqual(result.reason, expected)
-      }
-    }
   })
 
   it('should expose flush for limiter-based batching', async () => {

--- a/packages/synapse-sdk/src/test/storage-upload.test.ts
+++ b/packages/synapse-sdk/src/test/storage-upload.test.ts
@@ -12,6 +12,8 @@ import { setup } from 'iso-web/msw'
 import { HttpResponse, http } from 'msw'
 import { createWalletClient, http as viemHttp } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
+import type { StorageContext } from '../storage/context.ts'
+import { PieceBatchingService } from '../storage/piece-batching.ts'
 import { Synapse } from '../synapse.ts'
 import type { PieceCID } from '../types.ts'
 import { SIZE_CONSTANTS } from '../utils/constants.ts'
@@ -178,6 +180,37 @@ describe('Storage Upload', () => {
       [0n, 1n, 2n],
       'The set of assigned piece IDs should be {0, 1, 2}'
     )
+  })
+
+  it('should reject concurrent uploads cleanly when shared batch entry creation fails', async () => {
+    const expected = new Error('entry creation failed')
+    let rejectEntry: (error: Error) => void = () => undefined
+    const entryFailure = new Promise<never>((_resolve, reject) => {
+      rejectEntry = reject
+    })
+    const context = {
+      dataSetId: 1n,
+      provider: { id: 1n },
+      getBatcherDataSet: () => entryFailure,
+    } as unknown as StorageContext
+    const batching = new PieceBatchingService(new Synapse({ client, source: null }), {})
+
+    const uploads = [
+      batching.upload(context, { data: new Uint8Array(127) }).committed,
+      batching.upload(context, { data: new Uint8Array(128) }).committed,
+    ]
+    rejectEntry(expected)
+
+    const results = await Promise.allSettled(uploads)
+    assert.deepEqual(
+      results.map((result) => result.status),
+      ['rejected', 'rejected']
+    )
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        assert.strictEqual(result.reason, expected)
+      }
+    }
   })
 
   it('should expose flush for limiter-based batching', async () => {

--- a/packages/synapse-sdk/src/test/storage-upload.test.ts
+++ b/packages/synapse-sdk/src/test/storage-upload.test.ts
@@ -58,13 +58,11 @@ describe('Storage Upload', () => {
       http.get<{ id: string; txHash: string }>(
         `https://pdp.example.com/pdp/data-sets/:id/pieces/added/:txHash`,
         ({ params }) => {
-          // Extract the piece ID from the last character of the txHash
-          const pieceId = Number.parseInt(params.txHash.slice(-1), 10)
           const response = {
             addMessageOk: true,
-            confirmedPieceIds: [pieceId],
+            confirmedPieceIds: [0, 1, 2],
             dataSetId: parseInt(params.id, 10),
-            pieceCount: 1,
+            pieceCount: 3,
             piecesAdded: true,
             txHash: params.txHash,
             txStatus: 'confirmed',
@@ -153,7 +151,7 @@ describe('Storage Upload', () => {
         }
       )
     )
-    const synapse = new Synapse({ client, source: null })
+    const synapse = new Synapse({ client, source: null, pieceBatching: false })
     const context = await synapse.storage.createContext({
       withCDN: true,
       metadata: {
@@ -179,6 +177,98 @@ describe('Storage Upload', () => {
       [...resultPieceIds].sort((a, b) => Number(a - b)),
       [0n, 1n, 2n],
       'The set of assigned piece IDs should be {0, 1, 2}'
+    )
+  })
+
+  it('should expose flush for limiter-based batching', async () => {
+    let addPiecesCalls = 0
+    const txHash = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef123456'
+    server.use(
+      Mocks.JSONRPC({
+        ...Mocks.presets.basic,
+        debug: false,
+        warmStorageView: {
+          ...Mocks.presets.basic.warmStorageView,
+          getDataSet: ([dataSetId]) => [
+            dataSetId === 123n
+              ? {
+                  cacheMissRailId: 0n,
+                  cdnRailId: 0n,
+                  clientDataSetId: 0n,
+                  commissionBps: 100n,
+                  dataSetId,
+                  payee: Mocks.ADDRESSES.serviceProvider1,
+                  payer: Mocks.ADDRESSES.client1,
+                  pdpEndEpoch: 0n,
+                  pdpRailId: 1n,
+                  providerId: 1n,
+                  pendingOneTimePayments: 0n,
+                  lifecycleReserveBalance: 0n,
+                  serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                }
+              : {
+                  cacheMissRailId: 0n,
+                  cdnRailId: 0n,
+                  clientDataSetId: 0n,
+                  commissionBps: 0n,
+                  dataSetId,
+                  payee: Mocks.ADDRESSES.zero,
+                  payer: Mocks.ADDRESSES.zero,
+                  pdpEndEpoch: 0n,
+                  pdpRailId: 0n,
+                  providerId: 0n,
+                  pendingOneTimePayments: 0n,
+                  lifecycleReserveBalance: 0n,
+                  serviceProvider: Mocks.ADDRESSES.zero,
+                },
+          ],
+        },
+      }),
+      Mocks.PING(),
+      ...Mocks.pdp.streamingUploadHandlers(),
+      Mocks.pdp.findAnyPieceHandler(true),
+      http.post(`https://pdp.example.com/pdp/data-sets/create-and-add`, () => {
+        addPiecesCalls++
+        return new HttpResponse(null, {
+          status: 201,
+          headers: {
+            Location: `/pdp/data-sets/created/${txHash}`,
+          },
+        })
+      }),
+      Mocks.pdp.dataSetCreationStatusHandler(txHash, {
+        createMessageHash: txHash,
+        dataSetCreated: true,
+        service: 'test-service',
+        txStatus: 'confirmed',
+        ok: true,
+        dataSetId: 123,
+      }),
+      Mocks.pdp.pieceAdditionStatusHandler(123, txHash, {
+        addMessageOk: true,
+        confirmedPieceIds: [10, 11],
+        dataSetId: 123,
+        pieceCount: 2,
+        piecesAdded: true,
+        txHash,
+        txStatus: 'confirmed',
+      })
+    )
+    const synapse = new Synapse({
+      client,
+      source: null,
+      pieceBatching: { wait: { kind: 'limiter' } },
+    })
+    const context = await synapse.storage.createContext({ withCDN: true })
+
+    const uploads = [context.upload(new Uint8Array(127).fill(1)), context.upload(new Uint8Array(128).fill(2))]
+    await synapse.storage.flush()
+    const results = await Promise.all(uploads)
+
+    assert.strictEqual(addPiecesCalls, 1, 'flush should submit both parked pieces in one batch')
+    assert.deepEqual(
+      results.map((result) => result.copies[0].pieceId),
+      [10n, 11n]
     )
   })
 

--- a/packages/synapse-sdk/src/test/synapse.test.ts
+++ b/packages/synapse-sdk/src/test/synapse.test.ts
@@ -816,6 +816,51 @@ describe('Synapse', () => {
       const FAKE_TX_HASH = '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
       const DATA_SET_ID = 7
       beforeEach(async () => {
+        server.use(
+          Mocks.JSONRPC({
+            ...Mocks.presets.basic,
+            serviceRegistry: Mocks.mockServiceProviderRegistry([Mocks.PROVIDERS.provider1, Mocks.PROVIDERS.provider2]),
+            endorsements: {
+              getProviderIds: () => [endorsedProviderIds],
+            },
+            warmStorageView: {
+              ...Mocks.presets.basic.warmStorageView,
+              getDataSet: ([dataSetId]) => [
+                dataSetId === BigInt(DATA_SET_ID)
+                  ? {
+                      cacheMissRailId: 0n,
+                      cdnRailId: 0n,
+                      clientDataSetId: 0n,
+                      commissionBps: 100n,
+                      dataSetId,
+                      payee: Mocks.ADDRESSES.serviceProvider1,
+                      payer: Mocks.ADDRESSES.client1,
+                      pdpEndEpoch: 0n,
+                      pdpRailId: 1n,
+                      providerId: 1n,
+                      pendingOneTimePayments: 0n,
+                      lifecycleReserveBalance: 0n,
+                      serviceProvider: Mocks.ADDRESSES.serviceProvider1,
+                    }
+                  : {
+                      cacheMissRailId: 0n,
+                      cdnRailId: 0n,
+                      clientDataSetId: 0n,
+                      commissionBps: 0n,
+                      dataSetId,
+                      payee: Mocks.ADDRESSES.zero,
+                      payer: Mocks.ADDRESSES.zero,
+                      pdpEndEpoch: 0n,
+                      pdpRailId: 0n,
+                      providerId: 0n,
+                      pendingOneTimePayments: 0n,
+                      lifecycleReserveBalance: 0n,
+                      serviceProvider: Mocks.ADDRESSES.zero,
+                    },
+              ],
+            },
+          })
+        )
         contexts = await synapse.storage.createContexts({
           providerIds: [1n, 2n],
         })

--- a/packages/synapse-sdk/src/types.ts
+++ b/packages/synapse-sdk/src/types.ts
@@ -8,7 +8,7 @@
 import type { FilecoinChain } from '@filoz/synapse-core/chains'
 import type { PieceCID } from '@filoz/synapse-core/piece'
 import type { Permission, SessionKey, SessionKeyAccount } from '@filoz/synapse-core/session-key'
-import type { pullPiecesApiRequest } from '@filoz/synapse-core/sp'
+import type { PieceBatcherWait, pullPiecesApiRequest } from '@filoz/synapse-core/sp'
 import type { PDPProvider } from '@filoz/synapse-core/sp-registry'
 import type { MetadataObject } from '@filoz/synapse-core/utils'
 import type { getPriceList, getUploadCosts } from '@filoz/synapse-core/warm-storage'
@@ -17,7 +17,7 @@ import type { Synapse } from './synapse.ts'
 import type { WarmStorageService } from './warm-storage/service.ts'
 
 // Re-export PieceCID, PDPProvider, and PullStatus types
-export type { PDPProvider, PieceCID }
+export type { PDPProvider, PieceBatcherWait, PieceCID }
 export type PullStatus = pullPiecesApiRequest.PullStatus
 export type PrivateKey = string
 export type TokenAmount = bigint
@@ -81,6 +81,12 @@ export interface PrepareResult {
  */
 export type FilecoinNetworkType = 'mainnet' | 'calibration' | 'devnet'
 
+/** Configuration for automatic addPieces batching. */
+export interface PieceBatchingOptions {
+  /** Defaults to `{ kind: 'delay', ms: 0 }`. */
+  wait?: PieceBatcherWait
+}
+
 /**
  * Token identifier for balance queries
  */
@@ -132,6 +138,9 @@ export interface SynapseOptions {
   /** Whether to use CDN for retrievals (default: false) */
   withCDN?: boolean
 
+  /** Automatic addPieces batching. Enabled by default; pass `false` to disable. */
+  pieceBatching?: false | PieceBatchingOptions
+
   /**
    * Application identifier for namespace isolation. When set to a non-empty string, datasets
    * are tagged with this value and only datasets with a matching source are reused. Set to
@@ -158,6 +167,9 @@ export interface SynapseFromClientOptions {
 
   /** Whether to use CDN for retrievals (default: false) */
   withCDN?: boolean
+
+  /** Automatic addPieces batching. Enabled by default; pass `false` to disable. */
+  pieceBatching?: false | PieceBatchingOptions
 
   /**
    * Application identifier for namespace isolation. When set to a non-empty string, datasets


### PR DESCRIPTION
## Summary

- add a core piece batcher that groups `addPieces` work while respecting transaction message-size limits
- enable batching by default for `StorageManager.upload()` and `StorageContext.upload()`
- preserve the SDK's default two-copy flow: upload to a primary provider, pull to secondary providers, then batch each provider's on-chain commit independently
- expose delay and limiter wait strategies through `Synapse`, plus `synapse.storage.flush()` for explicitly releasing limiter-held batches
- allow callers to opt out with `pieceBatching: false`

## Usage

Batching is enabled by default, using a zero-delay window:

```ts
const synapse = await Synapse.create({
  privateKey,
  rpcUrl,
})
```

The delay can be configured when creating the client:

```ts
const synapse = await Synapse.create({
  privateKey,
  rpcUrl,
  pieceBatching: {
    wait: { kind: 'delay', ms: 100 },
  },
})
```

The limiter strategy holds a batch until it reaches the transaction size boundary or the application flushes it:

```ts
const synapse = await Synapse.create({
  privateKey,
  rpcUrl,
  pieceBatching: {
    wait: { kind: 'limiter' },
  },
})

const uploads = files.map((file) => synapse.storage.upload(file))
await synapse.storage.flush()
const results = await Promise.all(uploads)
```

To retain the previous immediate, per-upload behavior:

```ts
const synapse = await Synapse.create({
  privateKey,
  rpcUrl,
  pieceBatching: false,
})
```

## How it works

1. `StorageManager.upload()` resolves the primary and secondary contexts exactly as before, including the default request for at least two copies.
2. The primary upload is parked at its provider. Once parked, each secondary starts its provider-to-provider pull from the primary.
3. A Synapse-scoped coordinator assigns the upload or pull to a batcher keyed by provider and data set. Providers therefore submit separate batches, while compatible pieces for the same data set share one transaction.
4. The core batcher waits according to the configured delay or limiter and automatically splits batches that would exceed the encoded `addPieces` message-size limit.
5. All pieces in a submitted batch share the confirmation request. Each upload resolves to its own piece ID using its batch index.
6. Newly created data-set IDs are synchronized back into their storage contexts so later uploads reuse the established data set.

The existing result and failure semantics remain intact: successful copies are returned in `copies`, intermediate provider failures remain in `failedAttempts`, and the manager still throws `StoreError` or `CommitError` when the corresponding operation cannot succeed.

The split `store()`, `pull()`, and `commit()` APIs remain unchanged and unbatched. `flush()` waits for uploads and pulls to finish parking before releasing all current windows; the core batcher's `close()` prevents new work and delegates to that same flush behavior.

## Compatibility

- batching can be disabled with `pieceBatching: false`
- the public `PdpDataSet` contract remains unchanged
- the core custom limiter contract still receives the data set and pending pieces
- session-key signing uses the delegated client while preserving the root payer

## Tests

- `packages/synapse-core` build
- `packages/synapse-sdk` build
- package lint
- core Node tests: 858 passing
- core browser tests: 858 passing
- SDK Node tests: 280 passing, 7 pending
- SDK browser tests: 280 passing, 7 pending
