### PR TITLE
chore(synapse-core): update FWSS StateView addresses

### DIFF
--- a/packages/synapse-core/src/abis/generated.ts
+++ b/packages/synapse-core/src/abis/generated.ts
@@ -3198,7 +3198,7 @@ export const filecoinWarmStorageServiceConfig = {
 
 /**
  * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab)
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x9BF9e67e83EC8613883FDdDec4D3b38AEE937177)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x1B68d64f01bAa42014B9774605867BF4eDC0320f)
  */
 export const filecoinWarmStorageServiceStateViewAbi = [
   {
@@ -3668,16 +3668,16 @@ export const filecoinWarmStorageServiceStateViewAbi = [
 
 /**
  * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab)
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x9BF9e67e83EC8613883FDdDec4D3b38AEE937177)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x1B68d64f01bAa42014B9774605867BF4eDC0320f)
  */
 export const filecoinWarmStorageServiceStateViewAddress = {
   314: '0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab',
-  314159: '0x9BF9e67e83EC8613883FDdDec4D3b38AEE937177',
+  314159: '0x1B68d64f01bAa42014B9774605867BF4eDC0320f',
 } as const
 
 /**
  * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab)
- * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x9BF9e67e83EC8613883FDdDec4D3b38AEE937177)
+ * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x1B68d64f01bAa42014B9774605867BF4eDC0320f)
  */
 export const filecoinWarmStorageServiceStateViewConfig = {
   address: filecoinWarmStorageServiceStateViewAddress,

--- a/packages/synapse-core/src/abis/generated.ts
+++ b/packages/synapse-core/src/abis/generated.ts
@@ -3197,7 +3197,7 @@ export const filecoinWarmStorageServiceConfig = {
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab)
+ * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xcf184Ab1FD8D1a563054d30Aa1fFb08136998172)
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x1B68d64f01bAa42014B9774605867BF4eDC0320f)
  */
 export const filecoinWarmStorageServiceStateViewAbi = [
@@ -3667,16 +3667,16 @@ export const filecoinWarmStorageServiceStateViewAbi = [
 ] as const
 
 /**
- * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab)
+ * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xcf184Ab1FD8D1a563054d30Aa1fFb08136998172)
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x1B68d64f01bAa42014B9774605867BF4eDC0320f)
  */
 export const filecoinWarmStorageServiceStateViewAddress = {
-  314: '0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab',
+  314: '0xcf184Ab1FD8D1a563054d30Aa1fFb08136998172',
   314159: '0x1B68d64f01bAa42014B9774605867BF4eDC0320f',
 } as const
 
 /**
- * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xdDd8F083a3fe9C66547D46bee24e5AaF56BCa0ab)
+ * - [__View Contract on Filecoin Mainnet Filfox__](https://filfox.info/en/address/0xcf184Ab1FD8D1a563054d30Aa1fFb08136998172)
  * - [__View Contract on Filecoin Calibration Filscan__](https://calibration.filscan.io/address/0x1B68d64f01bAa42014B9774605867BF4eDC0320f)
  */
 export const filecoinWarmStorageServiceStateViewConfig = {

--- a/packages/synapse-core/wagmi.config.ts
+++ b/packages/synapse-core/wagmi.config.ts
@@ -89,7 +89,8 @@ const config: ReturnType<typeof defineConfig> = defineConfig(async () => {
     {
       name: 'FilecoinWarmStorageServiceStateView',
       address: {
-        314: mainnetAddresses.FWSS_VIEW_ADDRESS,
+        // Temporary override for testing updated pricing after the Mainnet upgrade; remove once deployments are published.
+        314: '0xcf184Ab1FD8D1a563054d30Aa1fFb08136998172',
         314159: calibrationAddresses.FWSS_VIEW_ADDRESS,
       },
     },

--- a/packages/synapse-core/wagmi.config.ts
+++ b/packages/synapse-core/wagmi.config.ts
@@ -7,7 +7,7 @@ import { ZodValidationError } from './src/errors/base.ts'
 import { zAddress } from './src/utils/schemas.ts'
 
 // GIT_REF can be one of: '<branch name>', '<commit>' or 'tags/<tag>'
-const FILECOIN_SERVICES_GIT_REF = '4cbbea4a4f7da51ad674a1d9d122c6e677acfbec' // v1.4.0
+const FILECOIN_SERVICES_GIT_REF = '5858b4d2778cac5d743264094fa54c7891b78d52' // v1.4.0
 const FILECOIN_SERVICES_REF = FILECOIN_SERVICES_GIT_REF.replace(/^(?![a-f0-9]{40}$)/, 'refs/')
 const BASE_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/abi`
 const DEPLOYMENTS_URL = `https://raw.githubusercontent.com/FilOzone/filecoin-services/${FILECOIN_SERVICES_REF}/service_contracts/deployments.json`


### PR DESCRIPTION
## Summary

- update the Calibnet FWSS StateView address from the published FWSS v1.4.0 `deployments.json`
- temporarily override the future Mainnet FWSS StateView address with `0xcf184Ab1FD8D1a563054d30Aa1fFb08136998172`
- regenerate the wagmi contract bindings and explorer links

## Rationale

The FWSS StateView defines the storage pricing exposed by the SDK.

Calibnet has been upgraded and its updated `deployments.json` is available, so the wagmi generation flow now consumes the published StateView address.

Mainnet has not been upgraded yet, so an updated Mainnet `deployments.json` is not available. The temporary override preconfigures the SDK with the new StateView address, allowing updated pricing to be tested immediately after the Mainnet upgrade. It should be removed once the Mainnet deployment metadata is published.

The only breaking StateView ABI change is the removal of the piece metadata getters. Synapse already uses the new ABI and no longer relies on those getters, so no additional SDK migration is required.

## Commit structure

The changes are intentionally split into two commits:

1. `09eb4ee` updates Calibnet from the published deployment metadata.
2. `4661b80` adds the temporary Mainnet override.

This allows reviewers to select only the published Calibnet update or both changes.

## Verification

- `pnpm run generate-abi`
- `pnpm run build`
- runtime checks confirmed:
  - Calibnet StateView: `0x1B68d64f01bAa42014B9774605867BF4eDC0320f`
  - Mainnet StateView: `0xcf184Ab1FD8D1a563054d30Aa1fFb08136998172`
- `git diff --check`

Tracks #945.