### PR TITLE
fix(synapse-core): sign new dataset pulls correctly

### DIFF
--- a/packages/synapse-core/src/sp/create-piece-batcher.ts
+++ b/packages/synapse-core/src/sp/create-piece-batcher.ts
@@ -4,8 +4,7 @@ import { AddPiecesFlushError } from '../errors/pdp.ts'
 import { PullError } from '../errors/pull.ts'
 import { DataSetNotFoundError } from '../errors/warm-storage.ts'
 import type { PieceCID } from '../piece/piece-cid.ts'
-import { signAddPieces } from '../typed-data/sign-add-pieces.ts'
-import { type MetadataObject, pieceMetadataObjectToEntry } from '../utils/metadata.ts'
+import type { MetadataObject } from '../utils/metadata.ts'
 import { randU256 } from '../utils/rand.ts'
 import { isUint8Array } from '../utils/streams.ts'
 import { getPdpDataSet } from '../warm-storage/get-pdp-data-set.ts'
@@ -129,8 +128,8 @@ export namespace createPieceBatcher {
  * `upload` and `pull` run per-piece I/O right away (`upload` uses the
  * streaming CommP-last protocol for bytes and streams). The tumbling window
  * only batches the on-chain addPieces (or createDataSetAndAddPieces) call.
- * Pull authorization uses `signAddPieces` for that one piece; flush signs a
- * new extraData for the whole window.
+ * Pull authorization matches the eventual operation for that one piece;
+ * flush signs new extraData for the whole window.
  *
  * @param client - Wallet client used to sign and submit.
  * @param options - {@link createPieceBatcher.OptionsType}
@@ -456,16 +455,6 @@ export function createPieceBatcher(
   async function pull(input: PullInput): Promise<PieceResult> {
     return parkAndEnqueue(async () => {
       assertPieceCidSize(input.pieceCid)
-      const signingPieces = [
-        {
-          pieceCid: input.pieceCid,
-          metadata: pieceMetadataObjectToEntry(input.metadata),
-        },
-      ]
-      const extraData = await signAddPieces(client, {
-        clientDataSetId: dataSet == null ? createClientDataSetId : dataSet.clientDataSetId,
-        pieces: signingPieces,
-      })
       const pullPiece = {
         pieceCid: input.pieceCid,
         sourceUrl: input.sourceUrl,
@@ -476,7 +465,7 @@ export function createPieceBatcher(
           ? await waitForPullPieces(client, {
               serviceURL: serviceURL(),
               pieces: [pullPiece],
-              extraData,
+              clientDataSetId: createClientDataSetId,
               payee: requirePayee(),
               payer,
               cdn,
@@ -487,7 +476,6 @@ export function createPieceBatcher(
           : await waitForPullPieces(client, {
               serviceURL: serviceURL(),
               pieces: [pullPiece],
-              extraData,
               dataSetId: dataSet.dataSetId,
               clientDataSetId: dataSet.clientDataSetId,
               signal: input.signal,

--- a/packages/synapse-core/test/create-piece-batcher.test.ts
+++ b/packages/synapse-core/test/create-piece-batcher.test.ts
@@ -325,6 +325,57 @@ describe('createPieceBatcher', () => {
     assert.equal(uploaded.txHash, pulled.txHash)
   })
 
+  it('should use create-and-add authorization when pulling into a new data set', async () => {
+    let pullExtraData: string | undefined
+    let pullDataSetId: number | undefined
+    server.use(
+      JSONRPC(presets.basic),
+      pullPiecesWithCaptureHandler(
+        createPullResponse('complete', [{ pieceCid: pieceCidB.toString() }]),
+        (request) => {
+          pullExtraData = request.extraData
+          pullDataSetId = request.dataSetId
+        },
+        { baseUrl: pdpBase }
+      ),
+      createAndAddPiecesHandler(mockTxHash, { baseUrl: pdpBase }),
+      dataSetCreationStatusHandler(
+        mockTxHash,
+        {
+          createMessageHash: mockTxHash,
+          dataSetCreated: true,
+          service: 'warm',
+          txStatus: 'confirmed',
+          ok: true,
+          dataSetId: 1,
+        },
+        { baseUrl: pdpBase }
+      )
+    )
+
+    const batcher = createPieceBatcher(client, {
+      dataSet: undefined,
+      serviceURL: pdpBase,
+      payee: ADDRESSES.payee1,
+      wait: { kind: 'limiter' },
+    })
+    const pulledP = batcher.pull({
+      pieceCid: pieceCidB,
+      sourceUrl: `${pdpBase}/piece/${pieceCidB.toString()}`,
+    })
+    await batcher.close()
+    await pulledP
+
+    assert.equal(pullDataSetId, undefined)
+    assert.ok(pullExtraData)
+    const [createExtraData, addExtraData] = decodeAbiParameters(
+      TypedData.signcreateDataSetAndAddPiecesAbiParameters,
+      pullExtraData as `0x${string}`
+    )
+    decodeAbiParameters(TypedData.signCreateDataSetAbiParameters, createExtraData)
+    decodeAbiParameters(TypedData.signAddPiecesAbiParameters, addExtraData)
+  })
+
   it('should call onParked after park and before addPieces', async () => {
     const parked: string[] = []
     const bodies: addPiecesApiRequest.RequestBody[] = []


### PR DESCRIPTION
## Problem

The piece batcher generated `AddPieces` extraData for every pull request, including pulls targeting a new dataset.

For a new dataset, the pull request omits `dataSetId` (represented as dataset ID `0` by Curio). Curio therefore validates the eventual `CreateDataSetAndAddPieces` operation. That operation requires composite extraData containing both:

- the create-dataset authorization;
- the add-pieces authorization.

Sending bare `AddPieces` extraData causes Curio's authorization validation to use the wrong payload shape.

This became visible after storage batching was enabled by default.

## Fix

Delegate pull authorization generation to the existing `waitForPullPieces` implementation.

The shared pull implementation already selects the correct signature based on the target:

- existing dataset: `signAddPieces`;
- new dataset: `signCreateDataSetAndAddPieces`.

For new datasets, the batcher now passes its stable `createClientDataSetId` together with the payee, payer, dataset metadata, and CDN configuration. This keeps the pull authorization consistent with the eventual dataset creation.

The batcher no longer duplicates pull-signing or metadata-conversion logic.

## Tests

Added regression coverage that pulls into a new dataset and verifies:

- `dataSetId` is omitted from the Curio request;
- `extraData` uses the composite create-and-add encoding;
- both nested create-dataset and add-pieces payloads decode successfully.

Verification:

- `pnpm run test:node` — 851 passing
- `pnpm run lint` — passed, including the package build