### PR TITLE
fix: enforce the 40-piece limit for addPieces operations

### DIFF
--- a/packages/synapse-core/src/sp/add-pieces-fits.ts
+++ b/packages/synapse-core/src/sp/add-pieces-fits.ts
@@ -45,7 +45,8 @@ export namespace addPiecesFits {
  *
  * Uses estimated encoded-params size (PieceCID bytes + dummy extraData) against
  * {@link SIZE_CONSTANTS.MAX_ADD_PIECES_MESSAGE_SIZE} (64 KiB message cap minus
- * overhead). Empty `pieces` does not fit.
+ * overhead), with a temporary cap of {@link SIZE_CONSTANTS.MAX_ADD_PIECES_BATCH_SIZE}
+ * pieces per operation. Empty `pieces` does not fit.
  *
  * @param options - {@link addPiecesFits.OptionsType}
  * @returns Whether the pieces fit {@link addPiecesFits.OutputType}
@@ -63,6 +64,11 @@ export namespace addPiecesFits {
  */
 export function addPiecesFits(options: addPiecesFits.OptionsType): addPiecesFits.OutputType {
   if (options.pieces.length < 1) {
+    return false
+  }
+  // TODO: Remove the temporary count cap once larger batches are supported.
+  // https://github.com/FilOzone/synapse-sdk/issues/954
+  if (options.pieces.length > SIZE_CONSTANTS.MAX_ADD_PIECES_BATCH_SIZE) {
     return false
   }
   return estimateAddPiecesCalldataSize(options) <= SIZE_CONSTANTS.MAX_ADD_PIECES_MESSAGE_SIZE
@@ -88,7 +94,7 @@ export function assertPieceCidSize(pieceCid: PieceCID): void {
  * @param options - {@link LimiterOptions}
  * @throws {@link AtLeastOnePieceRequiredError} when `pieces` is empty
  * @throws {@link InvalidUploadSizeError} when a PieceCID size is below {@link SIZE_CONSTANTS.MIN_UPLOAD_SIZE} or above {@link SIZE_CONSTANTS.MAX_UPLOAD_SIZE}
- * @throws {@link AddPiecesBatchTooLargeError} when the estimated message exceeds {@link SIZE_CONSTANTS.MAX_ADD_PIECES_MESSAGE_SIZE}
+ * @throws {@link AddPiecesBatchTooLargeError} when the piece count exceeds {@link SIZE_CONSTANTS.MAX_ADD_PIECES_BATCH_SIZE} or the estimated message exceeds {@link SIZE_CONSTANTS.MAX_ADD_PIECES_MESSAGE_SIZE}
  */
 export function assertAddPiecesFit(options: LimiterOptions): void {
   if (options.pieces.length < 1) {

--- a/packages/synapse-core/src/utils/constants.ts
+++ b/packages/synapse-core/src/utils/constants.ts
@@ -92,6 +92,13 @@ export const SIZE_CONSTANTS = {
   DEFAULT_UPLOAD_BATCH_SIZE: 32,
 
   /**
+   * Temporary maximum pieces per addPieces / createAndAdd operation.
+   *
+   * Enforced alongside `MAX_ADD_PIECES_MESSAGE_SIZE` by `addPiecesFits`.
+   */
+  MAX_ADD_PIECES_BATCH_SIZE: 40,
+
+  /**
    * Payload budget (bytes) for one addPieces / createAndAdd Filecoin message.
    *
    * Filecoin messages are capped at 64 KiB. 288 bytes are reserved for message

--- a/packages/synapse-core/test/add-pieces-fits.test.ts
+++ b/packages/synapse-core/test/add-pieces-fits.test.ts
@@ -76,10 +76,13 @@ describe('addPiecesFits', () => {
     )
   })
 
-  it('should accept more than the old 40-piece count cap when pieces are small', () => {
-    const pieces = Array.from({ length: 41 }, () => ({ pieceCid }))
-    assert.equal(addPiecesFits({ kind: 'addPieces', pieces }), true)
-  })
+  for (const kind of ['addPieces', 'createDataSetAndAddPieces'] as const) {
+    it(`should cap ${kind} at 40 pieces even when the message is small`, () => {
+      const pieces = Array.from({ length: 40 }, () => ({ pieceCid }))
+      assert.equal(addPiecesFits({ kind, pieces }), true)
+      assert.equal(addPiecesFits({ kind, pieces: [...pieces, { pieceCid }] }), false)
+    })
+  }
 
   it('should use compact metadata when every piece has none', () => {
     const emptyPieces = Array.from({ length: 2 }, () => ({ pieceCid }))

--- a/packages/synapse-core/test/add-pieces.test.ts
+++ b/packages/synapse-core/test/add-pieces.test.ts
@@ -42,10 +42,13 @@ describe('assertAddPiecesFit', () => {
     assert.doesNotThrow(() => assertAddPiecesFit({ kind: 'addPieces', pieces: [{ pieceCid }] }))
   })
 
-  it('should accept more than the old 40-piece count cap when pieces are small', () => {
-    const pieces = Array.from({ length: 41 }, () => ({ pieceCid }))
-    assert.doesNotThrow(() => assertAddPiecesFit({ kind: 'addPieces', pieces }))
-  })
+  for (const kind of ['addPieces', 'createDataSetAndAddPieces'] as const) {
+    it(`should reject ${kind} above 40 pieces`, () => {
+      const pieces = Array.from({ length: 40 }, () => ({ pieceCid }))
+      assert.doesNotThrow(() => assertAddPiecesFit({ kind, pieces }))
+      assert.throws(() => assertAddPiecesFit({ kind, pieces: [...pieces, { pieceCid }] }), AddPiecesBatchTooLargeError)
+    })
+  }
 
   it('should throw when a PieceCID is below MIN_UPLOAD_SIZE', () => {
     assert.throws(
@@ -63,7 +66,7 @@ describe('assertAddPiecesFit', () => {
     )
   })
 
-  it('should throw when the estimated message is too large', () => {
+  it('should throw when the batch exceeds the limiter', () => {
     assert.throws(
       () => assertAddPiecesFit({ kind: 'addPieces', pieces: oversizedBatch() }),
       AddPiecesBatchTooLargeError

--- a/packages/synapse-core/test/create-piece-batcher.test.ts
+++ b/packages/synapse-core/test/create-piece-batcher.test.ts
@@ -145,6 +145,24 @@ describe('createPieceBatcher', () => {
     assert.equal(a.batchIndex + b.batchIndex, 1)
   })
 
+  it('should split 41 pieces into batches of 40 and 1 with the default limiter', async () => {
+    const bodies: addPiecesApiRequest.RequestBody[] = []
+    server.use(addPiecesCaptureHandler((body) => bodies.push(body)))
+
+    const batcher = createPieceBatcher(client, { dataSet: createDataSet(), wait: { kind: 'limiter' } })
+    const pending = Array.from({ length: 41 }, (_, index) =>
+      batcher.enqueue({ pieceCid: pieceCidA, metadata: { index: String(index) } })
+    )
+    await batcher.close()
+    const results = await Promise.all(pending)
+
+    assert.deepEqual(
+      bodies.map((body) => body.pieces.length),
+      [40, 1]
+    )
+    assert.equal(results.length, 41)
+  })
+
   it('should stream an upload into the same addPieces window', async () => {
     const bodies: addPiecesApiRequest.RequestBody[] = []
     server.use(


### PR DESCRIPTION
## Summary

- Enforce the temporary 40-piece limit for `addPieces` and `createDataSetAndAddPieces`
- Update limiter documentation and error behavior
- Add coverage for the limit and splitting 41 pieces into batches of 40 and 1

## Testing

- Added unit tests for both add-pieces operation types
- Added a unit test covering piece batch splitting